### PR TITLE
Introduce base_definition

### DIFF
--- a/concourse/pipelines/__init__.py
+++ b/concourse/pipelines/__init__.py
@@ -207,8 +207,6 @@ def replicate_pipelines(
             team_credentials=team_credentials,
         )
 
-    return # XXX remove again
-
     concourse_api = client.ConcourseApi(base_url=concourse_cfg.external_url(), team_name=team_name)
     concourse_api.login(
         team=team_name,

--- a/concourse/pipelines/factory.py
+++ b/concourse/pipelines/factory.py
@@ -21,10 +21,14 @@ class DefinitionFactory(object):
         if not 'variants' in raw_dict:
             raise ModelValidationError('at least one variant must be specified')
 
-        for args_name, value in self.raw_dict['base_definition'].items():
-            self.raw_dict[args_name] = value
+        # temporary hack: restore original structure (where base definition was every attribute
+        # except for those named 'variants')
+        # TODO: rework subsequent processing steps
+        if 'base_definition' in self.raw_dict:
+            for args_name, value in self.raw_dict['base_definition'].items():
+                self.raw_dict[args_name] = value
 
-        del self.raw_dict['base_definition']
+            del self.raw_dict['base_definition']
 
 
     def create_pipeline_args(self):

--- a/concourse/pipelines/factory.py
+++ b/concourse/pipelines/factory.py
@@ -21,6 +21,12 @@ class DefinitionFactory(object):
         if not 'variants' in raw_dict:
             raise ModelValidationError('at least one variant must be specified')
 
+        for args_name, value in self.raw_dict['base_definition'].items():
+            self.raw_dict[args_name] = value
+
+        del self.raw_dict['base_definition']
+
+
     def create_pipeline_args(self):
         merged_variants_dict = self._create_variants_dict(self.raw_dict)
 


### PR DESCRIPTION
Group all non-variant definitions under base_definition attribute.
Doing this, users can more easily see inheritance of definitions