### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# cc-utils maintainers
+*   @andreasburger @ccwienk @RaphaelVogel

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,0 @@
-* Christian Cwienk <christian.cwienk@sap.com> @ccwienk
-* Raphael Vogel <raphael.vogel@sap.com> @RaphaelVogel
-* Andreas Burger <andreas.burger@sap.com> @andreasburger


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/