### PR TITLE
Adjust to changes in concourse-chart 1.3.0

### DIFF
--- a/concourse/client.py
+++ b/concourse/client.py
@@ -366,10 +366,11 @@ class ConcourseApi(object):
     def set_team(self, team_credentials: ConcourseTeamCredentials):
         body = {}
         if team_credentials.has_basic_auth_credentials():
-            body['basic_auth'] = {
-                'basic_auth_username': team_credentials.username(),
-                'basic_auth_password': team_credentials.passwd(),
+            basic_auth_cfg = {
+                'username': team_credentials.username(),
+                'password': team_credentials.passwd(),
             }
+            body['auth'] = {'basicauth': basic_auth_cfg}
         if team_credentials.has_github_oauth_credentials():
             github_org, github_team = team_credentials.github_auth_team(split=True)
             github_cfg = {
@@ -387,8 +388,10 @@ class ConcourseApi(object):
                     'token_url': team_credentials.github_auth_token_url(),
                     'api_url': team_credentials.github_auth_api_url(),
                 })
-
-            body['auth'] = {'github' : github_cfg}
+            if 'auth' in body:
+                body['auth'].update({'github' : github_cfg})
+            else:
+                body['auth'] = {'github' : github_cfg}
 
         team_url = self.routes.team_url(team_credentials.teamname())
 

--- a/concourse/setup.py
+++ b/concourse/setup.py
@@ -140,15 +140,17 @@ def create_instance_specific_helm_values(concourse_cfg: ConcourseConfig):
 
     instance_specific_values = {
         'concourse': {
-            'username': creds.username(),
-            'password': creds.passwd(),
+            'externalURL': external_url,
+        },
+        'secrets': {
+            'basicAuthUsername': creds.username(),
+            'basicAuthPassword': creds.passwd(),
             'githubAuthAuthUrl': creds.github_auth_auth_url(),
             'githubAuthTokenUrl': creds.github_auth_token_url(),
             'githubAuthApiUrl': creds.github_auth_api_url(),
             'githubAuthClientId': creds.github_auth_client_id(),
             'githubAuthClientSecret': creds.github_auth_client_secret(),
             'githubAuthTeam': creds.github_auth_team(),
-            'externalURL': external_url,
         },
         'web': {
             'ingress': {
@@ -254,7 +256,7 @@ def ensure_helm_setup():
 
 # intentionally hard-coded; review / adjustment of "values.yaml" is required in most cases
 # of version upgrades
-CONCOURSE_HELM_CHART_VERSION = "1.2.1"
+CONCOURSE_HELM_CHART_VERSION = "1.3.0"
 
 def deploy_or_upgrade_concourse(
         config_dir: str,


### PR DESCRIPTION
Enables automated deployment of Concourse 3.10.0 using the stable/concourse Helm-chart version 1.3.0 by introducing the required changes to the Concourse-API-calls and the computation of the chart-values we perform.