### PR TITLE
Use cluster-config configured in ConcourseConfig when deploying Concourse

### DIFF
--- a/concourse/setup.py
+++ b/concourse/setup.py
@@ -181,8 +181,12 @@ def deploy_concourse_landscape(
     config_set = config_factory.cfg_set(cfg_name=config_name)
     concourse_cfg = config_set.concourse()
 
-    # Set the global context to the cluster specified by the given config
-    kubernetes_config = config_set.kubernetes()
+    # Set the global context to the cluster specified in the ConcourseConfig
+    kubernetes_config_name = concourse_cfg.kubernetes_cluster_config()
+    kubernetes_config = config_factory._cfg_element(
+        cfg_type_name = 'kubernetes',
+        cfg_name = kubernetes_config_name,
+    )
     kubeutil.ctx.set_kubecfg(kubernetes_config.kubeconfig())
 
     ensure_cluster_version(kubernetes_config)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -455,8 +455,11 @@ class ConcourseConfig(NamedModelElement):
     def deploy_delaying_proxy(self):
         return self.snd.deploy_delaying_proxy
 
+    def kubernetes_cluster_config(self):
+        return self.snd.kubernetes_cluster_config
+
     def _required_attributes(self):
-        return ['externalUrl', 'teams', 'helm_chart_default_values_config']
+        return ['externalUrl', 'teams', 'helm_chart_default_values_config', 'kubernetes_cluster_config']
 
     def _validate_dict(self):
         super()._validate_dict()

--- a/test/model_validation_test.py
+++ b/test/model_validation_test.py
@@ -178,10 +178,11 @@ class ConcourseConfigTest(unittest.TestCase):
             },
             'helm_chart_default_values_config':'foo',
             'deploy_delaying_proxy':True,
+            'kubernetes_cluster_config': 'bar'
         }
 
     def test_validation_fails_on_missing_key(self):
-        for key in ('externalUrl', 'teams', 'helm_chart_default_values_config'):
+        for key in ('externalUrl', 'teams', 'helm_chart_default_values_config','kubernetes_cluster_config'):
             with self.subTest(key=key):
                 test_dict = ConcourseConfigTest.create_valid_test_dictionary()
                 test_dict.pop(key)


### PR DESCRIPTION
Use the cluster-config configured explicitly in the ConcourseConfig when deploying Concourse instead of using the cluster-config set in the ConfigSet.

Should only be merged after changes to the config are merged.