### PR TITLE
Adjust deploy_and_run_smoketest_pipeline to new repo structure

### DIFF
--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -104,14 +104,14 @@ def release_and_prepare_next_dev_cycle(
 
     helper = GitHubRepositoryHelper(
         github_cfg=github_cfg,
-        repository_owner=github_repository_owner,
-        repository_name=github_repository_name,
+        owner=github_repository_owner,
+        name=github_repository_name,
+        default_branch=repository_branch,
     )
 
     # Persist version change, create release commit
     release_commit_sha = helper.create_or_update_file(
-        repository_branch=repository_branch,
-        repository_version_file_path=repository_version_file_path,
+        file_path=repository_version_file_path,
         file_contents=release_version,
         commit_message="Release " + release_version
     )
@@ -142,8 +142,7 @@ def release_and_prepare_next_dev_cycle(
 
     # Prepare version file for next dev cycle
     helper.create_or_update_file(
-        repository_branch=repository_branch,
-        repository_version_file_path=repository_version_file_path,
+        file_path=repository_version_file_path,
         file_contents=next_version_dev,
         commit_message="Prepare next dev cycle " + next_version_dev
     )

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -19,7 +19,7 @@ from github3.exceptions import NotFoundError
 from util import ctx, not_empty, info, warning, verbose, CliHint
 from github import GithubWebHookSyncer, CONCOURSE_ID
 from github.util import (
-    GitHubHelper,
+    GitHubRepositoryHelper,
     _create_github_api_object,
     _create_team,
     _add_user_to_team,
@@ -102,7 +102,7 @@ def release_and_prepare_next_dev_cycle(
         prerelease=prerelease_suffix
     )
 
-    helper = GitHubHelper(
+    helper = GitHubRepositoryHelper(
         github_cfg=github_cfg,
         repository_owner=github_repository_owner,
         repository_name=github_repository_name,

--- a/github/util.py
+++ b/github/util.py
@@ -103,6 +103,18 @@ class GitHubRepositoryHelper(object):
             ref=branch,
         )
 
+    def retrieve_text_file_contents(
+        self,
+        file_path: str,
+        branch: str=None,
+        encoding: str='utf-8',
+    ):
+        if branch is None:
+            branch = self.default_branch
+
+        contents = self.retrieve_file_contents(file_path, branch)
+        return contents.decoded.decode(encoding)
+
     def create_tag(
         self,
         tag_name: str,

--- a/github/util.py
+++ b/github/util.py
@@ -35,7 +35,7 @@ class RepoPermission(Enum):
     ADMIN = "admin"
 
 
-class GitHubHelper(object):
+class GitHubRepositoryHelper(object):
     GITHUB_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
     def __init__(
@@ -213,7 +213,7 @@ def replicate_pipeline_definitions(
         repo_owner, repo_name = repo_path.split('/')
 
 
-        helper = GitHubHelper(
+        helper = GitHubRepositoryHelper(
             github_cfg=github_cfg,
             repository_owner=repo_owner,
             repository_name=repo_name,

--- a/github/util.py
+++ b/github/util.py
@@ -70,10 +70,7 @@ class GitHubRepositoryHelper(object):
             branch = self.default_branch
 
         try:
-            contents = self.repository.file_contents(
-                path=file_path,
-                ref=branch,
-            )
+            contents = self.retrieve_file_contents(file_path=file_path, branch=branch)
         except NotFoundError:
             contents = None # file did not yet exist
 
@@ -96,6 +93,15 @@ class GitHubRepositoryHelper(object):
                 branch=branch,
             )
         return response['commit'].sha
+
+    def retrieve_file_contents(self, file_path: str, branch: str=None):
+        if branch is None:
+            branch = self.default_branch
+
+        return self.repository.file_contents(
+            path=file_path,
+            ref=branch,
+        )
 
     def create_tag(
         self,

--- a/product/util.py
+++ b/product/util.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 import itertools
 import yaml
 
-from github.util import GitHubHelper
+from github.util import GitHubRepositoryHelper
 from util import not_none
 from .model import Product, COMPONENT_DESCRIPTOR_ASSET_NAME
 
@@ -30,7 +30,7 @@ class ComponentDescriptorResolver(object):
         self.github_cfg = github_cfg
 
     def _repository_helper(self, component_reference):
-        return GitHubHelper(
+        return GitHubRepositoryHelper(
             github_cfg=self.github_cfg,
             repository_owner=self.github_organisation,
             repository_name=component_reference.name(),

--- a/product/util.py
+++ b/product/util.py
@@ -32,8 +32,8 @@ class ComponentDescriptorResolver(object):
     def _repository_helper(self, component_reference):
         return GitHubRepositoryHelper(
             github_cfg=self.github_cfg,
-            repository_owner=self.github_organisation,
-            repository_name=component_reference.name(),
+            owner=self.github_organisation,
+            name=component_reference.name(),
         )
 
     def retrieve_raw_descriptor(self, component_reference, as_dict=False):


### PR DESCRIPTION
The move of our smoketest-pipeline to its new location has brought a change to the relative path under which it can be found. Furthermore the name of one of the methods arguments is changed to not refer to the old smoke-test location by its name anymore.