### PR TITLE
Add job mapping to sync hooks

### DIFF
--- a/cli/concourseutil.py
+++ b/cli/concourseutil.py
@@ -221,7 +221,7 @@ def sync_webhooks_from_cfg(
           github_cfg=github_cfg,
           concourse_cfg=concourse_cfg,
           job_mapping=job_mapping,
-          concourse_team=team.teamname(),
+          concourse_team_credentials=team,
         )
 
 

--- a/cli/concourseutil.py
+++ b/cli/concourseutil.py
@@ -201,7 +201,6 @@ def render_pipelines(
 
 
 def sync_webhooks_from_cfg(
-    team_name: str,
     cfg_name: str,
 ):
     '''
@@ -212,13 +211,18 @@ def sync_webhooks_from_cfg(
     github_cfg = cfg_set.github()
     github_cred = github_cfg.credentials()
     concourse_cfg = cfg_set.concourse()
-    team_cfg = concourse_cfg.team_credentials(team_name)
+    job_mapping_set = cfg_factory.job_mapping(concourse_cfg.job_mapping_cfg_name())
 
-    sync_webhooks(
-      github_cfg=github_cfg,
-      concourse_cfg=concourse_cfg,
-      concourse_team=team_cfg.teamname(),
-    )
+    for job_mapping in job_mapping_set.job_mappings().values():
+        team_name = job_mapping.team_name()
+        info("syncing webhooks (team: {})".format(team_name))
+        team = concourse_cfg.team_credentials(team_name)
+        sync_webhooks(
+          github_cfg=github_cfg,
+          concourse_cfg=concourse_cfg,
+          job_mapping=job_mapping,
+          concourse_team=team.teamname(),
+        )
 
 
 def diff_pipelines(left_file: CliHints.yaml_file(), right_file: CliHints.yaml_file()):

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse, parse_qs
 from github3.exceptions import NotFoundError
 
 from util import ctx, not_empty, info, warning, verbose, CliHint
-from github import GithubWebHookSyncer, CONCOURSE_ID
+from github import GithubWebHookSyncer, WebhookQueryAttributes
 from github.util import (
     GitHubRepositoryHelper,
     _create_github_api_object,
@@ -167,7 +167,7 @@ def remove_webhooks(
     webhook_syncer = GithubWebHookSyncer(github_api)
 
     def filter_function(url):
-        concourse_id = parse_qs(urlparse(url).query).get(CONCOURSE_ID)
+        concourse_id = parse_qs(urlparse(url).query).get(WebhookQueryAttributes.CONCOURSE_ID_ATTRIBUTE_NAME)
         should_delete = concourse_id and concourse_cfg_name in concourse_id
         return should_delete
 

--- a/concourse/client.py
+++ b/concourse/client.py
@@ -137,6 +137,7 @@ class ConcourseApiRoutes(object):
         query_args = urlencode({
             WebhookQueryAttributes.WEBHOOK_TOKEN_ATTRIBUTE_NAME: query_attributes.webhook_token,
             WebhookQueryAttributes.CONCOURSE_ID_ATTRIBUTE_NAME: query_attributes.concourse_id,
+            WebhookQueryAttributes.JOB_MAPPING_ID_ATTRIBUTE_NAME: query_attributes.job_mapping_id,
         })
         return self._api_url(
             'pipelines',

--- a/concourse/client.py
+++ b/concourse/client.py
@@ -136,12 +136,12 @@ class ConcourseApiRoutes(object):
     ):
         query_args = urlencode({'webhook_token': webhook_token, 'concourse_id': concourse_id})
         return self._api_url(
-          'pipelines',
-          pipeline_name,
-          'resources',
-          resource_name,
-          'check',
-          'webhook'
+            'pipelines',
+            pipeline_name,
+            'resources',
+            resource_name,
+            'check',
+            'webhook'
         ) + '?' + query_args
 
     @ensure_annotations

--- a/concourse/client.py
+++ b/concourse/client.py
@@ -20,6 +20,7 @@ import warnings
 from enum import Enum
 import sseclient
 
+from github import WebhookQueryAttributes
 from http_requests import AuthenticatedRequestBuilder
 from model import ConcourseTeamCredentials
 from util import fail, warning, ensure_not_empty
@@ -131,10 +132,12 @@ class ConcourseApiRoutes(object):
         self,
         pipeline_name: str,
         resource_name: str,
-        webhook_token: str,
-        concourse_id: str,
+        query_attributes: WebhookQueryAttributes,
     ):
-        query_args = urlencode({'webhook_token': webhook_token, 'concourse_id': concourse_id})
+        query_args = urlencode({
+            WebhookQueryAttributes.WEBHOOK_TOKEN_ATTRIBUTE_NAME: query_attributes.webhook_token,
+            WebhookQueryAttributes.CONCOURSE_ID_ATTRIBUTE_NAME: query_attributes.concourse_id,
+        })
         return self._api_url(
             'pipelines',
             pipeline_name,

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -22,18 +22,18 @@ from util import parse_yaml_file, info, fail, which, warning, CliHints, CliHint
 
 
 def list_github_resources(
-  concourse_url:str,
-  concourse_user:str='kubernetes',
-  concourse_passwd:str='kubernetes',
-  concourse_team:str='kubernetes',
-  concourse_pipelines=None,
-  github_url:str=None,
+    concourse_url: str,
+    concourse_user: str='kubernetes',
+    concourse_passwd: str='kubernetes',
+    concourse_team: str='kubernetes',
+    concourse_pipelines=None,
+    github_url: str=None,
 ):
     concourse_api = concourse.ConcourseApi(base_url=concourse_url, team_name=concourse_team)
     concourse_api.login(
-      team=concourse_team,
-      username=concourse_user,
-      passwd=concourse_passwd
+        team=concourse_team,
+        username=concourse_user,
+        passwd=concourse_passwd
     )
     github_hostname = urlparse(github_url).netloc
     pipeline_names = concourse_pipelines if concourse_pipelines else concourse_api.pipelines()
@@ -46,11 +46,11 @@ def list_github_resources(
 
 
 def sync_webhooks(
-  github_cfg:'GithubConfig',
-  concourse_cfg:'ConcourseConfig',
-  concourse_team:str='kubernetes',
-  concourse_pipelines:[str]=None,
-  concourse_verify_ssl:bool=False,
+    github_cfg: 'GithubConfig',
+    concourse_cfg: 'ConcourseConfig',
+    concourse_team: str='kubernetes',
+    concourse_pipelines: [str]=None,
+    concourse_verify_ssl: bool=False,
 ):
     concourse_url = concourse_cfg.external_url()
     team_cfg = concourse_cfg.team_credentials(concourse_team)
@@ -58,12 +58,12 @@ def sync_webhooks(
     concourse_passwd = team_cfg.passwd()
 
     github_resources = list_github_resources(
-      concourse_url=concourse_url,
-      concourse_user=concourse_user,
-      concourse_passwd=concourse_passwd,
-      concourse_team=concourse_team,
-      concourse_pipelines=concourse_pipelines,
-      github_url=github_cfg.http_url(),
+        concourse_url=concourse_url,
+        concourse_user=concourse_user,
+        concourse_passwd=concourse_passwd,
+        concourse_team=concourse_team,
+        concourse_pipelines=concourse_pipelines,
+        github_url=github_cfg.http_url(),
     )
     # group by repositories
     path_to_resources = {}
@@ -82,10 +82,10 @@ def sync_webhooks(
     for repo, resources in path_to_resources.items():
         try:
             _sync_webhook(
-              resources=resources,
-              webhook_syncer=webhook_syncer,
-              concourse_cfg=concourse_cfg,
-              skip_ssl_validation=not concourse_verify_ssl
+                resources=resources,
+                webhook_syncer=webhook_syncer,
+                concourse_cfg=concourse_cfg,
+                skip_ssl_validation=not concourse_verify_ssl
             )
         except RuntimeError as rte:
             failed_hooks += 1
@@ -96,10 +96,10 @@ def sync_webhooks(
 
 
 def _sync_webhook(
-  resources: [concourse.Resource],
-  webhook_syncer: github.GithubWebHookSyncer,
-  concourse_cfg: 'ConcourseConfig',
-  skip_ssl_validation: bool=False
+    resources: [concourse.Resource],
+    webhook_syncer: github.GithubWebHookSyncer,
+    concourse_cfg: 'ConcourseConfig',
+    skip_ssl_validation: bool=False
 ):
     first_res = resources[0]
     first_github_src = first_res.github_source()
@@ -119,20 +119,20 @@ def _sync_webhook(
     def webhook_url(gh_res):
         github_src = gh_res.github_source()
         webhook_url = routes.resource_check_webhook(
-          pipeline_name=gh_res.pipeline.name,
-          resource_name=gh_res.name,
-          webhook_token=gh_res.webhook_token(),
-          concourse_id=concourse_cfg.name(),
+            pipeline_name=gh_res.pipeline.name,
+            resource_name=gh_res.name,
+            webhook_token=gh_res.webhook_token(),
+            concourse_id=concourse_cfg.name(),
         )
         return webhook_url
 
     webhook_urls = set(map(webhook_url, resources))
 
     webhook_syncer.add_or_update_hooks(
-      owner=organisation,
-      repository_name=repository,
-      callback_urls=webhook_urls,
-      skip_ssl_validation=skip_ssl_validation
+        owner=organisation,
+        repository_name=repository,
+        callback_urls=webhook_urls,
+        skip_ssl_validation=skip_ssl_validation
     )
 
     def url_filter(url):

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -118,11 +118,14 @@ def _sync_webhook(
     # collect callback URLs
     def webhook_url(gh_res):
         github_src = gh_res.github_source()
+        query_attributes = github.WebhookQueryAttributes(
+            webhook_token=gh_res.webhook_token(),
+            concourse_id=concourse_cfg.name(),
+        )
         webhook_url = routes.resource_check_webhook(
             pipeline_name=gh_res.pipeline.name,
             resource_name=gh_res.name,
-            webhook_token=gh_res.webhook_token(),
-            concourse_id=concourse_cfg.name(),
+            query_attributes=query_attributes,
         )
         return webhook_url
 
@@ -136,7 +139,7 @@ def _sync_webhook(
     )
 
     def url_filter(url):
-        concourse_id = parse_qs(urlparse(url).query).get(github.CONCOURSE_ID)
+        concourse_id = parse_qs(urlparse(url).query).get(github.WebhookQueryAttributes.CONCOURSE_ID_ATTRIBUTE_NAME)
         return concourse_id and concourse_cfg.name() in concourse_id
 
     processed, removed = webhook_syncer.remove_outdated_hooks(

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -18,6 +18,7 @@ from copy import copy
 import github
 from github.util import _create_github_api_object
 import concourse.client as concourse
+from model import ConcourseTeamCredentials, ConcourseConfig, GithubConfig, JobMapping
 from util import parse_yaml_file, info, fail, which, warning, CliHints, CliHint
 
 
@@ -46,17 +47,17 @@ def list_github_resources(
 
 
 def sync_webhooks(
-    github_cfg: 'GithubConfig',
-    concourse_cfg: 'ConcourseConfig',
-    job_mapping: 'JobMapping',
-    concourse_team: str='kubernetes',
+    github_cfg: GithubConfig,
+    concourse_cfg: ConcourseConfig,
+    job_mapping: JobMapping,
+    concourse_team_credentials: ConcourseTeamCredentials,
     concourse_pipelines: [str]=None,
     concourse_verify_ssl: bool=False,
 ):
     concourse_url = concourse_cfg.external_url()
-    team_cfg = concourse_cfg.team_credentials(concourse_team)
-    concourse_user = team_cfg.username()
-    concourse_passwd = team_cfg.passwd()
+    concourse_team = concourse_team_credentials.teamname()
+    concourse_user = concourse_team_credentials.username()
+    concourse_passwd = concourse_team_credentials.passwd()
 
     github_resources = list_github_resources(
         concourse_url=concourse_url,

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -22,7 +22,19 @@ from urllib.parse import urlparse
 DEFAULT_HOOK_EVENTS = ['create', 'pull_request', 'push']
 DEFAULT_HOOK_NAME = 'web' # see https://developer.github.com/v3/repos/hooks/
 DEFAULT_HOOK_CONTENT_TYPE = 'json'
-CONCOURSE_ID = 'concourse_id'
+
+class WebhookQueryAttributes(object):
+    WEBHOOK_TOKEN_ATTRIBUTE_NAME = 'webhook_token'
+    CONCOURSE_ID_ATTRIBUTE_NAME = 'concourse_id'
+
+    def __init__(
+        self,
+        webhook_token: str,
+        concourse_id: str,
+    ):
+        self.webhook_token = webhook_token
+        self.concourse_id = concourse_id
+
 
 class GithubWebHookSyncer(object):
     '''

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -26,14 +26,17 @@ DEFAULT_HOOK_CONTENT_TYPE = 'json'
 class WebhookQueryAttributes(object):
     WEBHOOK_TOKEN_ATTRIBUTE_NAME = 'webhook_token'
     CONCOURSE_ID_ATTRIBUTE_NAME = 'concourse_id'
+    JOB_MAPPING_ID_ATTRIBUTE_NAME = 'job_mapping_id'
 
     def __init__(
         self,
         webhook_token: str,
         concourse_id: str,
+        job_mapping_id: str,
     ):
         self.webhook_token = webhook_token
         self.concourse_id = concourse_id
+        self.job_mapping_id = job_mapping_id
 
 
 class GithubWebHookSyncer(object):


### PR DESCRIPTION
Enables adding the job mapping name as additional meta-information to webhooks created by our automation. This meta-information is then used to ensure correct behaviour when configuring webhooks for multiple job mappings.