### PR TITLE
Generate release notes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -237,7 +237,7 @@ ignored-modules=
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,GitError
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -122,7 +122,7 @@ def release_and_prepare_next_dev_cycle(
         )
 
     if generate_release_notes:
-        release_notes = generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch, commit_range=commit_range)
+        release_notes = generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch)
     else:
         release_notes = 'release notes'
 

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -15,8 +15,13 @@
 import version
 from urllib.parse import urlparse, parse_qs
 from github3.exceptions import NotFoundError
+from pydash import _
+from collections import namedtuple
+from semver import parse_version_info
+import git
+import re
 
-from util import ctx, not_empty, info, warning, fail, verbose, CliHint, CliHints
+from util import ctx, not_empty, info, warning, fail, verbose, CliHint, CliHints, existing_dir
 from github.webhook import GithubWebHookSyncer, WebhookQueryAttributes
 from github.util import (
     GitHubRepositoryHelper,
@@ -27,6 +32,15 @@ from github.util import (
 )
 import product.model
 
+ReleaseNote = namedtuple('ReleaseNote', ["category_id", "group_id", "text", "pr_number", "user_login"])
+Category = namedtuple("Category", "identifier title")
+Group = namedtuple("Group", "identifier title")
+categories = \
+    Category(identifier='noteworthy', title='## Most notable changes'),\
+    Category(identifier='improvement', title='## Improvements')
+groups = \
+    Group(identifier='user', title='### To end users'), \
+    Group(identifier='operator', title='### To operations team')
 
 def assign_github_team_to_repo(
     github_cfg_name: str,
@@ -71,6 +85,213 @@ def assign_github_team_to_repo(
         team_name=team_name
     )
 
+def generate_release_notes_cli(
+    repo_dir: str,
+    github_cfg_name: str,
+    github_repository_owner: str,
+    github_repository_name: str,
+    repository_branch: str,
+    commit_range: str=None
+):
+    github_cfg = ctx().cfg_factory().github(github_cfg_name)
+    helper = GitHubRepositoryHelper(
+        github_cfg=github_cfg,
+        owner=github_repository_owner,
+        name=github_repository_name,
+        default_branch=repository_branch,
+    )
+    generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch, commit_range=commit_range)
+
+def generate_release_notes(
+    repo_dir: str,
+    helper: GitHubRepositoryHelper,
+    repository_branch: str,
+    commit_range: str=None
+):
+    repo = git.Repo(existing_dir(repo_dir))
+    if repo.active_branch.name != repository_branch:
+        fail('need to switch to branch {branch}. Current active branch: {active_branch}'.format(branch=repository_branch, active_branch=repo.active_branch.name))
+
+    if not commit_range:
+        commit_range = calculate_range(repo, helper)
+    pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
+    release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers)
+    release_notes = build_markdown(release_note_objs)
+
+    info(release_notes)
+    return release_notes
+
+def build_markdown(
+    release_note_objs: list
+) -> str:
+    def release_notes_for_group(
+        category: Category,
+        group: Group,
+        release_note_objs: list()
+    ) -> list:
+        release_note_objs = _.filter(release_note_objs, lambda release_note: category.identifier == release_note.category_id and group.identifier == release_note.group_id)
+
+        release_note_lines = list()
+        if release_note_objs:
+            release_note_lines.append(group.title)
+            for release_note in release_note_objs:
+                for i, rls_note_line in enumerate(release_note.text.splitlines()):
+                    if i == 0:
+                        release_note_lines.append('* {rls_note_line} (#{pr_num}, @{user})'.format(pr_num=release_note.pr_number, user=release_note.user_login, rls_note_line=rls_note_line))
+                    else:
+                        release_note_lines.append('  * {rls_note_line}'.format(rls_note_line=rls_note_line))
+        return release_note_lines
+
+    def release_notes_for_category(
+        category: Category,
+        release_note_objs: list
+    ) -> list:
+        rn_lines = list()
+        rn_lines_category = list()
+        for group in groups:
+            rn_lines_category.extend(release_notes_for_group(category=category, group=group, release_note_objs=release_note_objs))
+
+        if rn_lines_category:
+            rn_lines.append(category.title)
+            rn_lines.extend(rn_lines_category)
+        return rn_lines
+
+    release_note_lines = list()
+    for category in categories:
+        release_note_lines.extend(release_notes_for_category(category, release_note_objs=release_note_objs))
+
+    if release_note_lines:
+        return '\n'.join(release_note_lines)
+    else: # fallback
+        return 'release notes'
+
+def calculate_range(
+    repo: git.Repo,
+    helper: GitHubRepositoryHelper,
+) -> str:
+
+    branch_head = repo.head.commit
+    range_start = _.head(reachable_release_tags_from_commit(helper, repo, branch_head))
+
+    range_end = None
+    try:
+        range_end = repo.git.describe(branch_head) # better readable range_end by describing head commit
+    except git.exc.GitCommandError:
+        range_end = branch_head.hexsha
+
+    commit_range = "{start}..{end}".format(start=range_start, end=range_end)
+    return commit_range
+
+def release_tags(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo
+) -> list:
+    release_tags = helper.release_tags()
+    tags = _ \
+        .chain(repo.tags) \
+        .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
+        .filter(lambda item: _.find(release_tags, lambda el: el == item['tag'])) \
+        .key_by('commit') \
+        .map_values('tag') \
+        .value()
+    return tags
+
+def reachable_release_tags_from_commit(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo, commit
+) -> list:
+    tags = release_tags(helper, repo)
+
+    visited = set()
+    queue = list()
+    queue.append(commit)
+    visited.add(commit.hexsha)
+
+    reachable_tags = list()
+
+    while queue:
+        commit = queue.pop(0)
+        if commit.hexsha in tags:
+            reachable_tags.append(tags[commit.hexsha])
+        not_visited_parents = _.filter(commit.parents, lambda parent_commit: not parent_commit.hexsha in visited)
+        if not_visited_parents:
+            queue.extend(not_visited_parents)
+            # queue.sort(key=lambda commit: commit.committed_date, reverse=True) #not needed anymore as we sort by semver at the end
+            visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
+
+    reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
+
+    if not reachable_tags:
+        warning('no release tag found, falling back to root commit')
+        root_commits = repo.iter_commits(rev=commit, max_parents=0)
+        root_commit = next(root_commits, None)
+        if not root_commit:
+            fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
+        if next(root_commits, None):
+            fail('cannot determine range for release notes. Repository has multiple root commits. Specify range via commit_range parameter.')
+        reachable_tags.append(root_commit.hexsha)
+
+    return reachable_tags
+
+
+def fetch_pr_numbers_in_range(
+    repo: git.Repo,
+    commit_range: str
+) -> set:
+    info('git log {range}'.format(range=commit_range))
+    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
+    pr_numbers = []
+    for commitMessage in gitLogs:
+        if commitMessage.startswith('Merge pull'):
+            pr_number = _.head(re.findall(r"#(\d+|$)", commitMessage))
+            if pr_number:
+                pr_numbers.append(pr_number)
+
+    verbose('Merged pull request numbers in range {range}: {pr_numbers}'.format(range=commit_range, pr_numbers=pr_numbers))
+    return pr_numbers
+
+def fetch_release_notes_from_prs(
+    helper: GitHubRepositoryHelper,
+    pr_numbers_in_range: set
+) -> list:
+    # we should consider adding a release-note label to the PRs to reduce the number of search results
+    prs_iter = helper.search_issues_in_repo('type:pull is:closed')
+
+    release_notes = list()
+    for pr_iter in prs_iter:
+        pr_dict = pr_iter.as_dict()
+
+        pr_number = pr_dict['number']
+        if not str(pr_number) in pr_numbers_in_range:
+            continue
+
+        release_notes_pr = extract_release_notes(pr_number=pr_number, text=pr_dict['body'], user_login=_.get(pr_dict, 'user.login'))
+        if not release_notes_pr:
+            continue
+
+        release_notes.extend(release_notes_pr)
+    return release_notes
+
+def extract_release_notes(
+    pr_number: int,
+    text: str,
+    user_login: str
+) -> list:
+    release_notes = list()
+
+    quotes = re.findall(r"``` *(improvement|noteworthy)( (user|operator)?)?.*?\n(.*?)\n```", text, re.MULTILINE | re.DOTALL)
+    for quote in quotes:
+        quote = _.map(quote, lambda obj: _.trim(obj))
+
+        text = quote[3]
+        if not text or 'none' == text.lower():
+            continue
+
+        category = quote[0]
+        group = quote[2] or 'user'
+
+        release_notes.append(ReleaseNote(category_id=category, group_id=group, text=text, pr_number=pr_number, user_login=user_login))
+    return release_notes
 
 def release_and_prepare_next_dev_cycle(
     github_cfg_name: str,
@@ -79,28 +300,15 @@ def release_and_prepare_next_dev_cycle(
     repository_branch: str,
     repository_version_file_path: str,
     release_version: str,
-    release_notes: str,
+    release_notes: str=None,
     version_operation: str="bump_minor",
     prerelease_suffix: str="dev",
     author_name: str="gardener-ci",
     author_email: str="gardener.ci.user@gmail.com",
     component_descriptor_file_path: str=None,
+    repo_dir: str=None
 ):
-    # retrieve github-cfg from secrets-server
-    from config import _retrieve_model_element
-    github_cfg = _retrieve_model_element(cfg_type='github', cfg_name=github_cfg_name)
-
-    # Do all the version handling upfront to catch errors early
-    # Bump release version and add suffix
-    next_version = version.process_version(
-        version_str=release_version,
-        operation=version_operation
-    )
-    next_version_dev = version.process_version(
-        version_str=next_version,
-        operation='set_prerelease',
-        prerelease=prerelease_suffix
-    )
+    github_cfg = ctx().cfg_factory().github(github_cfg_name)
 
     helper = GitHubRepositoryHelper(
         github_cfg=github_cfg,
@@ -116,6 +324,21 @@ def release_and_prepare_next_dev_cycle(
             )
         )
 
+    if not release_notes:
+        release_notes = generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch, commit_range=commit_range)
+
+    # Do all the version handling upfront to catch errors early
+    # Bump release version and add suffix
+    next_version = version.process_version(
+        version_str=release_version,
+        operation=version_operation
+    )
+    next_version_dev = version.process_version(
+        version_str=next_version,
+        operation='set_prerelease',
+        prerelease=prerelease_suffix
+    )
+
     # Persist version change, create release commit
     release_commit_sha = helper.create_or_update_file(
         file_path=repository_version_file_path,
@@ -124,7 +347,7 @@ def release_and_prepare_next_dev_cycle(
     )
     helper.create_tag(
         tag_name=release_version,
-        tag_message=release_notes,
+        tag_message="Release " + release_version, # TODO
         repository_reference=release_commit_sha,
         author_name=author_name,
         author_email=author_email

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -15,11 +15,6 @@
 import version
 from urllib.parse import urlparse, parse_qs
 from github3.exceptions import NotFoundError
-from pydash import _
-from collections import namedtuple
-from semver import parse_version_info
-import git
-import re
 
 from util import ctx, not_empty, info, warning, fail, verbose, CliHint, CliHints, existing_dir
 from github.webhook import GithubWebHookSyncer, WebhookQueryAttributes
@@ -30,17 +25,10 @@ from github.util import (
     _add_user_to_team,
     _add_all_repos_to_team
 )
+from github.release_notes import generate_release_notes
 import product.model
 
-ReleaseNote = namedtuple('ReleaseNote', ["category_id", "group_id", "text", "pr_number", "user_login"])
-Category = namedtuple("Category", "identifier title")
-Group = namedtuple("Group", "identifier title")
-categories = \
-    Category(identifier='noteworthy', title='## Most notable changes'),\
-    Category(identifier='improvement', title='## Improvements')
-groups = \
-    Group(identifier='user', title='### To end users'), \
-    Group(identifier='operator', title='### To operations team')
+
 
 def assign_github_team_to_repo(
     github_cfg_name: str,
@@ -102,197 +90,6 @@ def generate_release_notes_cli(
     )
     generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch, commit_range=commit_range)
 
-def generate_release_notes(
-    repo_dir: str,
-    helper: GitHubRepositoryHelper,
-    repository_branch: str,
-    commit_range: str=None
-):
-    repo = git.Repo(existing_dir(repo_dir))
-    if repo.active_branch.name != repository_branch:
-        fail('need to switch to branch {branch}. Current active branch: {active_branch}'.format(branch=repository_branch, active_branch=repo.active_branch.name))
-
-    if not commit_range:
-        commit_range = calculate_range(repo, helper)
-    pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
-    release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers)
-    release_notes = build_markdown(release_note_objs)
-
-    info(release_notes)
-    return release_notes
-
-def build_markdown(
-    release_note_objs: list
-) -> str:
-    def release_notes_for_group(
-        category: Category,
-        group: Group,
-        release_note_objs: list()
-    ) -> list:
-        release_note_objs = _.filter(release_note_objs, lambda release_note: category.identifier == release_note.category_id and group.identifier == release_note.group_id)
-
-        release_note_lines = list()
-        if release_note_objs:
-            release_note_lines.append(group.title)
-            for release_note in release_note_objs:
-                for i, rls_note_line in enumerate(release_note.text.splitlines()):
-                    if i == 0:
-                        release_note_lines.append('* {rls_note_line} (#{pr_num}, @{user})'.format(pr_num=release_note.pr_number, user=release_note.user_login, rls_note_line=rls_note_line))
-                    else:
-                        release_note_lines.append('  * {rls_note_line}'.format(rls_note_line=rls_note_line))
-        return release_note_lines
-
-    def release_notes_for_category(
-        category: Category,
-        release_note_objs: list
-    ) -> list:
-        rn_lines = list()
-        rn_lines_category = list()
-        for group in groups:
-            rn_lines_category.extend(release_notes_for_group(category=category, group=group, release_note_objs=release_note_objs))
-
-        if rn_lines_category:
-            rn_lines.append(category.title)
-            rn_lines.extend(rn_lines_category)
-        return rn_lines
-
-    release_note_lines = list()
-    for category in categories:
-        release_note_lines.extend(release_notes_for_category(category, release_note_objs=release_note_objs))
-
-    if release_note_lines:
-        return '\n'.join(release_note_lines)
-    else: # fallback
-        return 'release notes'
-
-def calculate_range(
-    repo: git.Repo,
-    helper: GitHubRepositoryHelper,
-) -> str:
-
-    branch_head = repo.head.commit
-    range_start = _.head(reachable_release_tags_from_commit(helper, repo, branch_head))
-
-    range_end = None
-    try:
-        range_end = repo.git.describe(branch_head) # better readable range_end by describing head commit
-    except git.exc.GitCommandError:
-        range_end = branch_head.hexsha
-
-    commit_range = "{start}..{end}".format(start=range_start, end=range_end)
-    return commit_range
-
-def release_tags(
-    helper: GitHubRepositoryHelper,
-    repo: git.Repo
-) -> list:
-    release_tags = helper.release_tags()
-    tags = _ \
-        .chain(repo.tags) \
-        .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
-        .filter(lambda item: _.find(release_tags, lambda el: el == item['tag'])) \
-        .key_by('commit') \
-        .map_values('tag') \
-        .value()
-    return tags
-
-def reachable_release_tags_from_commit(
-    helper: GitHubRepositoryHelper,
-    repo: git.Repo, commit
-) -> list:
-    tags = release_tags(helper, repo)
-
-    visited = set()
-    queue = list()
-    queue.append(commit)
-    visited.add(commit.hexsha)
-
-    reachable_tags = list()
-
-    while queue:
-        commit = queue.pop(0)
-        if commit.hexsha in tags:
-            reachable_tags.append(tags[commit.hexsha])
-        not_visited_parents = _.filter(commit.parents, lambda parent_commit: not parent_commit.hexsha in visited)
-        if not_visited_parents:
-            queue.extend(not_visited_parents)
-            # queue.sort(key=lambda commit: commit.committed_date, reverse=True) #not needed anymore as we sort by semver at the end
-            visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
-
-    reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
-
-    if not reachable_tags:
-        warning('no release tag found, falling back to root commit')
-        root_commits = repo.iter_commits(rev=commit, max_parents=0)
-        root_commit = next(root_commits, None)
-        if not root_commit:
-            fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
-        if next(root_commits, None):
-            fail('cannot determine range for release notes. Repository has multiple root commits. Specify range via commit_range parameter.')
-        reachable_tags.append(root_commit.hexsha)
-
-    return reachable_tags
-
-
-def fetch_pr_numbers_in_range(
-    repo: git.Repo,
-    commit_range: str
-) -> set:
-    info('git log {range}'.format(range=commit_range))
-    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
-    pr_numbers = []
-    for commitMessage in gitLogs:
-        if commitMessage.startswith('Merge pull'):
-            pr_number = _.head(re.findall(r"#(\d+|$)", commitMessage))
-            if pr_number:
-                pr_numbers.append(pr_number)
-
-    verbose('Merged pull request numbers in range {range}: {pr_numbers}'.format(range=commit_range, pr_numbers=pr_numbers))
-    return pr_numbers
-
-def fetch_release_notes_from_prs(
-    helper: GitHubRepositoryHelper,
-    pr_numbers_in_range: set
-) -> list:
-    # we should consider adding a release-note label to the PRs to reduce the number of search results
-    prs_iter = helper.search_issues_in_repo('type:pull is:closed')
-
-    release_notes = list()
-    for pr_iter in prs_iter:
-        pr_dict = pr_iter.as_dict()
-
-        pr_number = pr_dict['number']
-        if not str(pr_number) in pr_numbers_in_range:
-            continue
-
-        release_notes_pr = extract_release_notes(pr_number=pr_number, text=pr_dict['body'], user_login=_.get(pr_dict, 'user.login'))
-        if not release_notes_pr:
-            continue
-
-        release_notes.extend(release_notes_pr)
-    return release_notes
-
-def extract_release_notes(
-    pr_number: int,
-    text: str,
-    user_login: str
-) -> list:
-    release_notes = list()
-
-    quotes = re.findall(r"``` *(improvement|noteworthy)( (user|operator)?)?.*?\n(.*?)\n```", text, re.MULTILINE | re.DOTALL)
-    for quote in quotes:
-        quote = _.map(quote, lambda obj: _.trim(obj))
-
-        text = quote[3]
-        if not text or 'none' == text.lower():
-            continue
-
-        category = quote[0]
-        group = quote[2] or 'user'
-
-        release_notes.append(ReleaseNote(category_id=category, group_id=group, text=text, pr_number=pr_number, user_login=user_login))
-    return release_notes
-
 def release_and_prepare_next_dev_cycle(
     github_cfg_name: str,
     github_repository_owner: str,
@@ -300,7 +97,7 @@ def release_and_prepare_next_dev_cycle(
     repository_branch: str,
     repository_version_file_path: str,
     release_version: str,
-    release_notes: str=None,
+    generate_release_notes: bool,
     version_operation: str="bump_minor",
     prerelease_suffix: str="dev",
     author_name: str="gardener-ci",
@@ -324,8 +121,10 @@ def release_and_prepare_next_dev_cycle(
             )
         )
 
-    if not release_notes:
+    if generate_release_notes:
         release_notes = generate_release_notes(repo_dir=repo_dir, helper=helper, repository_branch=repository_branch, commit_range=commit_range)
+    else:
+        release_notes = 'release notes'
 
     # Do all the version handling upfront to catch errors early
     # Bump release version and add suffix

--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -97,12 +97,12 @@ def release_and_prepare_next_dev_cycle(
     repository_branch: str,
     repository_version_file_path: str,
     release_version: str,
-    generate_release_notes: bool,
     version_operation: str="bump_minor",
     prerelease_suffix: str="dev",
     author_name: str="gardener-ci",
     author_email: str="gardener.ci.user@gmail.com",
     component_descriptor_file_path: str=None,
+    generate_release_notes: bool=True,
     repo_dir: str=None
 ):
     github_cfg = ctx().cfg_factory().github(github_cfg_name)

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydash import _
+from collections import namedtuple
+from semver import parse_version_info
+import git
+import re
+
+from util import info, warning, fail, verbose, existing_dir
+from github.util import GitHubRepositoryHelper
+
+ReleaseNote = namedtuple('ReleaseNote', \
+    ["category_id", "target_group_id", "text", "pr_number", "user_login"] \
+)
+Category = namedtuple("Category", ["identifier", "title"])
+TargetGroup = namedtuple("TargetGroup", ["identifier", "title"])
+categories = \
+    Category(identifier='noteworthy', title='## Most notable changes'), \
+    Category(identifier='improvement', title='## Improvements')
+target_groups = \
+    TargetGroup(identifier='user', title='### To end users'), \
+    TargetGroup(identifier='operator', title='### To operations team')
+
+def generate_release_notes(
+    repo_dir: str,
+    helper: GitHubRepositoryHelper,
+    repository_branch: str,
+    commit_range: str=None
+):
+    repo = git.Repo(existing_dir(repo_dir))
+
+    if not commit_range:
+        commit_range = calculate_range(repository_branch, repo, helper)
+    pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
+    release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers)
+    release_notes_str = build_markdown(release_note_objs)
+
+    info(release_notes_str)
+    return release_notes_str
+
+def build_markdown(
+    release_note_objs: list
+) -> str:
+    def release_notes_for_target_group(
+        category: Category,
+        target_group: TargetGroup,
+        release_note_objs: list()
+    ) -> list:
+        release_note_objs = _.filter(
+            release_note_objs,
+            lambda release_note:
+                category.identifier == release_note.category_id
+                and target_group.identifier == release_note.target_group_id
+        )
+
+        release_note_lines = list()
+        if release_note_objs:
+            release_note_lines.append(target_group.title)
+            for release_note in release_note_objs:
+                for i, rls_note_line in enumerate(release_note.text.splitlines()):
+                    if i == 0:
+                        release_note_lines.append(
+                            '* {rls_note_line} (#{pr_num}, @{user})'
+                                .format(
+                                    pr_num=release_note.pr_number,
+                                    user=release_note.user_login,
+                                    rls_note_line=rls_note_line
+                                )
+                        )
+                    else:
+                        release_note_lines.append('  * {rls_note_line}'.format(
+                            rls_note_line=rls_note_line
+                        ))
+        return release_note_lines
+
+    def release_notes_for_category(
+        category: Category,
+        release_note_objs: list
+    ) -> list:
+        rn_lines = list()
+        rn_lines_category = list()
+        for target_group in target_groups:
+            rn_lines_category.extend(
+                release_notes_for_target_group(
+                    category=category,
+                    target_group=target_group,
+                    release_note_objs=release_note_objs
+                )
+            )
+
+        if rn_lines_category:
+            rn_lines.append(category.title)
+            rn_lines.extend(rn_lines_category)
+        return rn_lines
+
+    release_note_lines = list()
+    for category in categories:
+        release_note_lines.extend(release_notes_for_category(
+            category=category,
+            release_note_objs=release_note_objs
+        ))
+
+    if release_note_lines:
+        return '\n'.join(release_note_lines)
+    else: # fallback
+        return 'no release notes available'
+
+def calculate_range(
+    repository_branch: str,
+    repo: git.Repo,
+    helper: GitHubRepositoryHelper,
+) -> str:
+
+    branch_head = repo.rev_parse('refs/remotes/origin/' + repository_branch)
+    if not branch_head:
+        fail('could not determine branch head of {branch} branch'.format(
+            branch=repository_branch
+        ))
+    range_start = _.head(reachable_release_tags_from_commit(helper, repo, branch_head))
+
+    range_end = None
+    try:
+        range_end = repo.git.describe(branch_head) # better readable range_end by describing head commit
+    except git.exc.GitCommandError:
+        range_end = branch_head.hexsha
+
+    commit_range = "{start}..{end}".format(start=range_start, end=range_end)
+    return commit_range
+
+def release_tags(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo
+) -> list:
+    release_tags = helper.release_tags()
+    tags = _ \
+        .chain(repo.tags) \
+        .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
+        .filter(lambda item: _.find(release_tags, lambda el: el == item['tag'])) \
+        .key_by('commit') \
+        .map_values('tag') \
+        .value()
+    return tags
+
+def reachable_release_tags_from_commit(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo,
+    commit: git.objects.Commit
+) -> list:
+    tags = release_tags(helper, repo)
+
+    visited = set()
+    queue = list()
+    queue.append(commit)
+    visited.add(commit.hexsha)
+
+    reachable_tags = list()
+
+    while queue:
+        commit = queue.pop(0)
+        if commit.hexsha in tags:
+            reachable_tags.append(tags[commit.hexsha])
+        not_visited_parents = _.filter(commit.parents,
+            lambda parent_commit: not parent_commit.hexsha in visited
+        )
+        if not_visited_parents:
+            queue.extend(not_visited_parents)
+            # queue.sort(key=lambda commit: commit.committed_date, reverse=True) #not needed anymore as we sort by semver at the end
+            visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
+
+    reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
+
+    if not reachable_tags:
+        warning('no release tag found, falling back to root commit')
+        root_commits = repo.iter_commits(rev=commit, max_parents=0)
+        root_commit = next(root_commits, None)
+        if not root_commit:
+            fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
+        if next(root_commits, None):
+            fail('cannot determine range for release notes. Repository has multiple root commits. Specify range via commit_range parameter.')
+        reachable_tags.append(root_commit.hexsha)
+
+    return reachable_tags
+
+
+def fetch_pr_numbers_in_range(
+    repo: git.Repo,
+    commit_range: str
+) -> set:
+    info('git log {range}'.format(range=commit_range))
+    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
+    pr_numbers = set()
+    for commitMessage in gitLogs:
+        if commitMessage.startswith('Merge pull'):
+            pr_number = _.head(re.findall(r"#(\d+|$)", commitMessage))
+            if pr_number:
+                pr_numbers.add(pr_number)
+
+    verbose('Merged pull request numbers in range {range}: {pr_numbers}'.format(
+        range=commit_range,
+        pr_numbers=pr_numbers
+    ))
+    return pr_numbers
+
+def fetch_release_notes_from_prs(
+    helper: GitHubRepositoryHelper,
+    pr_numbers_in_range: set
+) -> list:
+    # we should consider adding a release-note label to the PRs
+    # to reduce the number of search results
+    prs_iter = helper.search_issues_in_repo('type:pull is:closed')
+
+    release_notes = list()
+    for pr_iter in prs_iter:
+        pr_dict = pr_iter.as_dict()
+
+        pr_number = pr_dict['number']
+        if not str(pr_number) in pr_numbers_in_range:
+            continue
+
+        release_notes_pr = extract_release_notes(
+            pr_number=pr_number,
+            text=pr_dict['body'],
+            user_login=_.get(pr_dict, 'user.login')
+        )
+        if not release_notes_pr:
+            continue
+
+        release_notes.extend(release_notes_pr)
+    return release_notes
+
+def extract_release_notes(
+    pr_number: int,
+    text: str,
+    user_login: str
+) -> list:
+    release_notes = list()
+
+    quotes = re.findall(
+        r"``` *(improvement|noteworthy)( (user|operator)?)?.*?\n(.*?)\n```",
+        text,
+        re.MULTILINE | re.DOTALL
+    )
+    for quote in quotes:
+        quote = _.map(quote, lambda obj: _.trim(obj))
+
+        text = quote[3]
+        if not text or 'none' == text.lower():
+            continue
+
+        category = quote[0]
+        target_group = quote[2] or 'user'
+
+        release_notes.append(ReleaseNote(
+            category_id=category,
+            target_group_id=target_group,
+            text=text,
+            pr_number=pr_number,
+            user_login=user_login
+        ))
+    return release_notes

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -144,6 +144,9 @@ def release_tags(
     repo: git.Repo
 ) -> list:
     release_tags = helper.release_tags()
+    # you can remove the directive to disable the undefined-variable error once pylint is updated
+    # with fix https://github.com/PyCQA/pylint/commit/db01112f7e4beadf7cd99c5f9237d580309f0494 included
+    # pylint: disable=undefined-variable
     tags = _ \
         .chain(repo.tags) \
         .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
@@ -151,6 +154,7 @@ def release_tags(
         .key_by('commit') \
         .map_values('tag') \
         .value()
+    # pylint: enable=undefined-variable
     return tags
 
 def reachable_release_tags_from_commit(

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -133,7 +133,7 @@ def calculate_range(
     range_end = None
     try:
         range_end = repo.git.describe(branch_head) # better readable range_end by describing head commit
-    except git.exc.GitCommandError:
+    except git.exc.GitError:
         range_end = branch_head.hexsha
 
     commit_range = "{start}..{end}".format(start=range_start, end=range_end)
@@ -247,20 +247,20 @@ def extract_release_notes(
 ) -> list:
     release_notes = list()
 
-    quotes = re.findall(
+    code_blocks = re.findall(
         r"``` *(improvement|noteworthy)( (user|operator)?)?.*?\n(.*?)\n```",
         text,
         re.MULTILINE | re.DOTALL
     )
-    for quote in quotes:
-        quote = _.map(quote, lambda obj: _.trim(obj))
+    for code_block in code_blocks:
+        code_block = _.map(code_block, lambda obj: _.trim(obj))
 
-        text = quote[3]
+        text = code_block[3]
         if not text or 'none' == text.lower():
             continue
 
-        category = quote[0]
-        target_group = quote[2] or 'user'
+        category = code_block[0]
+        target_group = code_block[2] or 'user'
 
         release_notes.append(ReleaseNote(
             category_id=category,

--- a/github/util.py
+++ b/github/util.py
@@ -21,6 +21,7 @@ import re
 import semver
 import sys
 import urllib.parse
+from pydash import _
 
 import requests
 
@@ -76,6 +77,9 @@ class RepositoryHelperBase(object):
             owner=owner,
             name=name
         )
+        self.owner = owner
+        self.repository_name = name
+
         self.default_branch = default_branch
 
     def _create_repository(self, owner: str, name: str):
@@ -258,6 +262,10 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
             tagger=author
         )
 
+    def get_latest_release(self):
+        release = self.repository.latest_release()
+        return release
+
     def create_release(
         self,
         tag_name: str,
@@ -307,6 +315,14 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
             try:
                 yield semver.parse_version_info(release.tag_name)
             except ValueError: pass # ignore
+
+    def release_tags(self):
+        return _.map(self.repository.releases(), 'tag_name')
+
+    def search_issues_in_repo(self, query: str):
+        query = "repo:{org}/{repo} {query}".format(org=self.owner, repo=self.repository_name, query=query)
+        search_result = self.github.search_issues(query)
+        return search_result
 
 
 def github_api_ctor(github_url: str, verify_ssl: bool=True):

--- a/github/util.py
+++ b/github/util.py
@@ -262,10 +262,6 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
             tagger=author
         )
 
-    def get_latest_release(self):
-        release = self.repository.latest_release()
-        return release
-
     def create_release(
         self,
         tag_name: str,

--- a/test/github/__init__.py
+++ b/test/github/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+
+# add modules from root dir to module search path
+# so unit test modules can use regular imports
+sys.path.extend(
+    (
+        os.path.join(
+            os.path.realpath(os.path.dirname(__file__)),
+            os.pardir,
+            os.pardir
+        ),
+        os.path.realpath(os.path.dirname(__file__))
+    )
+)

--- a/test/github/release_notes_test.py
+++ b/test/github/release_notes_test.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pydash import _
+
+from github.release_notes import (
+    extract_release_notes,
+    ReleaseNote,
+    build_markdown
+)
+
+class ReleaseNotesTest(unittest.TestCase):
+    def test_rls_note_extraction_improvement(self):
+        text = \
+            '``` improvement user\n'\
+            'this is a release note text\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(1, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='this is a release note text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+
+    def test_rls_note_extraction_noteworthy(self):
+        text = \
+            '``` noteworthy operator\n'\
+            'notew-text\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(1, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='notew-text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+
+    def test_multiple_rls_note_extraction(self):
+        text = \
+            'random text\n'\
+            '``` improvement user\n'\
+            'imp-user-text\n'\
+            '```\n'\
+            '``` improvement operator\n'\
+            'imp-op-text\n'\
+            '```\n'\
+            '``` noteworthy operator\n'\
+            'notew-text\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(3, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='imp-user-text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='operator',
+                text='imp-op-text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 1)
+        )
+        self.assertEqual(
+            ReleaseNote(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='notew-text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 2)
+        )
+
+    def test_rls_note_extraction_multiple_lines(self):
+        text = \
+            '``` improvement user\n'\
+            'first line\n'\
+            'second line\r\n'\
+            'third line\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(1, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='first line\nsecond line\r\nthird line',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+
+    def test_rls_note_extraction_trim_text(self):
+        text = \
+            '``` improvement user\n'\
+            '\n'\
+            '        text with spaces      '\
+            '\n'\
+            '\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(1, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='text with spaces',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+
+    def test_rls_note_extraction_no_target_group_should_default_to_user(self):
+        text = \
+            '``` improvement\n'\
+            'text\n'\
+            '```'
+        release_notes = extract_release_notes(
+            pr_number=42,
+            text=text,
+            user_login='foo'
+        )
+
+        self.assertEqual(1, len(release_notes))
+        self.assertEqual(
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='text',
+                pr_number=42,
+                user_login='foo'),
+            _.nth(release_notes, 0)
+        )
+
+    def test_build_markdown(self):
+        release_note_objs = [
+            ReleaseNote(
+              category_id='improvement',
+              target_group_id='user',
+              text='rls note 1',
+              pr_number=42,
+              user_login='foo'
+            ),
+            ReleaseNote(
+                category_id='improvement',
+                target_group_id='user',
+                text='rls note 2',
+                pr_number=42,
+                user_login='foo'
+            )
+        ]
+        actual_str = build_markdown(release_note_objs)
+
+        expected_str = \
+            '## Improvements\n'\
+            '### To end users\n'\
+            '* rls note 1 (#42, @foo)\n'\
+            '* rls note 2 (#42, @foo)'
+        self.assertEquals(expected_str, actual_str)

--- a/test/github/release_notes_test.py
+++ b/test/github/release_notes_test.py
@@ -184,6 +184,41 @@ class ReleaseNotesTest(unittest.TestCase):
             _.nth(release_notes, 0)
         )
 
+    def test_rls_note_extraction_no_release_notes(self):
+        def verify_no_release_note(text: str):
+            release_notes = extract_release_notes(
+                pr_number=42,
+                text=text,
+                user_login='foo'
+            )
+            self.assertEqual(0, len(release_notes))
+
+        text = \
+            '``` improvement user\n'\
+            '\n'\
+            '```'
+        verify_no_release_note(text)
+
+        text = \
+            '``` improvement user\n'\
+            ' NONE \n'\
+            '```'
+        verify_no_release_note(text)
+
+        text = \
+            '``` improvement user\n'\
+            'none\n'\
+            '```'
+        verify_no_release_note(text)
+
+        text = \
+            '``` improvement user\n'\
+            '```'
+        verify_no_release_note(text)
+
+        text = 'some random description'
+        verify_no_release_note(text)
+
     def test_build_markdown(self):
         release_note_objs = [
             ReleaseNote(
@@ -209,3 +244,9 @@ class ReleaseNotesTest(unittest.TestCase):
             '* rls note 1 (#42, @foo)\n'\
             '* rls note 2 (#42, @foo)'
         self.assertEquals(expected_str, actual_str)
+
+    def test_build_markdown_no_release_notes(self):
+        release_note_objs = []
+
+        expected_str = 'no release notes available'
+        self.assertEquals(expected_str, build_markdown(release_note_objs))


### PR DESCRIPTION
Generate release notes from specially tagged quotes in pull request descriptions.

Introducing new method `generate_release_notes` to generate release notes (inspired by https://github.com/kubernetes/release/blob/master/relnotes).

Flow is:

1. calculate range since last release
2. get commits in range and gather pull request numbers from merge commits 
3. scrape description of pull requests with code block

> \`\`\` \<category\> \<target_group\>
> \<release note text\>
> \`\`\`

**category**: improvement|noteworthy
**target_group**: user|operator

4. build release note text as markdown string