### PR TITLE
do not use release_notes variable for tag message

### DIFF
--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -124,7 +124,7 @@ def release_and_prepare_next_dev_cycle(
     )
     helper.create_tag(
         tag_name=release_version,
-        tag_message=release_notes,
+        tag_message="Release " + release_version,
         repository_reference=release_commit_sha,
         author_name=author_name,
         author_email=author_email


### PR DESCRIPTION
not use release_notes variable for tag message (could be a rather long string)

as per ask from @ccwienk on pr #69 (https://github.com/gardener/cc-utils/pull/69/commits/d4586880c581233dd5da1197b84c0401d8cf84b1#diff-7c7cec701f48fc50fbe4cbd352faa016L127) to make a seperate commit for the tag message

