### PR TITLE
supporting release note origin - needed for release note transport

### DIFF
--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -14,7 +14,6 @@
 
 import re
 from collections import namedtuple
-
 import git
 from git.exc import GitError
 from pydash import _
@@ -22,18 +21,74 @@ from semver import parse_version_info
 from github.util import GitHubRepositoryHelper
 
 from util import info, warning, fail, verbose, existing_dir
+from product.model import ComponentReference
+from model.base import ModelValidationError
 
-ReleaseNote = namedtuple('ReleaseNote', \
-    ["category_id", "target_group_id", "text", "pr_number", "user_login"] \
-)
-Category = namedtuple("Category", ["identifier", "title"])
-TargetGroup = namedtuple("TargetGroup", ["identifier", "title"])
-categories = \
-    Category(identifier='noteworthy', title='# Most notable changes'), \
-    Category(identifier='improvement', title='# Improvements')
+ReleaseNote = namedtuple('ReleaseNote', [
+    "category_id",
+    "target_group_id",
+    "text",
+    "reference_is_pr",
+    "reference_id",
+    "user_login",
+    "origin_repo",
+    "is_current_repo",
+    "component_ref"
+])
+
+def create_release_note_obj(
+    category_id: str,
+    target_group_id: str,
+    text: str,
+    reference_is_pr: str,
+    reference_id: str,
+    user_login: str,
+    origin_repo: str,
+    is_current_repo: bool
+)->ReleaseNote:
+
+    if reference_id:
+        reference_id=str(reference_id)
+
+    return ReleaseNote(
+        category_id=category_id,
+        target_group_id=target_group_id,
+        text=text,
+        reference_is_pr=reference_is_pr,
+        reference_id=reference_id,
+        user_login=user_login,
+        origin_repo=origin_repo,
+        is_current_repo=is_current_repo,
+        component_ref=ComponentReference.create(name=origin_repo, version=None)
+    )
+
+Node = namedtuple("Node", ["identifier", "title", "nodes", "matches_rn_field"])
 target_groups = \
-    TargetGroup(identifier='user', title='## To end users'), \
-    TargetGroup(identifier='operator', title='## To operations team')
+    Node(
+        identifier='user',
+        title='USER',
+        nodes=None,
+        matches_rn_field='target_group_id'
+    ), \
+    Node(
+        identifier='operator',
+        title='OPERATOR',
+        nodes=None,
+        matches_rn_field='target_group_id'
+    )
+categories = \
+    Node(
+        identifier='noteworthy',
+        title='Most notable changes',
+        nodes=target_groups,
+        matches_rn_field='category_id'
+    ), \
+    Node(
+        identifier='improvement',
+        title='Improvements',
+        nodes=target_groups,
+        matches_rn_field='category_id'
+    )
 
 def generate_release_notes(
     repo_dir: str,
@@ -46,7 +101,7 @@ def generate_release_notes(
     if not commit_range:
         commit_range = calculate_range(repository_branch, repo, helper)
     pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
-    release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers)
+    release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers, helper.unique_repo_name())
     release_notes_str = build_markdown(release_note_objs)
 
     info(release_notes_str)
@@ -55,67 +110,145 @@ def generate_release_notes(
 def build_markdown(
     release_note_objs: list
 ) -> str:
-    def release_notes_for_target_group(
-        category: Category,
-        target_group: TargetGroup,
-        release_note_objs: list()
-    ) -> list:
-        release_note_objs = _.filter(
-            release_note_objs,
-            lambda release_note:
-                category.identifier == release_note.category_id
-                and target_group.identifier == release_note.target_group_id
-        )
 
-        release_note_lines = list()
-        if release_note_objs:
-            release_note_lines.append(target_group.title)
-            for release_note in release_note_objs:
-                for i, rls_note_line in enumerate(release_note.text.splitlines()):
-                    if i == 0:
-                        release_note_lines.append(
-                            '* {rls_note_line} (#{pr_num}, @{user})'
-                                .format(
-                                    pr_num=release_note.pr_number,
-                                    user=release_note.user_login,
-                                    rls_note_line=rls_note_line
-                                )
-                        )
+    def get_header_suffix(
+        rn_obj: ReleaseNote
+    )->str:
+        header_suffix = ''
+        if rn_obj.user_login or rn_obj.reference_id:
+            header_suffix_list = list()
+            cr = rn_obj.component_ref
+            if rn_obj.reference_id:
+                if rn_obj.reference_is_pr:
+                    reference_prefix = '#'
+                    reference_link = 'https://{origin_repo}/pull/{ref_id}'.format(
+                        origin_repo=rn_obj.origin_repo,
+                        ref_id=rn_obj.reference_id
+                    )
+                else: # commit
+                    if not rn_obj.is_current_repo:
+                        reference_prefix = '@'
                     else:
-                        release_note_lines.append('  * {rls_note_line}'.format(
-                            rls_note_line=rls_note_line
-                        ))
-        return release_note_lines
+                        # for the current repo we use gitHub's feature to auto-link to references,
+                        # hence in case of commits we don't need a prefix
+                        reference_prefix = ''
+                    reference_link = 'https://{origin_repo}/commit/{ref_id}'.format(
+                        origin_repo=rn_obj.origin_repo,
+                        ref_id=rn_obj.reference_id
+                )
 
-    def release_notes_for_category(
-        category: Category,
+                reference = '{reference_prefix}{ref_id}'.format(
+                    reference_prefix=reference_prefix,
+                    ref_id=rn_obj.reference_id,
+                )
+
+                if rn_obj.is_current_repo:
+                    header_suffix_list.append(reference)
+                else:
+                    header_suffix_list.append(
+                        '[{org}/{repo}{reference}]({ref_link})'.format(
+                            org=cr.github_organisation(),
+                            repo=cr.github_repo(),
+                            reference=reference,
+                            ref_link=reference_link
+                        )
+                    )
+            if rn_obj.user_login:
+                header_suffix_list.append('[@{u}](https://{github_host}/{u})'.format(
+                    u=rn_obj.user_login,
+                    github_host=cr.github_host()
+                ))
+            header_suffix = ' ({s})'.format(
+                s=', '.join(header_suffix_list)
+            )
+        return header_suffix
+
+    def build_bullet_point_head(
+        line: str,
+        tag: str,
+        rn_obj: ReleaseNote
+    )->str:
+        header_suffix = get_header_suffix(rn_obj)
+
+        return '* *[{tag}]* {rls_note_line}{header_suffix}'.format(
+                    tag=tag,
+                    rls_note_line=line,
+                    header_suffix=header_suffix
+                )
+    def to_md_bullet_points(
+        tag: str,
+        rn_objs: list,
+    ):
+        bullet_points = list()
+        for rn_obj in rn_objs:
+            for i, rls_note_line in enumerate(rn_obj.text.splitlines()):
+                if i == 0:
+                    bullet_points.append(
+                        build_bullet_point_head(line=rls_note_line, tag=tag, rn_obj=rn_obj)
+                    )
+                else:
+                    bullet_points.append('  * {rls_note_line}'.format(
+                        rls_note_line=rls_note_line
+                    ))
+        return bullet_points
+    def nodes_to_markdown_lines(
+        nodes: list,
+        level: int,
         release_note_objs: list
     ) -> list:
-        rn_lines = list()
-        rn_lines_category = list()
-        for target_group in target_groups:
-            rn_lines_category.extend(
-                release_notes_for_target_group(
-                    category=category,
-                    target_group=target_group,
-                    release_note_objs=release_note_objs
-                )
+        md_lines = list()
+        for node in nodes:
+            filtered_rn_objects = _.filter(
+                release_note_objs,
+                lambda rn: node.identifier == _.get(rn, node.matches_rn_field)
             )
+            if not filtered_rn_objects:
+                continue
+            if node.nodes:
+                tmp_md_lines = nodes_to_markdown_lines(
+                    nodes=node.nodes,
+                    level=level + 1,
+                    release_note_objs=filtered_rn_objects
+                )
+                skip_title = False
+            else:
+                tmp_md_lines = to_md_bullet_points(
+                    tag=node.title,
+                    rn_objs=filtered_rn_objects
+                )
+                # title is used as bullet point tag -> no need for additional title
+                skip_title = True
 
-        if rn_lines_category:
-            rn_lines.append(category.title)
-            rn_lines.extend(rn_lines_category)
-        return rn_lines
+            # only add title if there are lines below the title
+            if tmp_md_lines:
+                if not skip_title:
+                    md_lines.append('{hashtags} {title}'.format(
+                        hashtags=_.repeat('#', level),
+                        title=node.title
+                    ))
+                md_lines.extend(tmp_md_lines)
+        return md_lines
 
-    release_note_lines = list()
-    for category in categories:
-        release_note_lines.extend(release_notes_for_category(
-            category=category,
-            release_note_objs=release_note_objs
-        ))
+    origin_nodes = _\
+        .chain(release_note_objs)\
+        .sort_by(lambda rn_obj: rn_obj.component_ref.github_repo())\
+        .uniq_by(lambda rn_obj: rn_obj.origin_repo)\
+        .map(lambda rn_obj: Node(
+            identifier=rn_obj.origin_repo,
+            title='[{origin_name}]'.format(origin_name=rn_obj.component_ref.github_repo()),
+            nodes=categories,
+            matches_rn_field='origin_repo'
+        ))\
+        .value()
 
-    if release_note_lines:
-        return '\n'.join(release_note_lines)
+    md_lines = nodes_to_markdown_lines(
+        nodes=origin_nodes,
+        level=1,
+        release_note_objs=release_note_objs
+    )
+
+    if md_lines:
+        return '\n'.join(md_lines)
     else: # fallback
         return 'no release notes available'
 
@@ -134,7 +267,8 @@ def calculate_range(
 
     range_end = None
     try:
-        range_end = repo.git.describe(branch_head) # better readable range_end by describing head commit
+        # better readable range_end by describing head commit
+        range_end = repo.git.describe(branch_head)
     except GitError:
         range_end = branch_head.hexsha
 
@@ -155,7 +289,8 @@ def release_tags(
 
     release_tags = helper.release_tags()
     # you can remove the directive to disable the undefined-variable error once pylint is updated
-    # with fix https://github.com/PyCQA/pylint/commit/db01112f7e4beadf7cd99c5f9237d580309f0494 included
+    # with fix https://github.com/PyCQA/pylint/commit/db01112f7e4beadf7cd99c5f9237d580309f0494
+    # included
     # pylint: disable=undefined-variable
     tags = _ \
         .chain(repo.tags) \
@@ -191,7 +326,6 @@ def reachable_release_tags_from_commit(
         )
         if not_visited_parents:
             queue.extend(not_visited_parents)
-            # queue.sort(key=lambda commit: commit.committed_date, reverse=True) #not needed anymore as we sort by semver at the end
             visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
 
     reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
@@ -203,7 +337,10 @@ def reachable_release_tags_from_commit(
         if not root_commit:
             fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
         if next(root_commits, None):
-            fail('cannot determine range for release notes. Repository has multiple root commits. Specify range via commit_range parameter.')
+            fail(
+                'cannot determine range for release notes. Repository has multiple root commits.'\
+                'Specify range via commit_range parameter.'
+            )
         reachable_tags.append(root_commit.hexsha)
 
     return reachable_tags
@@ -230,7 +367,8 @@ def fetch_pr_numbers_in_range(
 
 def fetch_release_notes_from_prs(
     helper: GitHubRepositoryHelper,
-    pr_numbers_in_range: set
+    pr_numbers_in_range: set,
+    current_repo:str
 ) -> list:
     # we should consider adding a release-note label to the PRs
     # to reduce the number of search results
@@ -247,7 +385,8 @@ def fetch_release_notes_from_prs(
         release_notes_pr = extract_release_notes(
             pr_number=pr_number,
             text=pr_dict['body'],
-            user_login=_.get(pr_dict, 'user.login')
+            user_login=_.get(pr_dict, 'user.login'),
+            current_repo=current_repo
         )
         if not release_notes_pr:
             continue
@@ -258,30 +397,52 @@ def fetch_release_notes_from_prs(
 def extract_release_notes(
     pr_number: int,
     text: str,
-    user_login: str
+    user_login: str,
+    current_repo: str
 ) -> list:
     release_notes = list()
 
     code_blocks = re.findall(
-        r"``` *(improvement|noteworthy)( (user|operator)?)?.*?\n(.*?)\n```",
+        r""\
+            "``` *(improvement|noteworthy) (user|operator)"\
+            "( (\S+/\S+/\S+)(( (#|\$)(\S+))?( @(\S+))?)( .*?)?|( .*?)?)"\
+            "\r?\n(.*?)\n```",
         text,
         re.MULTILINE | re.DOTALL
     )
     for code_block in code_blocks:
         code_block = _.map(code_block, lambda obj: _.trim(obj))
 
-        text = code_block[3]
+        text = code_block[12]
         if not text or 'none' == text.lower():
             continue
 
         category = code_block[0]
-        target_group = code_block[2] or 'user'
+        target_group = code_block[1]
+        origin_repo = code_block[3]
+        if origin_repo:
+            reference_is_pr = code_block[6] == '#'
+            reference_id = code_block[7] or None
+            user_login = code_block[9] or None
+        else:
+            origin_repo = current_repo
+            reference_is_pr = True
+            reference_id = pr_number
 
-        release_notes.append(ReleaseNote(
-            category_id=category,
-            target_group_id=target_group,
-            text=text,
-            pr_number=pr_number,
-            user_login=user_login
-        ))
+        try:
+            release_notes.append(create_release_note_obj(
+                category_id=category,
+                target_group_id=target_group,
+                text=text,
+                reference_is_pr=reference_is_pr,
+                reference_id=reference_id,
+                user_login=user_login,
+                origin_repo=origin_repo,
+                is_current_repo=current_repo == origin_repo
+            ))
+        except ModelValidationError:
+            warning('skipping invalid origin repository: {origin_repo}'.format(
+                origin_repo=origin_repo
+            ))
+            continue
     return release_notes

--- a/github/util.py
+++ b/github/util.py
@@ -320,6 +320,11 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         search_result = self.github.search_issues(query)
         return search_result
 
+    def unique_repo_name(self):
+        '''returns a unique repository name in the format of a component reference name'''
+        parsed = urllib.parse.urlparse(self.repository.html_url)
+        return "{hostname}{path}".format(hostname=parsed.hostname, path=parsed.path)
+
 
 def github_api_ctor(github_url: str, verify_ssl: bool=True):
     '''returns the appropriate github3.GitHub constructor for the given github URL

--- a/github/util.py
+++ b/github/util.py
@@ -320,11 +320,6 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         search_result = self.github.search_issues(query)
         return search_result
 
-    def unique_repo_name(self):
-        '''returns a unique repository name in the format of a component reference name'''
-        parsed = urllib.parse.urlparse(self.repository.html_url)
-        return "{hostname}{path}".format(hostname=parsed.hostname, path=parsed.path)
-
 
 def github_api_ctor(github_url: str, verify_ssl: bool=True):
     '''returns the appropriate github3.GitHub constructor for the given github URL

--- a/product/model.py
+++ b/product/model.py
@@ -138,6 +138,13 @@ class ComponentName(object):
     def github_repo(self):
         return self.name().split('/')[2]
 
+    def __eq__(self, other):
+        if not isinstance(other, ComponentName):
+            return False
+        return self.name() == other.name()
+
+    def __hash__(self):
+        return hash((self.name()))
 
 class ComponentReference(DependencyBase):
     @staticmethod

--- a/test/github/release_notes_test.py
+++ b/test/github/release_notes_test.py
@@ -43,7 +43,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 0)
@@ -55,7 +55,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 pr_number=42,
                 text=text,
                 user_login='foo',
-                current_repo='github.com/o/r'
+                current_repo='github.com/s/repo'
             )
 
             self.assertEqual(1, len(release_notes))
@@ -67,7 +67,7 @@ class ReleaseNotesTest(unittest.TestCase):
                     reference_is_pr=True,
                     reference_id=42,
                     user_login='foo',
-                    origin_repo='github.com/o/r',
+                    source_repo='github.com/s/repo',
                     is_current_repo=True
                 ),
                 _.nth(release_notes, 0)
@@ -112,14 +112,14 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 0)
         )
 
-    def test_rls_note_extraction_origin(self):
-        def origin_test(
+    def test_rls_note_extraction_src_repo(self):
+        def source_repo_test(
             code_block,
             exp_ref_id,
             exp_usr,
@@ -141,53 +141,53 @@ class ReleaseNotesTest(unittest.TestCase):
                     reference_is_pr=exp_ref_is_pr,
                     reference_id=exp_ref_id,
                     user_login=exp_usr,
-                    origin_repo='github.com/gardener/origin-component',
+                    source_repo='github.com/gardener/source-component',
                     is_current_repo=False
                 ),
                 _.nth(release_notes, 0)
             )
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component #1 @original-user-foo\n'\
-            'origin, pr refid and user\n'\
+            '``` improvement user github.com/gardener/source-component #1 @original-user-foo\n'\
+            'source repo, pr refid and user\n'\
             '```'
-        origin_test(code_block, exp_ref_id=1, exp_usr='original-user-foo', exp_text='origin, pr refid and user')
+        source_repo_test(code_block, exp_ref_id=1, exp_usr='original-user-foo', exp_text='source repo, pr refid and user')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component $commit-id @original-user-foo\n'\
-            'origin, commit refid and user\n'\
+            '``` improvement user github.com/gardener/source-component $commit-id @original-user-foo\n'\
+            'source repo, commit refid and user\n'\
             '```'
-        origin_test(code_block, exp_ref_id='commit-id', exp_ref_is_pr=False, exp_usr='original-user-foo', exp_text='origin, commit refid and user')
+        source_repo_test(code_block, exp_ref_id='commit-id', exp_ref_is_pr=False, exp_usr='original-user-foo', exp_text='source repo, commit refid and user')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component #1 @original-user-foo some random noise\n'\
+            '``` improvement user github.com/gardener/source-component #1 @original-user-foo some random noise\n'\
             'noise test\n'\
             '```'
-        origin_test(code_block, exp_ref_id=1, exp_usr='original-user-foo', exp_text='noise test')
+        source_repo_test(code_block, exp_ref_id=1, exp_usr='original-user-foo', exp_text='noise test')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component #1 some random noise\n'\
+            '``` improvement user github.com/gardener/source-component #1 some random noise\n'\
             'no user specified\n'\
             '```'
-        origin_test(code_block, exp_ref_id=1, exp_usr=None, exp_text='no user specified')
+        source_repo_test(code_block, exp_ref_id=1, exp_usr=None, exp_text='no user specified')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component @user some random noise\n'\
+            '``` improvement user github.com/gardener/source-component @user some random noise\n'\
             'no pull request ref_id specified\n'\
             '```'
-        origin_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr='user', exp_text='no pull request ref_id specified')
+        source_repo_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr='user', exp_text='no pull request ref_id specified')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component\n'\
-            'origin_repo only\n'\
+            '``` improvement user github.com/gardener/source-component\n'\
+            'source_repo only\n'\
             '```'
-        origin_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr=None, exp_text='origin_repo only')
+        source_repo_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr=None, exp_text='source_repo only')
 
         code_block = \
-            '``` improvement user github.com/gardener/origin-component some random noise\n'\
-            'origin_repo only - with noise\n'\
+            '``` improvement user github.com/gardener/source-component some random noise\n'\
+            'source_repo only - with noise\n'\
             '```'
-        origin_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr=None, exp_text='origin_repo only - with noise')
+        source_repo_test(code_block, exp_ref_id=None, exp_ref_is_pr=False, exp_usr=None, exp_text='source_repo only - with noise')
 
 
     def test_multiple_rls_note_extraction(self):
@@ -218,7 +218,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 0)
@@ -231,7 +231,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 1)
@@ -244,7 +244,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 2)
@@ -273,7 +273,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 0)
@@ -303,7 +303,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             _.nth(release_notes, 0)
@@ -364,7 +364,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             )
         ]
@@ -387,7 +387,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=42,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             create_release_note_obj(
@@ -397,7 +397,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=1,
                 user_login='bar',
-                origin_repo='github.com/gardener/a-foo-bar',
+                source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             )
         ]
@@ -421,7 +421,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=False,
                 reference_id='commit-id-1',
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
             create_release_note_obj(
@@ -431,7 +431,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=False,
                 reference_id='commit-id-2',
                 user_login='bar',
-                origin_repo='github.com/gardener/a-foo-bar',
+                source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             )
         ]
@@ -446,16 +446,16 @@ class ReleaseNotesTest(unittest.TestCase):
             '* *[USER]* rls note 1 (commit-id-1, [@foo](https://github.com/foo))'
         self.assertEqual(expected_str, actual_str)
 
-    def test_markdown_origin_user(self):
+    def test_markdown_source_repo_user(self):
         release_note_objs = [
             create_release_note_obj(
                 category_id='improvement',
                 target_group_id='operator',
-                text='no origin user',
+                text='no source repo user',
                 reference_is_pr=True,
                 reference_id=42,
                 user_login=None,
-                origin_repo='github.com/o/repo',
+                source_repo='github.com/s/repo',
                 is_current_repo=False
             ),
             create_release_note_obj(
@@ -465,7 +465,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=True,
                 reference_id=1,
                 user_login=None,
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             )
         ]
@@ -476,7 +476,7 @@ class ReleaseNotesTest(unittest.TestCase):
             '* *[OPERATOR]* no user (#1)\n'\
             '# [repo]\n'\
             '## Improvements\n'\
-            '* *[OPERATOR]* no origin user ([o/repo#42](https://github.com/o/repo/pull/42))'
+            '* *[OPERATOR]* no source repo user ([s/repo#42](https://github.com/s/repo/pull/42))'
         self.assertEqual(expected_str, actual_str)
 
     def test_markdown_no_reference(self):
@@ -484,11 +484,11 @@ class ReleaseNotesTest(unittest.TestCase):
             create_release_note_obj(
                 category_id='noteworthy',
                 target_group_id='operator',
-                text='no origin reference',
+                text='no source repo reference',
                 reference_is_pr=False,
                 reference_id=None,
                 user_login='bar',
-                origin_repo='github.com/gardener/a-foo-bar',
+                source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             ),
             create_release_note_obj(
@@ -498,7 +498,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=False,
                 reference_id=None,
                 user_login='foo',
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             )
         ]
@@ -507,7 +507,7 @@ class ReleaseNotesTest(unittest.TestCase):
         expected_str = \
             '# [a-foo-bar]\n'\
             '## Most notable changes\n'\
-            '* *[OPERATOR]* no origin reference ([@bar](https://github.com/bar))\n'\
+            '* *[OPERATOR]* no source repo reference ([@bar](https://github.com/bar))\n'\
             '# [current-repo]\n'\
             '## Improvements\n'\
             '* *[USER]* no reference ([@foo](https://github.com/foo))'
@@ -518,11 +518,11 @@ class ReleaseNotesTest(unittest.TestCase):
             create_release_note_obj(
                 category_id='noteworthy',
                 target_group_id='operator',
-                text='no origin reference no user',
+                text='no source repo reference no user',
                 reference_is_pr=False,
                 reference_id=None,
                 user_login=None,
-                origin_repo='github.com/gardener/a-foo-bar',
+                source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             ),
             create_release_note_obj(
@@ -532,7 +532,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 reference_is_pr=False,
                 reference_id=None,
                 user_login=None,
-                origin_repo='github.com/gardener/current-repo',
+                source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             )
         ]
@@ -541,7 +541,7 @@ class ReleaseNotesTest(unittest.TestCase):
         expected_str = \
             '# [a-foo-bar]\n'\
             '## Most notable changes\n'\
-            '* *[OPERATOR]* no origin reference no user\n'\
+            '* *[OPERATOR]* no source repo reference no user\n'\
             '# [current-repo]\n'\
             '## Improvements\n'\
             '* *[USER]* no reference no user'


### PR DESCRIPTION
- release note lines now have the target group as tag instead of having an own header for the target group (user / operator) which made the release note harder to read
- introducing new optional header parameter for specifying the origin

# Header
\`\`\`\<category\> \<target_group\>[ \<origin_repo\>[ #\<pr\>|$\<commit\>][ @\<origin_user\>]]

# Examples:
\`\`\`noteworthy operator github.com/gardener/machine-controller-manager #1 @prashanth26
some release note
\`\`\`

# Example release note
<img width="676" alt="screen shot 2018-07-26 at 18 06 16" src="https://user-images.githubusercontent.com/5526658/43274189-c158182c-90fe-11e8-8b63-ca643912129b.png">
