### PR TITLE
Transport release notes

### DIFF
--- a/cli/githubutil.py
+++ b/cli/githubutil.py
@@ -25,8 +25,8 @@ from github.util import (
     _add_user_to_team,
     _add_all_repos_to_team
 )
-from github.release_notes import generate_release_notes
 import product.model
+from github.release_notes import generate_release_notes, get_release_note_blocks
 
 
 
@@ -227,6 +227,30 @@ def create_or_update_draft_release(
             draft_release.edit(body=release_notes)
         else:
             info('draft release notes are already up to date')
+
+def get_release_note_blocks_cli(
+    repo_dir: str,
+    github_cfg_name: str,
+    github_repository_owner: str,
+    github_repository_name: str,
+    repository_branch: str,
+    commit_range: str=None
+):
+    github_cfg = ctx().cfg_factory().github(github_cfg_name)
+
+    helper = GitHubRepositoryHelper(
+        github_cfg=github_cfg,
+        owner=github_repository_owner,
+        name=github_repository_name,
+        default_branch=repository_branch,
+    )
+
+    get_release_note_blocks(
+        repo_dir=repo_dir,
+        helper=helper,
+        repository_branch=repository_branch,
+        commit_range=commit_range
+    )
 
 def remove_webhooks(
     github_org_name: CliHints.non_empty_string(

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -37,38 +37,58 @@ ReleaseNote = namedtuple('ReleaseNote', [
     "component_name"
 ])
 
-def create_release_note_obj(
-    category_id: str,
-    target_group_id: str,
-    text: str,
-    reference_is_pr: str,
-    reference_id: str,
-    user_login: str,
-    source_repo: str,
-    is_current_repo: bool
-)->ReleaseNote:
-
-    if reference_id:
-        reference_id=str(reference_id)
-
-    return ReleaseNote(
-        category_id=category_id,
-        target_group_id=target_group_id,
-        text=text,
-        reference_is_pr=reference_is_pr,
-        reference_id=reference_id,
-        user_login=user_login,
-        source_repo=source_repo,
-        is_current_repo=is_current_repo,
-        component_name=ComponentName(name=source_repo)
-    )
-
 def generate_release_notes(
     repo_dir: str,
     helper: GitHubRepositoryHelper,
     repository_branch: str,
     commit_range: str=None
 ):
+    release_note_objs = _get_rls_note_objs(
+        repo_dir=repo_dir,
+        helper=helper,
+        repository_branch=repository_branch,
+        commit_range=commit_range
+    )
+    release_notes_str = MarkdownRenderer(release_note_objs).render()
+
+    info(release_notes_str)
+    return release_notes_str
+
+def get_release_note_blocks(
+    repo_dir: str,
+    helper: GitHubRepositoryHelper,
+    repository_branch: str,
+    commit_range: str=None
+):
+    release_note_objs = _get_rls_note_objs(
+        repo_dir=repo_dir,
+        helper=helper,
+        repository_branch=repository_branch,
+        commit_range=commit_range
+    )
+
+    release_notes_str = release_note_objs_to_block_str(release_note_objs)
+
+    info(release_notes_str)
+    return release_notes_str
+
+def release_note_objs_to_block_str(
+    release_note_objs: list
+)->str:
+    block_strings = _.map(release_note_objs, lambda rn_obj: rn_obj.to_block_str())
+
+    if block_strings:
+        release_notes_str = '\n\n'.join(block_strings)
+    else:
+        release_notes_str = ''
+    return release_notes_str
+
+def _get_rls_note_objs(
+    repo_dir: str,
+    helper: GitHubRepositoryHelper,
+    repository_branch: str,
+    commit_range: str=None
+)->list:
     repo = git.Repo(existing_dir(repo_dir))
 
     current_repo_name = ComponentName.from_github_repo_url(helper.repository.html_url).name()
@@ -77,10 +97,200 @@ def generate_release_notes(
         commit_range = calculate_range(repository_branch, repo, helper)
     pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
     release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers, current_repo_name)
-    release_notes_str = MarkdownRenderer(release_note_objs).render()
+    return release_note_objs
 
-    info(release_notes_str)
-    return release_notes_str
+def calculate_range(
+    repository_branch: str,
+    repo: git.Repo,
+    helper: GitHubRepositoryHelper,
+) -> str:
+
+    branch_head = repo.rev_parse('refs/remotes/origin/' + repository_branch)
+    if not branch_head:
+        fail('could not determine branch head of {branch} branch'.format(
+            branch=repository_branch
+        ))
+    range_start = _.head(reachable_release_tags_from_commit(helper, repo, branch_head))
+
+    range_end = None
+    try:
+        # better readable range_end by describing head commit
+        range_end = repo.git.describe(branch_head)
+    except GitError:
+        range_end = branch_head.hexsha
+
+    commit_range = "{start}..{end}".format(start=range_start, end=range_end)
+    return commit_range
+
+def release_tags(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo
+) -> list:
+    def is_valid_semver(tag_name):
+        try:
+            parse_version_info(tag_name)
+            return True
+        except ValueError:
+            warning('{tag} is not a valid SemVer string'.format(tag=tag_name))
+            return False
+
+    release_tags = helper.release_tags()
+    # you can remove the directive to disable the undefined-variable error once pylint is updated
+    # with fix https://github.com/PyCQA/pylint/commit/db01112f7e4beadf7cd99c5f9237d580309f0494
+    # included
+    # pylint: disable=undefined-variable
+    tags = _ \
+        .chain(repo.tags) \
+        .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
+        .filter(lambda item: _.find(release_tags, lambda el: el == item['tag'])) \
+        .filter(lambda item: is_valid_semver(item['tag'])) \
+        .key_by('commit') \
+        .map_values('tag') \
+        .value()
+    # pylint: enable=undefined-variable
+    return tags
+
+def reachable_release_tags_from_commit(
+    helper: GitHubRepositoryHelper,
+    repo: git.Repo,
+    commit: git.objects.Commit
+) -> list:
+    tags = release_tags(helper, repo)
+
+    visited = set()
+    queue = list()
+    queue.append(commit)
+    visited.add(commit.hexsha)
+
+    reachable_tags = list()
+
+    while queue:
+        commit = queue.pop(0)
+        if commit.hexsha in tags:
+            reachable_tags.append(tags[commit.hexsha])
+        not_visited_parents = _.filter(commit.parents,
+            lambda parent_commit: not parent_commit.hexsha in visited
+        )
+        if not_visited_parents:
+            queue.extend(not_visited_parents)
+            visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
+
+    reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
+
+    if not reachable_tags:
+        warning('no release tag found, falling back to root commit')
+        root_commits = repo.iter_commits(rev=commit, max_parents=0)
+        root_commit = next(root_commits, None)
+        if not root_commit:
+            fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
+        if next(root_commits, None):
+            fail(
+                'cannot determine range for release notes. Repository has multiple root commits. '
+                'Specify range via commit_range parameter.'
+            )
+        reachable_tags.append(root_commit.hexsha)
+
+    return reachable_tags
+
+
+def fetch_pr_numbers_in_range(
+    repo: git.Repo,
+    commit_range: str
+) -> set:
+    info('git log {range}'.format(range=commit_range))
+    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
+    pr_numbers = set()
+    for commitMessage in gitLogs:
+        if commitMessage.startswith('Merge pull'):
+            pr_number = _.head(re.findall(r"#(\d+|$)", commitMessage))
+            if pr_number:
+                pr_numbers.add(pr_number)
+
+    verbose('Merged pull request numbers in range {range}: {pr_numbers}'.format(
+        range=commit_range,
+        pr_numbers=pr_numbers
+    ))
+    return pr_numbers
+
+def fetch_release_notes_from_prs(
+    helper: GitHubRepositoryHelper,
+    pr_numbers_in_range: set,
+    current_repo:str
+) -> list:
+    # we should consider adding a release-note label to the PRs
+    # to reduce the number of search results
+    prs_iter = helper.search_issues_in_repo('type:pull is:closed')
+
+    release_notes = list()
+    for pr_iter in prs_iter:
+        pr_dict = pr_iter.as_dict()
+
+        pr_number = pr_dict['number']
+        if not str(pr_number) in pr_numbers_in_range:
+            continue
+
+        release_notes_pr = extract_release_notes(
+            pr_number=pr_number,
+            text=pr_dict['body'],
+            user_login=_.get(pr_dict, 'user.login'),
+            current_repo=current_repo
+        )
+        if not release_notes_pr:
+            continue
+
+        release_notes.extend(release_notes_pr)
+    return release_notes
+
+def extract_release_notes(
+    pr_number: int,
+    text: str,
+    user_login: str,
+    current_repo: str
+) -> list:
+    release_notes = list()
+
+    r = re.compile(
+        r"``` *(?P<category>improvement|noteworthy) (?P<target_group>user|operator)"
+        "( (?P<source_repo>\S+/\S+/\S+)(( (?P<reference_type>#|\$)(?P<reference_id>\S+))?"
+        "( @(?P<user>\S+))?)( .*?)?|( .*?)?)\r?\n(?P<text>.*?)\n```",
+        re.MULTILINE | re.DOTALL
+    )
+    for m in r.finditer(text):
+        code_block = m.groupdict()
+
+        text = _.trim(code_block['text'])
+        if not text or 'none' == text.lower():
+            continue
+
+        category = code_block['category']
+        target_group = code_block['target_group']
+        source_repo = code_block['source_repo']
+        if source_repo:
+            reference_is_pr = code_block['reference_type'] == '#'
+            reference_id = code_block['reference_id'] or None
+            user_login = code_block['user'] or None
+        else:
+            source_repo = current_repo
+            reference_is_pr = True
+            reference_id = pr_number
+
+        try:
+            release_notes.append(ReleaseNoteBlock(
+                category_id=category,
+                target_group_id=target_group,
+                text=text,
+                reference_is_pr=reference_is_pr,
+                reference_id=reference_id,
+                user_login=user_login,
+                source_repo=source_repo,
+                is_current_repo=current_repo == source_repo
+            ))
+        except ModelValidationError:
+            warning('skipping invalid origin repository: {source_repo}'.format(
+                source_repo=source_repo
+            ))
+            continue
+    return release_notes
 
 class Renderer(object):
     Node = namedtuple("Node", ["identifier", "title", "nodes", "matches_rn_field"])
@@ -290,195 +500,67 @@ class MarkdownRenderer(Renderer):
                 md_lines.extend(tmp_md_lines)
         return md_lines
 
-def calculate_range(
-    repository_branch: str,
-    repo: git.Repo,
-    helper: GitHubRepositoryHelper,
-) -> str:
+class ReleaseNoteBlock(ReleaseNote):
 
-    branch_head = repo.rev_parse('refs/remotes/origin/' + repository_branch)
-    if not branch_head:
-        fail('could not determine branch head of {branch} branch'.format(
-            branch=repository_branch
-        ))
-    range_start = _.head(reachable_release_tags_from_commit(helper, repo, branch_head))
+    def __new__(
+        cls,
+        category_id: str,
+        target_group_id: str,
+        text: str,
+        reference_is_pr: str,
+        reference_id: str,
+        user_login: str,
+        source_repo: str,
+        is_current_repo: bool
+    ):
+        if reference_id:
+            reference_id=str(reference_id)
 
-    range_end = None
-    try:
-        # better readable range_end by describing head commit
-        range_end = repo.git.describe(branch_head)
-    except GitError:
-        range_end = branch_head.hexsha
-
-    commit_range = "{start}..{end}".format(start=range_start, end=range_end)
-    return commit_range
-
-def release_tags(
-    helper: GitHubRepositoryHelper,
-    repo: git.Repo
-) -> list:
-    def is_valid_semver(tag_name):
-        try:
-            parse_version_info(tag_name)
-            return True
-        except ValueError:
-            warning('{tag} is not a valid SemVer string'.format(tag=tag_name))
-            return False
-
-    release_tags = helper.release_tags()
-    # you can remove the directive to disable the undefined-variable error once pylint is updated
-    # with fix https://github.com/PyCQA/pylint/commit/db01112f7e4beadf7cd99c5f9237d580309f0494
-    # included
-    # pylint: disable=undefined-variable
-    tags = _ \
-        .chain(repo.tags) \
-        .map(lambda tag: {"tag": tag.name, "commit": tag.commit.hexsha}) \
-        .filter(lambda item: _.find(release_tags, lambda el: el == item['tag'])) \
-        .filter(lambda item: is_valid_semver(item['tag'])) \
-        .key_by('commit') \
-        .map_values('tag') \
-        .value()
-    # pylint: enable=undefined-variable
-    return tags
-
-def reachable_release_tags_from_commit(
-    helper: GitHubRepositoryHelper,
-    repo: git.Repo,
-    commit: git.objects.Commit
-) -> list:
-    tags = release_tags(helper, repo)
-
-    visited = set()
-    queue = list()
-    queue.append(commit)
-    visited.add(commit.hexsha)
-
-    reachable_tags = list()
-
-    while queue:
-        commit = queue.pop(0)
-        if commit.hexsha in tags:
-            reachable_tags.append(tags[commit.hexsha])
-        not_visited_parents = _.filter(commit.parents,
-            lambda parent_commit: not parent_commit.hexsha in visited
+        self = super().__new__(
+            cls,
+            category_id,
+            target_group_id,
+            text,
+            reference_is_pr,
+            reference_id,
+            user_login,
+            source_repo,
+            is_current_repo,
+            ComponentName(name=source_repo)
         )
-        if not_visited_parents:
-            queue.extend(not_visited_parents)
-            visited |= set(_.map(not_visited_parents, lambda commit: commit.hexsha))
+        return self
 
-    reachable_tags.sort(key=lambda t: parse_version_info(t), reverse=True)
+    def ref_type(self):
+        if self.reference_is_pr:
+            return '#'
+        else: # commit
+            return '$'
 
-    if not reachable_tags:
-        warning('no release tag found, falling back to root commit')
-        root_commits = repo.iter_commits(rev=commit, max_parents=0)
-        root_commit = next(root_commits, None)
-        if not root_commit:
-            fail('could not determine root commit from rev {rev}'.format(rev=commit.hexsha))
-        if next(root_commits, None):
-            fail(
-                'cannot determine range for release notes. Repository has multiple root commits. '
-                'Specify range via commit_range parameter.'
+    def ref(self):
+        ref = ''
+        if self.reference_id:
+            ref = ' {ref_type}{ref_id}'.format(
+                ref_type=self.ref_type(),
+                ref_id=self.reference_id
             )
-        reachable_tags.append(root_commit.hexsha)
+        return ref
 
-    return reachable_tags
+    def user(self):
+        user = ''
+        if self.user_login:
+            user = ' @{user}'.format(
+                user=self.user_login
+            )
+        return user
 
-
-def fetch_pr_numbers_in_range(
-    repo: git.Repo,
-    commit_range: str
-) -> set:
-    info('git log {range}'.format(range=commit_range))
-    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
-    pr_numbers = set()
-    for commitMessage in gitLogs:
-        if commitMessage.startswith('Merge pull'):
-            pr_number = _.head(re.findall(r"#(\d+|$)", commitMessage))
-            if pr_number:
-                pr_numbers.add(pr_number)
-
-    verbose('Merged pull request numbers in range {range}: {pr_numbers}'.format(
-        range=commit_range,
-        pr_numbers=pr_numbers
-    ))
-    return pr_numbers
-
-def fetch_release_notes_from_prs(
-    helper: GitHubRepositoryHelper,
-    pr_numbers_in_range: set,
-    current_repo:str
-) -> list:
-    # we should consider adding a release-note label to the PRs
-    # to reduce the number of search results
-    prs_iter = helper.search_issues_in_repo('type:pull is:closed')
-
-    release_notes = list()
-    for pr_iter in prs_iter:
-        pr_dict = pr_iter.as_dict()
-
-        pr_number = pr_dict['number']
-        if not str(pr_number) in pr_numbers_in_range:
-            continue
-
-        release_notes_pr = extract_release_notes(
-            pr_number=pr_number,
-            text=pr_dict['body'],
-            user_login=_.get(pr_dict, 'user.login'),
-            current_repo=current_repo
-        )
-        if not release_notes_pr:
-            continue
-
-        release_notes.extend(release_notes_pr)
-    return release_notes
-
-def extract_release_notes(
-    pr_number: int,
-    text: str,
-    user_login: str,
-    current_repo: str
-) -> list:
-    release_notes = list()
-
-    r = re.compile(
-        r"``` *(?P<category>improvement|noteworthy) (?P<target_group>user|operator)"
-        "( (?P<source_repo>\S+/\S+/\S+)(( (?P<reference_type>#|\$)(?P<reference_id>\S+))?"
-        "( @(?P<user>\S+))?)( .*?)?|( .*?)?)\r?\n(?P<text>.*?)\n```",
-        re.MULTILINE | re.DOTALL
-    )
-    for m in r.finditer(text):
-        code_block = m.groupdict()
-
-        text = _.trim(code_block['text'])
-        if not text or 'none' == text.lower():
-            continue
-
-        category = code_block['category']
-        target_group = code_block['target_group']
-        source_repo = code_block['source_repo']
-        if source_repo:
-            reference_is_pr = code_block['reference_type'] == '#'
-            reference_id = code_block['reference_id'] or None
-            user_login = code_block['user'] or None
-        else:
-            source_repo = current_repo
-            reference_is_pr = True
-            reference_id = pr_number
-
-        try:
-            release_notes.append(create_release_note_obj(
-                category_id=category,
-                target_group_id=target_group,
-                text=text,
-                reference_is_pr=reference_is_pr,
-                reference_id=reference_id,
-                user_login=user_login,
-                source_repo=source_repo,
-                is_current_repo=current_repo == source_repo
+    def to_block_str(self):
+        return ('``` {cat} {t_grp} {src_repo}{ref}{user}\n'
+            '{text}\n'
+            '```'.format(
+                cat=self.category_id,
+                t_grp=self.target_group_id,
+                src_repo=self.source_repo,
+                ref=self.ref(),
+                user=self.user(),
+                text=self.text
             ))
-        except ModelValidationError:
-            warning('skipping invalid origin repository: {source_repo}'.format(
-                source_repo=source_repo
-            ))
-            continue
-    return release_notes

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -40,7 +40,7 @@ ReleaseNote = namedtuple('ReleaseNote', [
 def generate_release_notes(
     repo_dir: str,
     helper: GitHubRepositoryHelper,
-    repository_branch: str,
+    repository_branch: str=None,
     commit_range: str=None
 ):
     release_note_objs = _get_rls_note_objs(
@@ -57,7 +57,7 @@ def generate_release_notes(
 def get_release_note_blocks(
     repo_dir: str,
     helper: GitHubRepositoryHelper,
-    repository_branch: str,
+    repository_branch: str=None,
     commit_range: str=None
 ):
     release_note_objs = _get_rls_note_objs(
@@ -86,7 +86,7 @@ def release_note_objs_to_block_str(
 def _get_rls_note_objs(
     repo_dir: str,
     helper: GitHubRepositoryHelper,
-    repository_branch: str,
+    repository_branch: str=None,
     commit_range: str=None
 )->list:
     repo = git.Repo(existing_dir(repo_dir))

--- a/github/util.py
+++ b/github/util.py
@@ -319,12 +319,18 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
 
     def release_versions(self):
         for release in self.repository.releases():
+            if release.draft:
+                continue
             try:
                 yield semver.parse_version_info(release.tag_name)
             except ValueError: pass # ignore
 
     def release_tags(self):
-        return _.map(self.repository.releases(), 'tag_name')
+        return _ \
+            .chain(self.repository.releases()) \
+            .filter(lambda rls: rls.draft == False) \
+            .map('tag_name') \
+            .value()
 
     def search_issues_in_repo(self, query: str):
         query = "repo:{org}/{repo} {query}".format(org=self.owner, repo=self.repository_name, query=query)

--- a/gitutil.py
+++ b/gitutil.py
@@ -36,21 +36,11 @@ class GitHelper(object):
         return [line[3:] for line in lines if line]
 
     def _authenticated_remote(self):
-        base_url = urllib.parse.urlparse(self.github_cfg.http_url())
-        credentials = self.github_cfg.credentials()
-        credentials_str = ':'.join((credentials.username(), credentials.passwd()))
-        push_url = urllib.parse.urlunparse((
-            base_url.scheme,
-            '@'.join((credentials_str, base_url.hostname)),
-            self.github_repo_path,
-            '',
-            '',
-            ''
-        ))
+        url = url_with_credentials(self.github_cfg, self.github_repo_path)
         remote = git.remote.Remote.add(
             repo=self.repo,
             name=random_str(),
-            url=push_url,
+            url=url,
         )
         return remote
 
@@ -82,6 +72,20 @@ class GitHelper(object):
             ))
         )
         self.repo.delete_remote(remote)
+
+def url_with_credentials(github_cfg, github_repo_path):
+    base_url = urllib.parse.urlparse(github_cfg.http_url())
+    credentials = github_cfg.credentials()
+    credentials_str = ':'.join((credentials.username(), credentials.passwd()))
+    url = urllib.parse.urlunparse((
+        base_url.scheme,
+        '@'.join((credentials_str, base_url.hostname)),
+        github_repo_path,
+        '',
+        '',
+        ''
+    ))
+    return url
 
 def update_submodule(
     repo_path: str,

--- a/gitutil.py
+++ b/gitutil.py
@@ -73,6 +73,14 @@ class GitHelper(object):
         )
         self.repo.delete_remote(remote)
 
+def clone_repository(
+        to_path: str,
+        github_cfg,
+        github_repo_path: str
+    ):
+        url = url_with_credentials(github_cfg, github_repo_path)
+        git.Git(to_path).clone(url)
+
 def url_with_credentials(github_cfg, github_repo_path):
     base_url = urllib.parse.urlparse(github_cfg.http_url())
     credentials = github_cfg.credentials()

--- a/product/model.py
+++ b/product/model.py
@@ -138,6 +138,13 @@ class ComponentName(object):
     def github_repo(self):
         return self.name().split('/')[2]
 
+    def github_repo_path(self):
+        return self.github_organisation() + '/' + self.github_repo()
+
+    def config_name(self):
+        return self.github_host().replace('.', '_')
+
+
     def __eq__(self, other):
         if not isinstance(other, ComponentName):
             return False
@@ -165,6 +172,12 @@ class ComponentReference(DependencyBase):
 
     def github_repo(self):
         return self._componentName.github_repo()
+
+    def github_repo_path(self):
+        return self._componentName.github_repo_path()
+
+    def config_name(self):
+        return self._componentName.config_name()
 
     def _validate_dict(self):
         ComponentName.validate_component_name(self.raw.get('name'))

--- a/test/github/release_notes_test.py
+++ b/test/github/release_notes_test.py
@@ -17,9 +17,11 @@ from pydash import _
 
 from github.release_notes import (
     extract_release_notes,
-    create_release_note_obj,
-    MarkdownRenderer
+    ReleaseNoteBlock,
+    MarkdownRenderer,
+    release_note_objs_to_block_str
 )
+from model.base import ModelValidationError
 
 class ReleaseNotesTest(unittest.TestCase):
     def test_rls_note_extraction_improvement(self):
@@ -28,7 +30,7 @@ class ReleaseNotesTest(unittest.TestCase):
             'this is a release note text\n'\
             '```'
         release_notes = extract_release_notes(
-            pr_number=42,
+            pr_number='42',
             text=text,
             user_login='foo',
             current_repo='github.com/gardener/current-repo'
@@ -36,12 +38,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual(1, len(release_notes))
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='this is a release note text',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -52,7 +54,7 @@ class ReleaseNotesTest(unittest.TestCase):
     def test_rls_note_extraction_ignore_noise_in_header(self):
         def verify_noise_ignored(text):
             release_notes = extract_release_notes(
-                pr_number=42,
+                pr_number='42',
                 text=text,
                 user_login='foo',
                 current_repo='github.com/s/repo'
@@ -60,12 +62,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
             self.assertEqual(1, len(release_notes))
             self.assertEqual(
-                create_release_note_obj(
+                ReleaseNoteBlock(
                     category_id='improvement',
                     target_group_id='user',
                     text='rlstext',
                     reference_is_pr=True,
-                    reference_id=42,
+                    reference_id='42',
                     user_login='foo',
                     source_repo='github.com/s/repo',
                     is_current_repo=True
@@ -97,7 +99,7 @@ class ReleaseNotesTest(unittest.TestCase):
             'notew-text\n'\
             '```'
         release_notes = extract_release_notes(
-            pr_number=42,
+            pr_number='42',
             text=text,
             user_login='foo',
             current_repo='github.com/gardener/current-repo'
@@ -105,12 +107,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual(1, len(release_notes))
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='notew-text',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -127,14 +129,14 @@ class ReleaseNotesTest(unittest.TestCase):
             exp_ref_is_pr=True
         ):
             release_notes = extract_release_notes(
-                pr_number=42,
+                pr_number='42',
                 text=code_block,
                 user_login='pr-transport-user',
                 current_repo='github.com/gardener/current-repo'
             )
             self.assertEqual(1, len(release_notes))
             self.assertEqual(
-                create_release_note_obj(
+                ReleaseNoteBlock(
                     category_id='improvement',
                     target_group_id='user',
                     text=exp_text,
@@ -203,7 +205,7 @@ class ReleaseNotesTest(unittest.TestCase):
             'notew-text\n'\
             '```'
         release_notes = extract_release_notes(
-            pr_number=42,
+            pr_number='42',
             text=text,
             user_login='foo',
             current_repo='github.com/gardener/current-repo'
@@ -211,12 +213,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual(3, len(release_notes))
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='imp-user-text',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -224,12 +226,12 @@ class ReleaseNotesTest(unittest.TestCase):
             _.nth(release_notes, 0)
         )
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='operator',
                 text='imp-op-text with carriage return and newline feed',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -237,12 +239,12 @@ class ReleaseNotesTest(unittest.TestCase):
             _.nth(release_notes, 1)
         )
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='notew-text',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -258,7 +260,7 @@ class ReleaseNotesTest(unittest.TestCase):
             'third line\n'\
             '```'
         release_notes = extract_release_notes(
-            pr_number=42,
+            pr_number='42',
             text=text,
             user_login='foo',
             current_repo='github.com/gardener/current-repo'
@@ -266,12 +268,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual(1, len(release_notes))
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='first line\nsecond line\r\nthird line',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -288,7 +290,7 @@ class ReleaseNotesTest(unittest.TestCase):
             '\n'\
             '```'
         release_notes = extract_release_notes(
-            pr_number=42,
+            pr_number='42',
             text=text,
             user_login='foo',
             current_repo='github.com/gardener/current-repo'
@@ -296,12 +298,12 @@ class ReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual(1, len(release_notes))
         self.assertEqual(
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='text with spaces',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -312,7 +314,7 @@ class ReleaseNotesTest(unittest.TestCase):
     def test_rls_note_extraction_no_release_notes(self):
         def verify_no_release_note(text: str):
             release_notes = extract_release_notes(
-                pr_number=42,
+                pr_number='42',
                 text=text,
                 user_login='foo',
                 current_repo='github.com/gardener/current-repo'
@@ -357,12 +359,12 @@ class ReleaseNotesTest(unittest.TestCase):
         'second line\n'\
         'third line\n'
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text=multiline_text,
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
@@ -380,17 +382,17 @@ class ReleaseNotesTest(unittest.TestCase):
 
     def test_markdown_pr(self):
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='rls note 1',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login='foo',
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='other component rls note',
@@ -414,7 +416,7 @@ class ReleaseNotesTest(unittest.TestCase):
 
     def test_markdown_commit(self):
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='rls note 1',
@@ -424,7 +426,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 source_repo='github.com/gardener/current-repo',
                 is_current_repo=True
             ),
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='other component rls note',
@@ -437,7 +439,7 @@ class ReleaseNotesTest(unittest.TestCase):
         ]
         actual_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
 
-        expected_str = \
+        expected_str = ''\
             '# [a-foo-bar]\n'\
             '## Most notable changes\n'\
             '* *[OPERATOR]* other component rls note ([gardener/a-foo-bar@commit-id-2](https://github.com/gardener/a-foo-bar/commit/commit-id-2), [@bar](https://github.com/bar))\n'\
@@ -448,17 +450,17 @@ class ReleaseNotesTest(unittest.TestCase):
 
     def test_markdown_source_repo_user(self):
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='operator',
                 text='no source repo user',
                 reference_is_pr=True,
-                reference_id=42,
+                reference_id='42',
                 user_login=None,
                 source_repo='github.com/s/repo',
                 is_current_repo=False
             ),
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='operator',
                 text='no user',
@@ -481,7 +483,7 @@ class ReleaseNotesTest(unittest.TestCase):
 
     def test_markdown_no_reference(self):
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='no source repo reference',
@@ -491,7 +493,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             ),
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='no reference',
@@ -515,7 +517,7 @@ class ReleaseNotesTest(unittest.TestCase):
 
     def test_markdown_no_reference_no_user(self):
         release_note_objs = [
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='noteworthy',
                 target_group_id='operator',
                 text='no source repo reference no user',
@@ -525,7 +527,7 @@ class ReleaseNotesTest(unittest.TestCase):
                 source_repo='github.com/gardener/a-foo-bar',
                 is_current_repo=False
             ),
-            create_release_note_obj(
+            ReleaseNoteBlock(
                 category_id='improvement',
                 target_group_id='user',
                 text='no reference no user',
@@ -552,3 +554,145 @@ class ReleaseNotesTest(unittest.TestCase):
 
         expected_str = 'no release notes available'
         self.assertEqual(expected_str, MarkdownRenderer(release_note_objs=release_note_objs).render())
+
+    def test_rls_note_obj_to_block_str(self):
+        try:
+            rn_block = ReleaseNoteBlock(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='no source repo, no reference, no user',
+                reference_is_pr=False,
+                reference_id='commit-id',
+                user_login='foo',
+                source_repo=None,
+                is_current_repo=False
+            )
+            self.fail('a ReleaseNoteBlock always has a source repository, even if it points to the "current" repository')
+        except RuntimeError:
+            pass
+
+
+        rn_block = ReleaseNoteBlock(
+            category_id='noteworthy',
+            target_group_id='operator',
+            text='no reference, no user',
+            reference_is_pr=False,
+            reference_id=None,
+            user_login=None,
+            source_repo='github.com/gardener/a-foo-bar',
+            is_current_repo=False
+        )
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar\n'\
+        'no reference, no user'\
+        '\n```'
+        self.assertEqual(expected, rn_block.to_block_str())
+
+        rn_block = ReleaseNoteBlock(
+            category_id='noteworthy',
+            target_group_id='operator',
+            text='no reference',
+            reference_is_pr=False,
+            reference_id=None,
+            user_login='foo',
+            source_repo='github.com/gardener/a-foo-bar',
+            is_current_repo=False
+        )
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar @foo\n'\
+        'no reference'\
+        '\n```'
+        self.assertEqual(expected, rn_block.to_block_str())
+
+        rn_block = ReleaseNoteBlock(
+            category_id='noteworthy',
+            target_group_id='operator',
+            text='no user; reference is PR',
+            reference_is_pr=True,
+            reference_id='42',
+            user_login=None,
+            source_repo='github.com/gardener/a-foo-bar',
+            is_current_repo=False
+        )
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar #42\n'\
+        'no user; reference is PR'\
+        '\n```'
+        self.assertEqual(expected, rn_block.to_block_str())
+
+        rn_block = ReleaseNoteBlock(
+            category_id='noteworthy',
+            target_group_id='operator',
+            text='reference is commit',
+            reference_is_pr=False,
+            reference_id='commit-id',
+            user_login='foo',
+            source_repo='github.com/gardener/a-foo-bar',
+            is_current_repo=False
+        )
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar $commit-id @foo\n'\
+        'reference is commit'\
+        '\n```'
+        self.assertEqual(expected, rn_block.to_block_str())
+
+    def test_release_note_objs_to_block_str(self):
+        rn_objs = []
+        expected = ''
+        self.assertEqual(expected, release_note_objs_to_block_str(rn_objs))
+
+        rn_objs = None
+        expected = ''
+        self.assertEqual(expected, release_note_objs_to_block_str(rn_objs))
+
+        rn_objs = [
+            ReleaseNoteBlock(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='test with one release note object',
+                reference_is_pr=False,
+                reference_id='commit-id',
+                user_login='foo',
+                source_repo='github.com/gardener/a-foo-bar',
+                is_current_repo=False
+            )
+        ]
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar $commit-id @foo\n'\
+        'test with one release note object'\
+        '\n```'
+        self.assertEqual(expected, release_note_objs_to_block_str(rn_objs))
+
+        rn_objs = [
+            ReleaseNoteBlock(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='test with multiple release note objects',
+                reference_is_pr=False,
+                reference_id='commit-id',
+                user_login='foo',
+                source_repo='github.com/gardener/a-foo-bar',
+                is_current_repo=True
+            ),
+            ReleaseNoteBlock(
+                category_id='noteworthy',
+                target_group_id='operator',
+                text='another one',
+                reference_is_pr=False,
+                reference_id='commit-id',
+                user_login='foo',
+                source_repo='github.com/s/repo',
+                is_current_repo=False
+            ),
+        ]
+        expected = \
+        '``` noteworthy operator github.com/gardener/a-foo-bar $commit-id @foo\n'\
+        'test with multiple release note objects'\
+        '\n```'\
+        '\n'\
+        '\n'\
+        '``` noteworthy operator github.com/s/repo $commit-id @foo\n'\
+        'another one'\
+        '\n```'
+        self.assertEqual(expected, release_note_objs_to_block_str(rn_objs))
+

--- a/test/product/product_model_test.py
+++ b/test/product/product_model_test.py
@@ -229,6 +229,8 @@ class ComponentNameModelTest(unittest.TestCase):
             self.assertEqual(result.github_repo(), 'bar_name')
             self.assertEqual(result.github_organisation(), 'foo_org')
             self.assertEqual(result.github_host(), 'github.xxx')
+            self.assertEqual(result.github_repo_path(), 'foo_org/bar_name')
+            self.assertEqual(result.config_name(), 'github_xxx')
 
 
 class DependenciesModelTest(unittest.TestCase, AssertMixin):


### PR DESCRIPTION
added ability to generate release notes as code block gathered from pull requests in range (called from update_component_deps.mako pipeline step when creating new PR)
plus minor refactorings