### PR TITLE
Allow configuring of a list of replacement labels for PRs

### DIFF
--- a/concourse/pipelines/model/traits/pullrequest.py
+++ b/concourse/pipelines/model/traits/pullrequest.py
@@ -21,13 +21,20 @@ class PullRequestPolicies(ModelBase):
     def require_label(self):
         return self.raw.get('require-label')
 
+    def replacement_labels(self):
+        return self.raw.get('replacement-labels')
+
 
 class PullRequestTrait(Trait):
 
     def policies(self):
         policies_dict = self.raw.get('policies')
         if not policies_dict:
-            policies_dict = {'require-label': 'reviewed/ok-to-test'}
+            policies_dict = {
+                'require-label': 'reviewed/ok-to-test',
+                'replacement-labels': ['needs/ok-to-test'],
+            }
+
 
         return PullRequestPolicies(raw_dict=policies_dict)
 


### PR DESCRIPTION
These labels will (if configured) be set on the pull-request once the 'required labels' are removed.
- If the specified labels do not already exist, they are created
- if the specified labels are already added to the pull-request, they will remain