### PR TITLE
Remove hard-coded access to template

### DIFF
--- a/concourse/pipelines/enumerator.py
+++ b/concourse/pipelines/enumerator.py
@@ -296,6 +296,23 @@ class DefinitionDescriptor(object):
             t=self.concourse_target_team
         )
 
+    def effective_descriptor(self) -> 'DefinitionDescriptor':
+        '''Return the DefinitionDescriptor resulting from the application of all override_definitions
+        '''
+        effective_definition = self.pipeline_definition
+        for override in self.override_definitions:
+            effective_definition = merge_dicts(effective_definition, override)
+
+        # TODO: Currently, the main-repository is passed along. However, the merging of the effective definition might
+        # have actually changed that in various ways.
+        return DefinitionDescriptor(
+                pipeline_name=self.pipeline_name,
+                pipeline_definition=effective_definition,
+                main_repo=self.main_repo,
+                concourse_target_cfg=self.concourse_target_cfg,
+                concourse_target_team=self.concourse_target_team,
+            )
+
 
 class TemplateRetriever(object):
     '''

--- a/concourse/pipelines/enumerator.py
+++ b/concourse/pipelines/enumerator.py
@@ -78,7 +78,6 @@ class DefinitionEnumerator(object):
             yield DefinitionDescriptor(
                 pipeline_name=name,
                 pipeline_definition=pipeline_definition,
-                template_name=pipeline_definition['template'],
                 main_repo={'path': repo_path, 'branch': branch, 'hostname': repo_hostname},
                 concourse_target_cfg=self.cfg_set.concourse(),
                 concourse_target_team=self.job_mapping.team_name(),
@@ -273,7 +272,6 @@ class DefinitionDescriptor(object):
         self,
         pipeline_name,
         pipeline_definition,
-        template_name,
         main_repo,
         concourse_target_cfg,
         concourse_target_team,
@@ -281,11 +279,13 @@ class DefinitionDescriptor(object):
     ):
         self.pipeline_name = not_empty(pipeline_name)
         self.pipeline_definition = not_none(pipeline_definition)
-        self.template_name = not_empty(template_name)
         self.main_repo = not_none(main_repo)
         self.concourse_target_cfg = not_none(concourse_target_cfg)
         self.concourse_target_team = not_none(concourse_target_team)
         self.override_definitions = not_none(override_definitions)
+
+    def template_name(self):
+        return self.pipeline_definition.get('template', 'default')
 
     def concourse_target(self):
         return (self.concourse_target_cfg, self.concourse_target_team)

--- a/concourse/pipelines/replicator.py
+++ b/concourse/pipelines/replicator.py
@@ -166,7 +166,7 @@ class Renderer(object):
         for override in definition_descriptor.override_definitions:
             effective_definition = merge_dicts(effective_definition, override)
 
-        template_name = definition_descriptor.template_name
+        template_name = definition_descriptor.template_name()
         template_contents = self.template_retriever.template_contents(template_name)
 
         pipeline_definition = RawPipelineDefinitionDescriptor(

--- a/concourse/pipelines/replicator.py
+++ b/concourse/pipelines/replicator.py
@@ -160,17 +160,16 @@ class Renderer(object):
             )
 
     def _render(self, definition_descriptor):
-        effective_definition = definition_descriptor.pipeline_definition
 
         # handle inheritance
-        for override in definition_descriptor.override_definitions:
-            effective_definition = merge_dicts(effective_definition, override)
+        effective_descriptor = definition_descriptor.effective_descriptor()
+        effective_definition = effective_descriptor.pipeline_definition
 
-        template_name = definition_descriptor.template_name()
+        template_name = effective_descriptor.template_name()
         template_contents = self.template_retriever.template_contents(template_name)
 
         pipeline_definition = RawPipelineDefinitionDescriptor(
-            name=definition_descriptor.pipeline_name,
+            name=effective_descriptor.pipeline_name,
             base_definition=effective_definition.get('base_definition', {}),
             variants=effective_definition.get('variants', {}),
             template=template_name,
@@ -180,7 +179,7 @@ class Renderer(object):
         pipeline_metadata = dict()
         pipeline_metadata['definition'] = factory.create_pipeline_definition()
         pipeline_metadata['name'] = pipeline_definition.name
-        pipeline_metadata['target_team'] = definition_descriptor.concourse_target_team
+        pipeline_metadata['target_team'] = effective_descriptor.concourse_target_team
         generated_model = pipeline_metadata.get('definition')
 
         # determine pipeline name (if there is main-repo, append the configured branch name)

--- a/integrationtest.py
+++ b/integrationtest.py
@@ -69,7 +69,6 @@ def deploy_and_run_smoketest_pipeline(
     definition_descriptor = DefinitionDescriptor(
         pipeline_name=pipeline_name,
         pipeline_definition=pipeline_definition[pipeline_name],
-        template_name=pipeline_definition[pipeline_name]['template'],
         main_repo={'path': 'kubernetes/cc-smoketest', 'branch': 'master'},
         concourse_target_cfg=concourse_cfg,
         concourse_target_team=concourse_team_name,


### PR DESCRIPTION
Removes the hard-coded access to the template-name for rendered pipelines. The rendered pipelines will now use the template as specified by their fully merged definition, or 'default' as default if none is set.

Do not merge, a final exhaustive test-run is still to be performed