### PR TITLE
Support release notes in commit message

### DIFF
--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -100,7 +100,7 @@ def _get_rls_note_objs(
     info('Fetching release notes from revision range: {range}'.format(
         range=commit_range
     ))
-    pr_numbers = fetch_pr_numbers_in_range(repo, commit_range)
+    pr_numbers = fetch_pr_numbers_in_range(repo, commit_range, repository_branch)
     release_note_objs = fetch_release_notes_from_prs(helper, pr_numbers, current_repo_name)
     return release_note_objs
 
@@ -200,9 +200,15 @@ def reachable_release_tags_from_commit(
 
 def fetch_pr_numbers_in_range(
     repo: git.Repo,
-    commit_range: str
+    commit_range: str,
+    repository_branch: str=None
 ) -> set:
-    gitLogs = repo.git.log(commit_range, pretty='%s').splitlines()
+    args = [commit_range]
+    if repository_branch:
+        args.append(repository_branch)
+    kwargs = {'pretty': '%s'}
+
+    gitLogs = repo.git.log(*args, **kwargs).splitlines()
     pr_numbers = set()
     for commit_message in gitLogs:
         pr_number = pr_number_from_message(commit_message)

--- a/github/release_notes.py
+++ b/github/release_notes.py
@@ -402,8 +402,8 @@ class MarkdownRenderer(Renderer):
             if rn_obj.reference_id:
                 if rn_obj.reference_is_pr:
                     reference_prefix = '#'
-                    reference_link = 'https://{source_repo}/pull/{ref_id}'.format(
-                        source_repo=rn_obj.cn_source_repo.name(),
+                    reference_link = '{source_repo_url}/pull/{ref_id}'.format(
+                        source_repo_url=rn_obj.cn_source_repo.github_repo_url(),
                         ref_id=rn_obj.reference_id
                     )
                 else: # commit
@@ -413,8 +413,8 @@ class MarkdownRenderer(Renderer):
                         # for the current repo we use gitHub's feature to auto-link to references,
                         # hence in case of commits we don't need a prefix
                         reference_prefix = ''
-                    reference_link = 'https://{source_repo}/commit/{ref_id}'.format(
-                        source_repo=rn_obj.cn_source_repo.name(),
+                    reference_link = '{source_repo_url}/commit/{ref_id}'.format(
+                        source_repo_url=rn_obj.cn_source_repo.github_repo_url(),
                         ref_id=rn_obj.reference_id
                 )
 
@@ -447,9 +447,9 @@ class MarkdownRenderer(Renderer):
                         u=rn_obj.user_login
                     ))
                 else:
-                    header_suffix_list.append('[@{u}](https://{github_host}/{u})'.format(
+                    header_suffix_list.append('[@{u}]({github_url}/{u})'.format(
                         u=rn_obj.user_login,
-                        github_host=cn.github_host()
+                        github_url=cn.github_url()
                     ))
             header_suffix = ' ({s})'.format(
                 s=', '.join(header_suffix_list)

--- a/product/model.py
+++ b/product/model.py
@@ -142,6 +142,13 @@ class ComponentName(object):
     def config_name(self):
         return self.github_host().replace('.', '_')
 
+    def github_url(self):
+        # hard-code schema to https
+        return 'https://' + self.github_host()
+
+    def github_repo_url(self):
+        # hard-code schema to https
+        return 'https://' + self.name()
 
     def __eq__(self, other):
         if not isinstance(other, ComponentName):


### PR DESCRIPTION
it is now possible to add release note texts within the commit message, as alternative to specifying the release notes within a pull request (same format). 

However, specifying the release notes within a pull request should be preferred as the release note text can be altered easily before the release.