### PR TITLE
Add draft_release trait

### DIFF
--- a/concourse/pipelines/model/traits/__init__.py
+++ b/concourse/pipelines/model/traits/__init__.py
@@ -24,6 +24,7 @@ from .release import ReleaseTrait
 from .scheduling import SchedulingTrait
 from .version import VersionTrait
 from .options import OptionsTrait
+from .draft_release import DraftReleaseTrait
 from .update_component_deps import UpdateComponentDependenciesTrait
 
 TRAITS = {
@@ -36,6 +37,7 @@ TRAITS = {
     'publish': PublishTrait,
     'options': OptionsTrait,
     'update_component_deps': UpdateComponentDependenciesTrait,
+    'draft_release': DraftReleaseTrait,
 }
 
 class TraitsFactory(object):

--- a/concourse/pipelines/model/traits/draft_release.py
+++ b/concourse/pipelines/model/traits/draft_release.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from util import not_none
+
+from concourse.pipelines.model.step import PipelineStep
+from concourse.pipelines.modelbase import (
+  Trait,
+  TraitTransformer
+)
+
+
+class DraftReleaseTrait(Trait):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def transformer(self):
+        return DraftReleaseTraitTransformer(name=self.name)
+
+
+class DraftReleaseTraitTransformer(TraitTransformer):
+    def inject_steps(self):
+        # inject 'release' step
+        self.release_step = PipelineStep(name='create draft-release-notes', raw_dict={}, is_synthetic=True)
+        yield self.release_step
+
+    def process_pipeline_args(self, pipeline_args: 'JobVariant'):
+        pass
+
+    def dependencies(self):
+        return super().dependencies() | {'version'}
+


### PR DESCRIPTION
Adds the `draft_release` trait. This trait can be used to tag variants that should create or update draft-release-notes.