### PR TITLE
use ingress_host instead of external_url

### DIFF
--- a/concourse/setup.py
+++ b/concourse/setup.py
@@ -20,7 +20,7 @@ import time
 
 from ensure import ensure_annotations
 from textwrap import dedent
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 from subprocess import CalledProcessError
 
 import yaml
@@ -478,8 +478,11 @@ def set_teams(config: ConcourseConfig):
     # Use main-team, i.e. the team that can change the other teams' credentials
     main_team_credentials = config.main_team_credentials()
 
+    # use ingress_host instead of external_url which points to a possibly not yet switched CNAME
+    base_url = urlunparse(('https', config.ingress_host(), '', '', '', ''))
+
     concourse_api = client.ConcourseApi(
-        base_url=config.external_url(),
+        base_url=base_url,
         team_name=main_team_credentials.teamname(),
     )
     concourse_api.login(


### PR DESCRIPTION
When executing 'set_teams' after the installation on the passive K8s cluster,
the external_url usually points to the CNAME record, which is not yet switched.
This results in setting the teams on the active cluster (which is wrong)
So we need to use the ingress_url instead