### PR TITLE
force link generation for slack markdown text

### DIFF
--- a/github/release_notes/renderer.py
+++ b/github/release_notes/renderer.py
@@ -265,6 +265,14 @@ class Renderer(object):
 
 
 class MarkdownRenderer(Renderer):
+    def __init__(
+        self,
+        release_note_objs: [ReleaseNote],
+        force_link_generation:bool=False
+    ):
+        super().__init__(release_note_objs)
+        self.force_link_generation = force_link_generation
+
     def _title(
         self,
         node: Node,
@@ -273,7 +281,7 @@ class MarkdownRenderer(Renderer):
         return '{hashtags} {title}'.format(hashtags=_.repeat('#', level),title=node.title)
 
     def _generate_link(self, rls_note_obj: ReleaseNote)->bool:
-        return not rls_note_obj.from_same_github_instance
+        return self.force_link_generation or not rls_note_obj.from_same_github_instance
 
     def _build_bullet_point_head(
         self,


### PR DESCRIPTION
slack can't auto link pull requests, commits or users hence we need to force the link generation when building the markdown string

![screen shot 2018-09-12 at 15 24 54](https://user-images.githubusercontent.com/5526658/45427878-4b59d080-b6a0-11e8-8540-30e5f348fa11.png)
