### PR TITLE
add action required category for release notes

### DIFF
--- a/github/release_notes/renderer.py
+++ b/github/release_notes/renderer.py
@@ -44,6 +44,13 @@ TARGET_GROUP_OPERATOR = TitleNode(
 )
 TARGET_GROUPS = [TARGET_GROUP_USER, TARGET_GROUP_OPERATOR]
 
+CATEGORY_ACTION_ID = 'action'
+CATEGORY_ACTION = TitleNode(
+    identifier=CATEGORY_ACTION_ID,
+    title='Action Required',
+    nodes=TARGET_GROUPS,
+    matches_rls_note_field_path='category_id'
+)
 CATEGORY_NOTEWORTHY_ID = 'noteworthy'
 CATEGORY_NOTEWORTHY = TitleNode(
     identifier=CATEGORY_NOTEWORTHY_ID,
@@ -58,7 +65,7 @@ CATEGORY_IMPROVEMENT = TitleNode(
     nodes=TARGET_GROUPS,
     matches_rls_note_field_path='category_id'
 )
-CATEGORIES = [CATEGORY_NOTEWORTHY, CATEGORY_IMPROVEMENT]
+CATEGORIES = [CATEGORY_ACTION, CATEGORY_NOTEWORTHY, CATEGORY_IMPROVEMENT]
 
 
 class Renderer(object):

--- a/test/github/release_notes/renderer_test.py
+++ b/test/github/release_notes/renderer_test.py
@@ -24,6 +24,7 @@ from github.release_notes.model import (
 from github.release_notes.renderer import (
     MarkdownRenderer,
     get_or_call,
+    CATEGORY_ACTION_ID,
     CATEGORY_NOTEWORTHY_ID,
     CATEGORY_IMPROVEMENT_ID,
     TARGET_GROUP_USER_ID,
@@ -293,11 +294,20 @@ class RendererTest(unittest.TestCase):
                 reference_id=None,
                 user_login=None,
             ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_ACTION_ID,
+                text='action required release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
         ]
 
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
+            '## Action Required\n'\
+            '* *[USER]* action required release note\n'\
             '## Most notable changes\n'\
             '* *[USER]* noteworthy release note\n'\
             '## Improvements\n'\


### PR DESCRIPTION
per suggestion by @rfranzke I added another category called `action` that maps to the title "Action Required"