### PR TITLE
Add Concourse version handling

### DIFF
--- a/cli/concourseutil.py
+++ b/cli/concourseutil.py
@@ -308,14 +308,10 @@ def trigger_resource_check(
     cfg_set = cfg_factory.cfg_set(cfg_name)
     concourse_cfg = cfg_set.concourse()
     team_credentials = concourse_cfg.team_credentials(team_name)
-    api = client.ConcourseApi(
-        base_url=concourse_cfg.external_url(),
-        team_name=team_credentials.teamname(),
-    )
-    api.login(
-        team_credentials.teamname(),
-        team_credentials.username(),
-        team_credentials.passwd(),
+
+    api = client.from_cfg(
+        concourse_cfg=concourse_cfg,
+        team_name=team_credentials.teamname()
     )
     api.trigger_resource_check(
         pipeline_name=pipeline_name,

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -241,17 +241,10 @@ class FilesystemDeployer(DefinitionDeployer):
 
 @functools.lru_cache()
 def _concourse_api(concourse_cfg, team_name: str):
-    team_credentials = concourse_cfg.team_credentials(team_name)
-    api = client.ConcourseApi(
-        base_url=concourse_cfg.ingress_url(),
-        team_name=team_credentials.teamname(),
+    return client.from_cfg(
+        concourse_cfg=concourse_cfg,
+        team_name=team_name,
     )
-    api.login(
-        team_credentials.teamname(),
-        team_credentials.username(),
-        team_credentials.passwd(),
-    )
-    return api
 
 
 class ConcourseDeployer(DefinitionDeployer):

--- a/http_requests.py
+++ b/http_requests.py
@@ -106,7 +106,8 @@ class AuthenticatedRequestBuilder(object):
             headers.update(kwargs['headers'])
             del kwargs['headers']
         if 'data' in kwargs:
-            headers['content-type'] = 'application/x-yaml'
+            if not 'content-type' in headers:
+                headers['content-type'] = 'application/x-yaml'
 
         result = method(
             url,


### PR DESCRIPTION
Add concourse version to ConcourseApi object to distinguish API access to different concourse versions.

Corresponds to https://github.wdf.sap.corp/kubernetes/cc-config/commit/c8f5781eef93a499dce2b8092305634910d4c29f
 