### PR TITLE
Enhance parsing of reST in tables

### DIFF
--- a/doc/lib/sphinxutil.py
+++ b/doc/lib/sphinxutil.py
@@ -111,14 +111,15 @@ class TableBuilder(object):
         # type: (unicode) -> None
         row = nodes.row('')
         source, line = self.state_machine.get_source_and_line()
-        for text in column_texts:
+        for text_line in column_texts:
             node = nodes.paragraph('')
             vl = ViewList()
-            vl.append(text, '%s:%d' % (source, line))
+            for text in text_line.split('\n'):
+                vl.append(text, '%s:%d' % (source, line))
             with switch_source_input(self.state, vl):
                 self.state.nested_parse(vl, 0, node)
                 try:
-                    if isinstance(node[0], nodes.paragraph):
+                    if isinstance(node[0], nodes.paragraph) and len(node.children) == 1:
                         node = node[0]
                 except IndexError:
                     pass


### PR DESCRIPTION
The way restructuredtext was parsed in table-cells is taken almost verbatim from the implementation provided by Sphinx's `autosummary` directive. As this directive aims to put short summaries (one line) into the cells, it's parsing was presumably not intended to be used with larger restructuredtext blocks.

This PR changes the construction of the ViewList required for parsing to be line by line. Thus, it enables usage of directives and other multi-line constructs.

Note: This also means that indentation and initial newlines of python multi-line-strings are taken into account.