### PR TITLE
include updated defaults.mako in built images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ ENV PATH /cc/utils/:/cc/utils/bin:$PATH
 ENV PYTHONPATH /cc/utils
 
 RUN pip3 install -r /cc/utils/requirements.txt
+
+RUN EFFECTIVE_VERSION="$(cat /metadata/VERSION)" REPO_DIR=/cc/utils /cc/utils/.ci/bump_job_image_version.py


### PR DESCRIPTION
Introduces a prepare-step in the docker built which executes the same script the release-hook uses to bump our defaults.mako.