### PR TITLE
Refactor notification.mako

### DIFF
--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -11,9 +11,10 @@
 >
 <%
 from makoutil import indent_func
+from concourse.steps import step_lib
 # xxx: for now, assume all repositories are from same github
 default_github_cfg_name = cfg_set.github().name()
-email_cfg = cfg_set.email()
+cc_email_cfg = cfg_set.email()
 
 notification_cfg = job_step.notifications_cfg()
 notification_cfg_name = notification_cfg.name()
@@ -30,225 +31,130 @@ import sys
 import os
 import traceback
 
+import github
 import util
 import mailutil
+
 
 from util import ctx
 cfg_factory = ctx().cfg_factory()
 cfg_set = cfg_factory.cfg_set("${cfg_set.name()}")
 
-${notification_step_lib()}
+${step_lib('notification')}
 
-v = meta_vars()
-concourse_api = from_cfg(cfg_set.concourse(), team_name=v['build-team-name'])
+meta_vars_dict = meta_vars()
+concourse_api = from_cfg(cfg_set.concourse(), team_name=meta_vars_dict['build-team-name'])
+## TODO: Replace with MAIN_REPO_DIR once it is available in synthetic steps
+path_to_main_repository = "${job_variant.main_repository().resource_name()}"
 
-
-print('Notification cfg: ${notification_cfg_name}')
-print('Triggering policy: ${triggering_policy}')
-print("Will notify: ${on_error_cfg.recipients()}")
+util.info('Notification cfg: ${notification_cfg_name}')
+util.info('Triggering policy: ${triggering_policy}')
+util.info("Will notify: ${on_error_cfg.recipients()}")
 
 if not should_notify(
     NotificationTriggeringPolicy('${triggering_policy.value}'),
-    meta_vars=v,
+    meta_vars=meta_vars_dict,
 ):
     print('will not notify due to policy')
     sys.exit(0)
 
-
-def retrieve_build_log(concourse_api):
-    try:
-      build_id = v['build-id']
-      task_id = concourse_api.build_plan(build_id=build_id).task_id(task_name='${job_step.name}')
-      build_events = concourse_api.build_events(build_id=build_id)
-      build_log = '\n'.join(build_events.iter_buildlog(task_id=task_id))
-      return build_log
-    except Exception as e:
-      traceback.print_exc() # print_err, but send email notification anyway
-      return 'failed to retrieve build log'
-
-
+## prepare notification config.
 notify_file = os.path.join('${on_error_dir}', 'notify.cfg')
 email_cfg = {
   'recipients': set(),
-  'component_name_recipients': set(),
-  'codeowners_files': set(),
+  'component_names': set(),
   'mail_body': None,
+  'codeowners_files': set(),
 }
 if os.path.isfile(notify_file):
-  notify_cfg = util.parse_yaml_file(notify_file)
-  email_cfg.update(notify_cfg.get('email', dict()))
-  util.info('found notify.cfg - applying cfg:')
-  print(notify_cfg)
+## custom notification config found in error dir
+    notify_cfg = util.parse_yaml_file(notify_file)
+    email_cfg.update(notify_cfg.get('email', dict()))
+    ## Convert elements of notify config to sets
+    email_cfg['component_names'] = set(email_cfg.get('component_names', set()))
+    email_cfg['recipients'] = set(email_cfg.get('recipients', set()))
+    email_cfg['codeowner_files'] = set(email_cfg.get('codeowner_files', set()))
+    util.info(f'found notify.cfg - applying cfg: \n{notify_cfg}')
+
 notify_cfg = {'email': email_cfg}
 
+main_repo_github_cfg = cfg_set.github("${job_variant.main_repository().cfg_name() or default_github_cfg_name}")
+main_repo_github_api = github.util._create_github_api_object(main_repo_github_cfg)
+
 if 'component_diff_owners' in ${on_error_cfg.recipients()}:
-  util.info('adding mail recipients from component diff since last release')
-  component_diff_path = os.path.join('component_descriptor_dir', 'dependencies.diff')
-  if not os.path.isfile(component_diff_path):
-    util.info('no component_diff found at: ' + str(component_diff_path))
-  else:
-    cdiff = util.parse_yaml_file(component_diff_path)
-    comp_names = cdiff.get('component_names_with_version_changes', set())
-    existing_comp_names = set(email_cfg['component_name_recipients'])
-    email_cfg['component_name_recipients'] = existing_comp_names | set(comp_names)
+    component_diff_path = os.path.join('component_descriptor_dir', 'dependencies.diff')
+    util.info('adding mail recipients from component diff since last release')
+    components = components_with_version_changes(component_diff_path)
+    ## Recipient-address resolution from component names will be done at a later point
+    email_cfg['component_names'] = email_cfg.get('component_names', set()) | set(components)
 
-% if component_name:
 if 'codeowners' in ${on_error_cfg.recipients()}:
-  util.info('adding codeowners from main repository as recipients')
-  email_cfg['component_name_recipients'] = set(email_cfg['component_name_recipients'])
-  email_cfg['component_name_recipients'].add('${component_name}')
-% endif
+    ## Add codeowners from main repository to recipients
+    util.info('adding codeowners from main repository as recipients')
+    recipients = set(
+        mailutil.determine_local_repository_codeowners_recipients(
+            github_api=main_repo_github_api,
+            src_dirs=(path_to_main_repository,),
+            )
+        )
+    email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
 
-% if 'email_addresses' in on_error_cfg.recipients():
-util.info('adding excplicitly configured recipients')
-addresses = set(${on_error_cfg.recipients()['email_addresses']})
-existing_recipients = set(email_cfg.get('recipients', {}))
-email_cfg['recipients'] = existing_recipients | addresses
-% endif
+## Also consider explicitly given CODEOWNERS files
+if email_cfg['codeowners_files']:
+    util.info("adding codeowners from explicitly configured 'CODEOWNERS' files")
+    recipients = set(
+        mailutil.determine_codeowner_file_recipients(
+            github_api=main_repo_github_api,
+            codeowners_files=email_cfg['codeowners_files'],
+        )
+    )
+    email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
+
+if 'email_addresses' in ${on_error_cfg.recipients()}:
+    util.info('adding excplicitly configured recipients')
+    recipients = set(${on_error_cfg.recipients().get('email_addresses',())})
+    email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
+
+if 'committers' in ${on_error_cfg.recipients()}:
+    util.info('adding committers of main repository to recipients')
+    recipients = set(mailutil.determine_head_commit_recipients(
+            src_dirs=(path_to_main_repository,),
+        ))
+    email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
 
 def default_mail_recipients():
-  recipients = set()
+    recipients = set()
 % for repo_cfg in repo_cfgs:
-  recipients.update(mailutil.determine_mail_recipients(
-    github_cfg_name="${repo_cfg.cfg_name() if repo_cfg.cfg_name() else default_github_cfg_name}",
-    src_dirs=("${repo_cfg.resource_name()}",),
-    )
-  )
-  return recipients
+## Get default (i.e. committer of head commit and codeowners) from local repositories
+    recipients.update(mailutil.determine_mail_recipients(
+        github_cfg_name="${repo_cfg.cfg_name() or default_github_cfg_name}",
+        src_dirs=("${repo_cfg.resource_name()}",),
+    ))
+    return recipients
 % endfor
 
-def retrieve_component_name_recipients(email_cfg):
-    component_names = email_cfg.get('component_name_recipients', ())
-    codeowners_files = email_cfg.get('codeowners_files', ())
-
-    component_recipients = mailutil.determine_mail_recipients(
-        github_cfg_name="${default_github_cfg_name}", # todo: actually this is not required here
-        component_names=component_names,
-        codeowners_files=codeowners_files,
-    )
-    recipients = set(email_cfg.get('recipients', set()))
-    recipients.update(component_recipients)
-    email_cfg['recipients'] = recipients
-
-
-# fill notify_cfg with default values if not configured
+## Fill notify_cfg with default values if none configured
 if not email_cfg.get('recipients'):
-  email_cfg['recipients'] = default_mail_recipients()
+    email_cfg['recipients'] = default_mail_recipients()
 if not email_cfg.get('mail_body'):
-  email_cfg['mail_body'] = retrieve_build_log(concourse_api=concourse_api)
-retrieve_component_name_recipients(email_cfg)
-
-
-# determine mail recipients
-email_cfg_name = "${email_cfg.name()}"
-mailutil.notify(
-  subject="${subject}",
-  body='\n'.join((job_url(v), email_cfg['mail_body'])),
-  email_cfg_name=email_cfg_name,
-  recipients=email_cfg['recipients'],
-)
-</%def>
-
-<%def name="notification_step_lib()">
-from concourse.model.traits.notifications import NotificationTriggeringPolicy
-from concourse.client import from_cfg
-from concourse.client.model import BuildStatus
-
-def meta_vars():
-    v = {}
-    for name in (
-      'build-id',
-      'build-name',
-      'build-job-name',
-      'build-team-name',
-      'build-pipeline-name',
-      'atc-external-url'
-    ):
-      with open(os.path.join('meta', name)) as f:
-        v[name] = f.read().strip()
-
-    return v
-
-def job_url(v):
-    return '/'.join([
-      v['atc-external-url'],
-      'teams',
-      v['build-team-name'],
-      'pipelines',
-      v['build-pipeline-name'],
-      'jobs',
-      v['build-job-name'],
-      'builds',
-      v['build-name']
-    ])
-
-def determine_previous_build_status(v):
-    concourse_api = from_cfg(cfg_set.concourse(), team_name=v['build-team-name'])
-    try:
-      build_number = int(v['build-name'])
-      if build_number < 2:
-        util.info('this seems to be the first build - will notify')
-        return BuildStatus.SUCCEEDED
-
-      previous_build = str(build_number - 1)
-      previous_build = concourse_api.job_build(
-        pipeline_name=v['build-pipeline-name'],
-        job_name=v['build-job-name'],
-        build_name=previous_build
-      )
-      return previous_build.status()
-    except Exception as e:
-      if type(e) == SystemExit:
-        raise e
-      # in doubt, ensure notification is sent
-      traceback.print_exc()
-      return None
-
-def should_notify(
-    triggering_policy,
-    meta_vars,
-    determine_previous_build_status=determine_previous_build_status,
-):
-    if triggering_policy == NotificationTriggeringPolicy.ALWAYS:
-        return True
-    elif triggering_policy == NotificationTriggeringPolicy.NEVER:
-        return False
-    elif triggering_policy == NotificationTriggeringPolicy.ONLY_FIRST:
-        previous_build_status = determine_previous_build_status(meta_vars)
-        if not previous_build_status:
-          print('failed to determine previous build status - will notify')
-          return True
-
-        # assumption: current job failed
-        if previous_build_status in (BuildStatus.FAILED, BuildStatus.ERRORED):
-          print('previous build was already broken - will not notify')
-          return False
-        return True
-    else:
-        raise NotImplementedError
-
-def cfg_from_callback(
-    repo_root,
-    callback_path,
-    effective_cfg_file,
-):
-    import subprocess
-    import os
-    import tempfile
-    import util
-
-    tmp_file = tempfile.NamedTemporaryFile()
-    cb_env = os.environ.copy()
-    cb_env['REPO_ROOT'] = repo_root
-    cb_env['NOTIFY_CFG_OUT'] = tmp_file.name
-    cb_env['EFFECTIVE_CFG'] = effective_cfg_file
-
-    subprocess.run(
-        [callback_path],
-        check=True,
-        env=cb_env,
+    email_cfg['mail_body'] = retrieve_build_log(
+        concourse_api=concourse_api,
+        task_name='${job_step.name}',
     )
 
-    return util.parse_yaml_file(tmp_file.name)
+## Finally, determine recipients for all component names gathered
+recipients = resolve_recipients_by_component_name(
+    component_names=email_cfg.get('component_names', ()),
+    github_cfg_name="${default_github_cfg_name}",
+)
+email_cfg['recipients'] = email_cfg['recipients'] | set(recipients)
 
+## Send mail
+email_cfg_name = "${cc_email_cfg.name()}"
+mailutil.notify(
+    subject="${subject}",
+    body='\n'.join((job_url(meta_vars_dict), email_cfg['mail_body'])),
+    email_cfg_name=email_cfg_name,
+    recipients=email_cfg['recipients'],
+)
 </%def>

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -1,0 +1,139 @@
+from concourse.model.traits.notifications import NotificationTriggeringPolicy
+from concourse.client import from_cfg
+from concourse.client.model import BuildStatus
+
+import os
+import util
+
+
+def meta_vars():
+    v = {}
+    for name in (
+      'build-id',
+      'build-name',
+      'build-job-name',
+      'build-team-name',
+      'build-pipeline-name',
+      'atc-external-url'
+    ):
+      with open(os.path.join('meta', name)) as f:
+        v[name] = f.read().strip()
+
+    return v
+
+
+def job_url(v):
+    return '/'.join([
+      v['atc-external-url'],
+      'teams',
+      v['build-team-name'],
+      'pipelines',
+      v['build-pipeline-name'],
+      'jobs',
+      v['build-job-name'],
+      'builds',
+      v['build-name']
+    ])
+
+
+def determine_previous_build_status(v):
+    concourse_api = from_cfg(cfg_set.concourse(), team_name=v['build-team-name'])
+    try:
+      build_number = int(v['build-name'])
+      if build_number < 2:
+        util.info('this seems to be the first build - will notify')
+        return BuildStatus.SUCCEEDED
+
+      previous_build = str(build_number - 1)
+      previous_build = concourse_api.job_build(
+        pipeline_name=v['build-pipeline-name'],
+        job_name=v['build-job-name'],
+        build_name=previous_build
+      )
+      return previous_build.status()
+    except Exception as e:
+      if type(e) == SystemExit:
+        raise e
+      # in doubt, ensure notification is sent
+      traceback.print_exc()
+      return None
+
+
+def should_notify(
+    triggering_policy,
+    meta_vars,
+    determine_previous_build_status=determine_previous_build_status,
+):
+    if triggering_policy == NotificationTriggeringPolicy.ALWAYS:
+        return True
+    elif triggering_policy == NotificationTriggeringPolicy.NEVER:
+        return False
+    elif triggering_policy == NotificationTriggeringPolicy.ONLY_FIRST:
+        previous_build_status = determine_previous_build_status(meta_vars)
+        if not previous_build_status:
+          util.info('failed to determine previous build status - will notify')
+          return True
+
+        # assumption: current job failed
+        if previous_build_status in (BuildStatus.FAILED, BuildStatus.ERRORED):
+          util.info('previous build was already broken - will not notify')
+          return False
+        return True
+    else:
+        raise NotImplementedError
+
+
+def cfg_from_callback(
+    repo_root,
+    callback_path,
+    effective_cfg_file,
+):
+    import subprocess
+    import os
+    import tempfile
+    import util
+
+    tmp_file = tempfile.NamedTemporaryFile()
+    cb_env = os.environ.copy()
+    cb_env['REPO_ROOT'] = repo_root
+    cb_env['NOTIFY_CFG_OUT'] = tmp_file.name
+    cb_env['EFFECTIVE_CFG'] = effective_cfg_file
+
+    subprocess.run(
+        [callback_path],
+        check=True,
+        env=cb_env,
+    )
+
+    return util.parse_yaml_file(tmp_file.name)
+
+
+def components_with_version_changes(component_diff_path: str):
+  if not os.path.isfile(component_diff_path):
+    util.info('no component_diff found at: ' + str(component_diff_path))
+    return set()
+  else:
+    component_diff = util.parse_yaml_file(component_diff_path)
+    comp_names = component_diff.get('component_names_with_version_changes', set())
+    return set(comp_names)
+
+
+def retrieve_build_log(concourse_api, task_name):
+    v = meta_vars()
+    try:
+      build_id = v['build-id']
+      task_id = concourse_api.build_plan(build_id=build_id).task_id(task_name=task_name)
+      build_events = concourse_api.build_events(build_id=build_id)
+      build_log = '\n'.join(build_events.iter_buildlog(task_id=task_id))
+      return build_log
+    except Exception as e:
+      traceback.print_exc() # print_err, but send email notification anyway
+      return 'failed to retrieve build log'
+
+
+def resolve_recipients_by_component_name(component_names, github_cfg_name):
+    component_recipients = mailutil.determine_mail_recipients(
+        github_cfg_name=github_cfg_name, # todo: actually this is not required here
+        component_names=component_names,
+    )
+    return component_recipients


### PR DESCRIPTION
Refactors our notification mako-coding and fixes some bugs/inconsistencies along the way.

Most of the changes should be self explanatory, although I would prefer discussing these changes in person on Monday, as there are still some parts where I am not 100% sure about the indended results even after reading the documentation.

Furthermore, this introduces one breaking change to the notifications.cfg by renaming `component_name_recipients` to `component_names`.
