### PR TITLE
Introduce GitHubRepoBranch class

### DIFF
--- a/github/util.py
+++ b/github/util.py
@@ -300,6 +300,17 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
             )
         return response['commit'].sha
 
+    @staticmethod
+    def from_githubrepobranch(
+        githubrepobranch: GitHubRepoBranch,
+    ):
+        return GitHubRepositoryHelper(
+            github_cfg=githubrepobranch.github_config(),
+            owner=githubrepobranch.repo_owner(),
+            name=githubrepobranch.repo_name(),
+            default_branch=githubrepobranch.branch(),
+        )
+
     def retrieve_file_contents(self, file_path: str, branch: str=None):
         if branch is None:
             branch = self.default_branch

--- a/github/util.py
+++ b/github/util.py
@@ -47,6 +47,34 @@ class RepoPermission(enum.Enum):
     ADMIN = "admin"
 
 
+class GitHubRepoBranch(object):
+    '''Instances of this class represent a specific branch of a given GitHub repository.
+    '''
+    def __init__(
+        self,
+        github_config: GithubConfig,
+        repo_owner: str,
+        repo_name: str,
+        branch: str,
+    ):
+        self._github_config = util.not_none(github_config)
+        self._repo_owner = util.not_empty(repo_owner)
+        self._repo_name = util.not_empty(repo_name)
+        self._branch = util.not_empty(branch)
+
+    def github_repo_path(self):
+        return f'{self._repo_owner}/{self._repo_name}'
+
+    def github_config(self):
+        return self._github_config
+
+    def repo_owner(self):
+        return self._repo_owner
+
+    def repo_name(self):
+        return self._repo_name
+
+
 class RepositoryHelperBase(object):
     GITHUB_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 

--- a/gitutil.py
+++ b/gitutil.py
@@ -22,6 +22,8 @@ import urllib.parse
 import git
 import git.objects.util
 
+from github.util import GitHubRepoBranch
+
 from util import not_empty, not_none, existing_dir, fail, random_str, urljoin
 
 
@@ -53,6 +55,17 @@ class GitHelper(object):
             github_cfg = github_cfg,
             github_repo_path = github_repo_path,
             )
+
+    @staticmethod
+    def from_githubrepobranch(
+        githubrepobranch: GitHubRepoBranch,
+        repo_path: str,
+    ):
+        return GitHelper(
+            repo=repo_path,
+            github_cfg=githubrepobranch.github_config(),
+            github_repo_path=githubrepobranch.github_repo_path(),
+        )
 
     def _changed_file_paths(self):
         lines = git.cmd.Git(self.repo.working_tree_dir).status('--porcelain=1', '-z').split('\x00')


### PR DESCRIPTION
As discussed in the other PR, introduce a new class to encapsule github-config, -repo-owner, -repo-name, the branch to be considered and (optionally) the path to the repository (on the disk)