### PR TITLE
Make posting of release notes to Slack its own transaction

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -25,11 +25,11 @@ from github.util import (
 )
 import product.model
 from github.release_notes.util import (
-    fetch_release_notes,
-    post_to_slack,
     delete_file_from_slack,
-    github_repo_path,
     draft_release_name_for_version,
+    fetch_release_notes,
+    github_repo_path,
+    post_to_slack,
 )
 from concourse.model.traits.release import (
     ReleaseNotesPolicy,

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -109,13 +109,16 @@ class Transaction(object):
         *steps: TransactionalStep,
     ):
         # create context object for this transaction
-        self.context = TransactionContext()
+        self._context = TransactionContext()
         # validate type of args and set context
         for step in steps:
             if not isinstance(step, TransactionalStep):
                 raise TypeError('Transactions may only contain instances of TransactionalStep')
-            step.set_context(self.context)
+            step.set_context(self._context)
         self._steps = steps
+
+    def context(self):
+        return self._context
 
     def validate(self):
         for step in self._steps:
@@ -131,7 +134,7 @@ class Transaction(object):
             executed_steps.append(step)
             try:
                 output = step.apply()
-                self.context.set_step_output(step_name, output)
+                self._context.set_step_output(step_name, output)
             except BaseException as e:
                 warning(f"An error occured while applying step '{step_name}': {e}")
                 traceback.print_exc()

--- a/test/concourse/steps/release_test.py
+++ b/test/concourse/steps/release_test.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from unittest.mock import MagicMock
 from github.util import GitHubRepositoryHelper, GitHubRepoBranch
+from github.release_notes.util import ReleaseNotes
 
 import concourse.steps.release
 import util
@@ -191,12 +192,14 @@ class TestSlackReleaseStep(object):
                 repo_name='test_name',
                 branch='master',
             ),
+            release_notes=ReleaseNotes(None),
             release_version='1.0.0',
         ):
             return concourse.steps.release.PostSlackReleaseStep(
                 slack_cfg_name=slack_cfg_name,
                 slack_channel=slack_channel,
                 githubrepobranch=githubrepobranch,
+                release_notes=release_notes,
                 release_version=release_version,
             )
         return _examinee


### PR DESCRIPTION
Prevents the removal of all release notes if only the act of posting to Slack fails.