### PR TITLE
Release Notes: Introduce `developer` target group

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,7 +23,7 @@ uses for building the release notes. ::
 Possible values:
 
   - category: improvement\|noteworthy\|action
-  - target\_group: user\|operator
+  - target\_group: user\|operator\|developer
 
 Example: ::
 

--- a/github/release_notes/renderer.py
+++ b/github/release_notes/renderer.py
@@ -42,7 +42,14 @@ TARGET_GROUP_OPERATOR = TitleNode(
     nodes=None,
     matches_rls_note_field_path='target_group_id'
 )
-TARGET_GROUPS = [TARGET_GROUP_USER, TARGET_GROUP_OPERATOR]
+TARGET_GROUP_DEVELOPER_ID = 'developer'
+TARGET_GROUP_DEVELOPER = TitleNode(
+    identifier=TARGET_GROUP_DEVELOPER_ID,
+    title='DEVELOPER',
+    nodes=None,
+    matches_rls_note_field_path='target_group_id'
+)
+TARGET_GROUPS = [TARGET_GROUP_USER, TARGET_GROUP_OPERATOR, TARGET_GROUP_DEVELOPER]
 
 CATEGORY_ACTION_ID = 'action'
 CATEGORY_ACTION = TitleNode(

--- a/github/release_notes/util.py
+++ b/github/release_notes/util.py
@@ -403,7 +403,7 @@ def extract_release_notes(
         return release_notes
 
     r = re.compile(
-        r"``` *(?P<category>improvement|noteworthy|action) (?P<target_group>user|operator)"
+        r"``` *(?P<category>improvement|noteworthy|action) (?P<target_group>user|operator|developer)"
         r"( (?P<source_repo>\S+/\S+/\S+)(( (?P<reference_type>#|\$)(?P<reference_id>\S+))?"
         r"( @(?P<user>\S+))?)( .*?)?|( .*?)?)\r?\n(?P<text>.*?)\n```",
         re.MULTILINE | re.DOTALL

--- a/test/github/release_notes/renderer_test.py
+++ b/test/github/release_notes/renderer_test.py
@@ -27,6 +27,7 @@ from github.release_notes.renderer import (
     CATEGORY_IMPROVEMENT_ID,
     TARGET_GROUP_USER_ID,
     TARGET_GROUP_OPERATOR_ID,
+    TARGET_GROUP_DEVELOPER_ID,
 )
 from test.github.release_notes.default_util import (
     release_note_block_with_defaults,
@@ -326,6 +327,13 @@ class RendererTest(unittest.TestCase):
                 reference_id=None,
                 user_login=None,
             ),
+            release_note_block_with_defaults(
+                target_group_id=TARGET_GROUP_DEVELOPER_ID,
+                text='developer release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
         ]
 
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
@@ -333,7 +341,8 @@ class RendererTest(unittest.TestCase):
             '# [current-repo]\n'\
             '## Improvements\n'\
             '* *[USER]* user release note\n'\
-            '* *[OPERATOR]* operator release note'
+            '* *[OPERATOR]* operator release note\n'\
+            '* *[DEVELOPER]* developer release note'
         self.assertEqual(expected_md_str, actual_md_str)
 
     def test_get_or_call(self):

--- a/test/github/release_notes/util_test.py
+++ b/test/github/release_notes/util_test.py
@@ -32,6 +32,7 @@ from github.release_notes.renderer import (
     CATEGORY_IMPROVEMENT_ID,
     TARGET_GROUP_USER_ID,
     TARGET_GROUP_OPERATOR_ID,
+    TARGET_GROUP_DEVELOPER_ID,
 )
 from test.github.release_notes.default_util import (
     release_note_block_with_defaults,
@@ -114,6 +115,22 @@ class ReleaseNotesTest(unittest.TestCase):
             category_id=CATEGORY_NOTEWORTHY_ID,
             target_group_id=TARGET_GROUP_OPERATOR_ID,
             text='notew-text',
+        )
+        self.assertEqual([exp_release_note], actual_release_notes)
+
+    def test_rls_note_extraction_developer(self):
+        text = \
+            '``` noteworthy developer\n'\
+            'rls-note-for-developer\n'\
+            '```'
+        actual_release_notes = extract_release_notes_with_defaults(
+            text=text,
+        )
+
+        exp_release_note = release_note_block_with_defaults(
+            category_id=CATEGORY_NOTEWORTHY_ID,
+            target_group_id=TARGET_GROUP_DEVELOPER_ID,
+            text='rls-note-for-developer',
         )
         self.assertEqual([exp_release_note], actual_release_notes)
 


### PR DESCRIPTION
As requested by @rfranzke, I introduced a new target group `developer`, in addition to `user` and `operator`