### PR TITLE
no resource check if 'skip ci' in commit msg

### DIFF
--- a/concourse/client/model.py
+++ b/concourse/client/model.py
@@ -159,6 +159,9 @@ class GithubSource(object):
     def access_token(self):
         return self.raw['access_token']
 
+    def disable_ci_skip(self) -> bool:
+        return self.raw.get('disable_ci_skip')
+
 
 class Build(ModelBase):
     '''

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -183,6 +183,13 @@ class GithubWebhookDispatcher(object):
             if isinstance(event, PushEvent):
                 if not event.ref().endswith(ghs.branch_name()):
                     continue
+            # TODO: remove for Concourse 6.0 see https://github.com/concourse/concourse/issues/3463
+            if any(skip in event.commit_message() for skip in ('[skip ci]', '[ci skip]')):
+                if not ghs.disable_ci_skip():
+                    app.logger.info(
+                        f"Do not trigger resource {resource.name}. Found [skip ci] or [ci skip]"
+                    )
+                    continue
 
             yield resource
 

--- a/whd/model.py
+++ b/whd/model.py
@@ -67,6 +67,9 @@ class PushEvent(EventBase):
             return ()
         yield from head_commit.get('modified', ())
 
+    def commit_message(self):
+        return self.raw.get('head_commit').get('message')
+
 
 class PullRequestAction(enum.Enum):
     ASSIGNED = 'assigned'


### PR DESCRIPTION
in case `[skip-ci]` or `[ci skip]` is in commit message, we do not want to check the resource.
We only check the resource, if `disable_ci_skip` is set to True