### PR TITLE
Implement SSE workaround for ClamAV scanning

### DIFF
--- a/clamav/client.py
+++ b/clamav/client.py
@@ -21,10 +21,11 @@ from .routes import ClamAVRoutes
 from clamav.util import iter_image_files
 
 from .model import (
+    ClamAVHealth,
     ClamAVInfo,
     ClamAVMonitoringInfo,
+    ClamAVScanEventClient,
     ClamAVScanResult,
-    ClamAVHealth,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,13 @@ class ClamAVClient(object):
         url = self.routes.scan()
         response = self._request(self._session.post, url=url, data=data)
         return ClamAVScanResult(response.json())
+
+    def sse_scan(self, data):
+        url = self.routes.sse_scan()
+        client = ClamAVScanEventClient(
+            self._request(self._session.post, url=url, data=data, stream=True)
+        )
+        return client.process_events()
 
     def health(self):
         url = self.routes.health()

--- a/clamav/routes.py
+++ b/clamav/routes.py
@@ -35,6 +35,9 @@ class ClamAVRoutes(object):
     def scan(self):
         return self._api_url('scan')
 
+    def sse_scan(self):
+        return self._api_url('sse', 'scan')
+
     def info(self):
         return self._api_url('info')
 


### PR DESCRIPTION
Due to short connection-timeouts we need to keep sending SSE to keep the connection alive when scanning large files.

This PR adds support for the SSE sent by our ClamAV service.