### PR TITLE
remove own node exporter metrics

### DIFF
--- a/landscape_setup/monitoring.py
+++ b/landscape_setup/monitoring.py
@@ -95,25 +95,14 @@ def deploy_monitoring_landscape(
         postgresql_helm_values,
     )
 
-    # deploy ingresses for kube-state-metrics, postgresql exporter and node-exporter
+    # deploy ingresses for kube-state-metrics, postgresql exporter
     monitoring_tls_secret_name = monitoring_cfg.tls_secret_name()
-    node_exporter_namespace = monitoring_cfg.node_exporter().namespace()
 
     info('Creating tls-secret in monitoring namespace for kube-state-metrics and postgresql...')
     create_tls_secret(
         tls_config=tls_config,
         tls_secret_name=monitoring_tls_secret_name,
         namespace=monitoring_namespace,
-        basic_auth_cred=BasicAuthCred(
-            user=monitoring_cfg.basic_auth_user(),
-            password=monitoring_cfg.basic_auth_pwd()
-        )
-    )
-    info('Creating tls-secret in kube-system namespace for node-exporter...')
-    create_tls_secret(
-        tls_config=tls_config,
-        tls_secret_name=monitoring_tls_secret_name,
-        namespace=node_exporter_namespace,
         basic_auth_cred=BasicAuthCred(
             user=monitoring_cfg.basic_auth_user(),
             password=monitoring_cfg.basic_auth_pwd()
@@ -140,16 +129,6 @@ def deploy_monitoring_landscape(
         service_port=monitoring_cfg.postgresql_exporter().service_port(),
     )
     ingress_helper.replace_or_create_ingress(monitoring_namespace, ingress)
-
-    info('Create ingress for node-exporter')
-    ingress = generate_monitoring_ingress_object(
-        secret_name=monitoring_tls_secret_name,
-        namespace=node_exporter_namespace,
-        hosts=[monitoring_cfg.ingress_host(), monitoring_cfg.external_url()],
-        service_name=monitoring_cfg.node_exporter().service_name(),
-        service_port=monitoring_cfg.node_exporter().service_port(),
-    )
-    ingress_helper.replace_or_create_ingress(node_exporter_namespace, ingress)
 
 
 def generate_monitoring_ingress_object(

--- a/model/monitoring.py
+++ b/model/monitoring.py
@@ -25,7 +25,6 @@ class CCMonitoringConfig(NamedModelElement):
             'namespace',
             'kube_state_metrics',
             'postgresql_exporter',
-            'node_exporter',
             'tls_config',
             'tls_secret_name',
             'ingress_host',
@@ -42,9 +41,6 @@ class CCMonitoringConfig(NamedModelElement):
 
     def postgresql_exporter(self):
         return PostgresqlExporter(raw_dict=self.raw['postgresql_exporter'])
-
-    def node_exporter(self):
-        return NodeExporter(raw_dict=self.raw['node_exporter'])
 
     def tls_config(self):
         return self.raw.get('tls_config')
@@ -85,14 +81,3 @@ class PostgresqlExporter(ModelBase):
 
     def service_port(self):
         return self.raw.get('service_port')
-
-
-class NodeExporter(ModelBase):
-    def service_name(self):
-        return self.raw.get('service_name')
-
-    def service_port(self):
-        return self.raw.get('service_port')
-
-    def namespace(self):
-        return self.raw.get('namespace')

--- a/test/model/monitoring_test.py
+++ b/test/model/monitoring_test.py
@@ -25,7 +25,6 @@ def monitoring_required_dict():
             'namespace': 'foo',
             'kube_state_metrics': 'foo',
             'postgresql_exporter': 'foo',
-            'node_exporter': 'foo',
             'tls_config': 'foo',
             'tls_secret_name': 'foo',
             'ingress_host': 'foo',


### PR DESCRIPTION
we rely on node metrics comming from the monitoring team.
No need to provide our own metrics