### PR TITLE
hacky workaround: trigger meta-resources prior to git/pr-resources

### DIFF
--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -125,6 +125,16 @@ class GithubWebhookDispatcher(object):
             )
 
     def _trigger_resource_check(self, concourse_api, resources):
+        resources = list(resources) # use a list so we can insert meta-resources
+
+        # hack: also trigger resource checks for all affected meta resources
+        #       this needs to be done _prior_ to git/pr resource triggering
+        pipeline_names = {resource.pipeline_name() for resource in resources}
+        for resource in concourse_api.pipeline_resources(pipeline_names=pipeline_names):
+            if not resource.type == 'meta': # XXX unhardcode `meta` str literal
+                continue
+            resources.insert(0, resource)
+
         for resource in resources:
             app.logger.info('triggering resource check for: ' + resource.name)
             concourse_api.trigger_resource_check(


### PR DESCRIPTION
Our extensive usage of concourse's meta-resource leads to performance
issues due to high write-load on underlying PostgresQL Db. Not updating
meta-resources periodically, however, leads to outdated meta-resource
versions. Thus, mitigate by identifying potentially relevant
meta-resources (all contained in given pipeline) and trigger those prior
to triggering git/pr-resources.

Note that this will not solve cases for pipelines that are triggered by
other sources than GitHub-Webhook.