### PR TITLE
Changes to GithubConfig protocol handling

### DIFF
--- a/test/model/github_test.py
+++ b/test/model/github_test.py
@@ -27,6 +27,7 @@ def required_dict():
             'apiUrl': 'foo',
             'disable_tls_validation': 'foo',
             'webhook_token': 'foo',
+            'available_protocols': ['https', 'ssh'],
     }
 
 


### PR DESCRIPTION
GithubConfig now specifies all available protocols as list instead of only explicitly giving the preferred one.

Also adds additional validation and adjusts tests.