### PR TITLE
Do not add build metadata automatically in els client

### DIFF
--- a/ccc/elasticsearch.py
+++ b/ccc/elasticsearch.py
@@ -49,32 +49,17 @@ def _metadata_dict():
     if not util._running_on_ci():
         return {}
 
-    build = concourse.util.find_own_running_build()
     pipeline_metadata = concourse.util.get_pipeline_metadata()
     config_set = util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
     concourse_cfg = config_set.concourse()
 
     meta_dict = {
-      'build-id': build.id(),
-      'build-name': str(build.build_number()),
-      'build-job-name': pipeline_metadata.job_name,
-      'build-team-name': pipeline_metadata.team_name,
-      'build-pipeline-name': pipeline_metadata.pipeline_name,
-      'atc-external-url': concourse_cfg.external_url(),
+        'build-uuid': pipeline_metadata.build_uuid,
+        'build-job-name': pipeline_metadata.job_name,
+        'build-team-name': pipeline_metadata.team_name,
+        'build-pipeline-name': pipeline_metadata.pipeline_name,
+        'atc-external-url': concourse_cfg.external_url(),
     }
-
-    # XXX deduplicate; mv to concourse package
-    meta_dict['concourse_url'] = util.urljoin(
-        meta_dict['atc-external-url'],
-        'teams',
-        meta_dict['build-team-name'],
-        'pipelines',
-        meta_dict['build-pipeline-name'],
-        'jobs',
-        meta_dict['build-job-name'],
-        'builds',
-        meta_dict['build-name'],
-    )
 
     # XXX do not hard-code env variables
     meta_dict['effective_version'] = os.environ.get('EFFECTIVE_VERSION')

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -45,6 +45,7 @@ class PipelineMetaData:
     pipeline_name: str
     job_name: str
     current_config_set_name: str
+    build_uuid: str
     team_name: str
 
 
@@ -149,11 +150,13 @@ def get_pipeline_metadata():
     team_name = check_env('CONCOURSE_CURRENT_TEAM')
     pipeline_name = check_env('PIPELINE_NAME')
     job_name = check_env('BUILD_JOB_NAME')
+    build_uuid = _get_build_uuid()
 
     return PipelineMetaData(
         pipeline_name=pipeline_name,
         job_name=job_name,
         current_config_set_name=current_cfg_set_name,
+        build_uuid=build_uuid,
         team_name=team_name,
     )
 

--- a/test/concourse/util_test.py
+++ b/test/concourse/util_test.py
@@ -12,23 +12,34 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import concourse.util as examinee
+import concourse.model.traits.meta
+import concourse.steps.meta
 
 
-def test_static_pipeline_metadata(monkeypatch):
+def test_static_pipeline_metadata(monkeypatch, tmp_path):
     # fake running on ci
-    monkeypatch.setenv('CC_ROOT_DIR', 'made/up/dir')
+    monkeypatch.setenv('CC_ROOT_DIR', tmp_path)
+    meta_dir_path = tmp_path / concourse.model.traits.meta.META_INFO_DIR_NAME
+    meta_dir_path.mkdir()
+    uuid_file_path = meta_dir_path / concourse.steps.meta.jobmetadata_filename
 
     TEST_CONFIG_SET_NAME = 'made-up_config_name'
     TEST_CONCOURSE_TEAM_NAME = 'made-up_concourse_team'
     TEST_PIPELINE_NAME = 'made-up_pipeline_name'
     TEST_JOB_NAME = 'made-up_job_name'
+    TEST_BUILD_UUID = 'made-up-UUID'
+
+    with open(uuid_file_path, 'w') as f:
+        json.dump({'uuid': TEST_BUILD_UUID}, f)
 
     test_metadata = examinee.PipelineMetaData(
         pipeline_name=TEST_PIPELINE_NAME,
         job_name=TEST_JOB_NAME,
         current_config_set_name=TEST_CONFIG_SET_NAME,
         team_name=TEST_CONCOURSE_TEAM_NAME,
+        build_uuid=TEST_BUILD_UUID,
     )
 
     monkeypatch.setenv('CONCOURSE_CURRENT_CFG', TEST_CONFIG_SET_NAME)


### PR DESCRIPTION
Removes build metadata from information that is automatically added when running on CI. The build
metadata is replaced by the build's UUID.