### PR TITLE
switch mapping-order in steps

### DIFF
--- a/concourse/model/step.py
+++ b/concourse/model/step.py
@@ -217,14 +217,14 @@ class PipelineStep(ModelBase):
         raw_dict['depends'] = set(raw_dict['depends'])
         if raw_dict.get('output_dir', None):
             name = raw_dict['output_dir']
-            self.add_output(name + '_path', name + '_path')
+            self.add_output(name=name + '_path', variable_name=name + '_path')
 
         # add hard-coded output "on_error" (allows build steps to pass custom
         # notification cfg for build errors)
-        self.add_output('on_error_dir', 'on_error_dir')
+        self.add_output(name='on_error_dir', variable_name='on_error_dir')
 
-        for name, variable_name in raw_dict.get('inputs').items():
-            self.add_input(name, variable_name)
+        for variable_name, name in raw_dict.get('inputs').items():
+            self.add_input(name=name, variable_name=variable_name)
 
         self._publish_to_dict = normalise_to_dict(raw_dict['publish_to'])
 
@@ -292,9 +292,9 @@ class PipelineStep(ModelBase):
         return self._outputs_dict
 
     def add_output(self, name, variable_name):
-        if name in self._outputs_dict:
-            raise ValueError('output already exists: ' + str(name))
-        self._outputs_dict[name] = variable_name
+        if variable_name in self._outputs_dict:
+            raise ValueError(f'output already exists: {variable_name}')
+        self._outputs_dict[variable_name] = name
 
     def inputs(self):
         return self._inputs_dict
@@ -306,15 +306,15 @@ class PipelineStep(ModelBase):
         util.not_none(name)
         util.not_none(variable_name)
 
-        if name in self._inputs_dict:
-            raise ValueError('input already exists: ' + str(name))
-        self._inputs_dict[name] = variable_name
+        if variable_name in self._inputs_dict:
+            raise ValueError(f'input already exists: {variable_name}')
+        self._inputs_dict[variable_name] = name
 
     def remove_input(self, name):
         util.not_none(name)
 
         if not name in self._inputs_dict:
-            raise ValueError('input does not exist: ' + str(name))
+            raise ValueError(f'input does not exist: {name}')
         self._inputs_dict.pop(name)
 
     def variables(self):

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -30,8 +30,6 @@ from concourse.model.base import (
   ScriptType,
 )
 
-COMPONENT_DESCRIPTOR_DIR_INPUT = ('component_descriptor_dir', 'component_descriptor_dir')
-
 ATTRIBUTES = (
     AttributeSpec.optional(
         name='step',
@@ -87,6 +85,10 @@ class ComponentDescriptorTrait(Trait):
         return ComponentDescriptorTraitTransformer(trait=self)
 
 
+DIR_NAME = 'component_descriptor_dir'
+ENV_VAR_NAME = 'component_descriptor_dir'
+
+
 class ComponentDescriptorTraitTransformer(TraitTransformer):
     name = 'component_descriptor'
 
@@ -102,7 +104,10 @@ class ComponentDescriptorTraitTransformer(TraitTransformer):
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
             script_type=ScriptType.PYTHON3,
         )
-        self.descriptor_step.add_output(*COMPONENT_DESCRIPTOR_DIR_INPUT)
+        self.descriptor_step.add_output(
+            name=DIR_NAME,
+            variable_name=ENV_VAR_NAME,
+        )
         self.descriptor_step.set_timeout(duration_string='30m')
 
         yield self.descriptor_step
@@ -110,7 +115,10 @@ class ComponentDescriptorTraitTransformer(TraitTransformer):
     def process_pipeline_args(self, pipeline_args: 'JobVariant'):
         if pipeline_args.has_step('release'):
             release_step = pipeline_args.step('release')
-            release_step.add_input(*COMPONENT_DESCRIPTOR_DIR_INPUT)
+            release_step.add_input(
+                name=DIR_NAME,
+                variable_name=ENV_VAR_NAME,
+            )
 
         # inject component_name if not configured
         if not self.trait.raw.get('component_name'):

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -33,7 +33,7 @@ from concourse.model.base import (
 from model.base import ModelValidationError
 from product.scanning import ProcessingMode
 
-from .component_descriptor import COMPONENT_DESCRIPTOR_DIR_INPUT
+import concourse.model.traits.component_descriptor
 from .images import (
     IMAGE_ATTRS,
     ImageFilterMixin,
@@ -213,7 +213,10 @@ class ImageScanTraitTransformer(TraitTransformer):
                 notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
                 script_type=ScriptType.PYTHON3
         )
-        self.image_scan_step.add_input(*COMPONENT_DESCRIPTOR_DIR_INPUT)
+        self.image_scan_step.add_input(
+            name=concourse.model.traits.component_descriptor.DIR_NAME,
+            variable_name=concourse.model.traits.component_descriptor.ENV_VAR_NAME,
+        )
         self.image_scan_step.set_timeout(duration_string='12h')
         yield self.image_scan_step
 

--- a/concourse/model/traits/image_upload.py
+++ b/concourse/model/traits/image_upload.py
@@ -27,7 +27,7 @@ from concourse.model.base import (
     ScriptType,
 )
 
-from .component_descriptor import COMPONENT_DESCRIPTOR_DIR_INPUT
+import concourse.model.traits.component_descriptor
 from .images import (
     IMAGE_ATTRS,
     ImageFilterMixin,
@@ -86,7 +86,10 @@ class ImageUploadTraitTransformer(TraitTransformer):
                 notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
                 script_type=ScriptType.PYTHON3
         )
-        self.image_upload_step.add_input(*COMPONENT_DESCRIPTOR_DIR_INPUT)
+        self.image_upload_step.add_input(
+            name=concourse.model.traits.component_descriptor.DIR_NAME,
+            variable_name=concourse.model.traits.component_descriptor.ENV_VAR_NAME,
+        )
         self.image_upload_step.set_timeout(duration_string='12h')
         yield self.image_upload_step
 

--- a/concourse/model/traits/meta.py
+++ b/concourse/model/traits/meta.py
@@ -41,10 +41,7 @@ class MetaTraitTransformer(TraitTransformer):
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
             script_type=ScriptType.PYTHON3,
         )
-        # name is the name of the env var exposed to tasks, variable name is the concourse-name
-        # of the input.
-        # TODO: Refactor arg names
-        self.meta_step.add_output(name=META_INFO_ENV_VAR_NAME, variable_name=META_INFO_DIR_NAME)
+        self.meta_step.add_output(name=META_INFO_DIR_NAME, variable_name=META_INFO_ENV_VAR_NAME)
         yield self.meta_step
 
     def process_pipeline_args(self, pipeline_args: JobVariant):
@@ -53,7 +50,7 @@ class MetaTraitTransformer(TraitTransformer):
             if step == self.meta_step:
                 continue
             step._add_dependency(self.meta_step)
-            step.add_input(name=META_INFO_ENV_VAR_NAME, variable_name=META_INFO_DIR_NAME)
+            step.add_input(name=META_INFO_DIR_NAME, variable_name=META_INFO_ENV_VAR_NAME)
         if pipeline_args.has_trait('version'):
             # All steps depend on version. Remove ourself to avoid circular dependency
             version_step = pipeline_args.step('version')

--- a/concourse/model/traits/publish.py
+++ b/concourse/model/traits/publish.py
@@ -169,6 +169,10 @@ class PublishTrait(Trait):
         return PublishTraitTransformer(trait=self)
 
 
+IMAGE_ENV_VAR_NAME = 'image_path'
+TAG_ENV_VAR_NAME = 'tag_path'
+
+
 class PublishTraitTransformer(TraitTransformer):
     name = 'publish'
 
@@ -211,12 +215,12 @@ class PublishTraitTransformer(TraitTransformer):
         tag_name = main_repo.branch() + '-tag'
 
         # configure prepare step's outputs (consumed by publish step)
-        prepare_step.add_output('image_path', image_name)
-        prepare_step.add_output('tag_path', tag_name)
+        prepare_step.add_output(variable_name=IMAGE_ENV_VAR_NAME, name=image_name)
+        prepare_step.add_output(variable_name=TAG_ENV_VAR_NAME, name=tag_name)
 
         # configure publish step's inputs (produced by prepare step)
-        publish_step.add_input('image_path', image_name)
-        publish_step.add_input('tag_path', tag_name)
+        publish_step.add_input(variable_name=IMAGE_ENV_VAR_NAME, name=image_name)
+        publish_step.add_input(variable_name=TAG_ENV_VAR_NAME, name=tag_name)
 
         input_step_names = set()
         for image_descriptor in self.trait.dockerimages():

--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -29,7 +29,7 @@ from concourse.model.job import (
     JobVariant,
 )
 
-from .component_descriptor import COMPONENT_DESCRIPTOR_DIR_INPUT
+import concourse.model.traits.component_descriptor
 
 
 class MergePolicy(enum.Enum):
@@ -115,7 +115,10 @@ class UpdateComponentDependenciesTraitTransformer(TraitTransformer):
                 notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
                 script_type=ScriptType.PYTHON3
         )
-        self.update_component_deps_step.add_input(*COMPONENT_DESCRIPTOR_DIR_INPUT)
+        self.update_component_deps_step.add_input(
+            name=concourse.model.traits.component_descriptor.DIR_NAME,
+            variable_name=concourse.model.traits.component_descriptor.ENV_VAR_NAME,
+        )
         self.update_component_deps_step.set_timeout(duration_string='30m')
 
         for name, value in self.trait.vars().items():

--- a/concourse/model/traits/version.py
+++ b/concourse/model/traits/version.py
@@ -85,6 +85,10 @@ class VersionTrait(Trait):
         return VersionTraitTransformer()
 
 
+ENV_VAR_NAME = 'version_path'
+DIR_NAME = 'managed-version'
+
+
 class VersionTraitTransformer(TraitTransformer):
     name = 'version'
 
@@ -96,7 +100,7 @@ class VersionTraitTransformer(TraitTransformer):
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
             script_type=ScriptType.PYTHON3,
             )
-        self.version_step.add_output(name='version_path', variable_name='managed-version')
+        self.version_step.add_output(name=DIR_NAME, variable_name=ENV_VAR_NAME)
         self.version_step.set_timeout(duration_string='5m')
 
         yield self.version_step
@@ -107,4 +111,4 @@ class VersionTraitTransformer(TraitTransformer):
             if step == self.version_step:
                 continue
             step._add_dependency(self.version_step)
-            step.add_input(name='version_path', variable_name='managed-version')
+            step.add_input(variable_name=ENV_VAR_NAME, name=DIR_NAME)

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -277,11 +277,11 @@ else:
       ${env_var_name}: ${env_var_value}
 % endfor
 % endfor
-% for name, value in job_step.inputs().items():
-      ${name.upper().replace('-','_')}: ${value}
+% for variable_name, value in job_step.inputs().items():
+      ${variable_name.upper().replace('-','_')}: ${value}
 % endfor
-% for name, value in job_step.outputs().items():
-      ${name.upper().replace('-','_')}: ${value}
+% for variable_name, value in job_step.outputs().items():
+      ${variable_name.upper().replace('-','_')}: ${value}
 % endfor
       SECRETS_SERVER_ENDPOINT: ${secrets_server_cfg.endpoint_url()}
       SECRETS_SERVER_CONCOURSE_CFG_NAME: ${secrets_server_cfg.secrets().concourse_cfg_name()}


### PR DESCRIPTION
At some point in the past, we started to use `<env_var_name>:<value>` mappings in our step in-/outputs backwards, i.e. we'd render the env_var name as value and the value as name.

Fortunately, these two values are the same, most of the time. Nevertheless, this PR 'fixes' the mapping to map env_var names to values and changes all usage of our step in-/outputs to be more expressive.