### PR TITLE
refactor: adjust to new util location

### DIFF
--- a/.ci/bump_job_image_version.py
+++ b/.ci/bump_job_image_version.py
@@ -3,7 +3,7 @@
 import pathlib
 import fileinput
 
-from util import (
+from ci.util import (
     check_env,
     existing_file,
 )

--- a/ccc/cfg.py
+++ b/ccc/cfg.py
@@ -1,8 +1,8 @@
 import functools
 
-import util
+import ci.util
 
-ctx = util.ctx()
+ctx = ci.util.ctx()
 
 
 @functools.lru_cache()

--- a/ccc/clamav.py
+++ b/ccc/clamav.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import util
+import ci.util
 
 from clamav.client import ClamAVClient
 from clamav.routes import ClamAVRoutes
@@ -26,6 +26,6 @@ def client_from_config(clamav_config: ClamAVConfig):
 
 
 def client_from_config_name(clamav_config_name: str):
-    cfg_factory = util.ctx().cfg_factory()
+    cfg_factory = ci.util.ctx().cfg_factory()
     clamav_config = cfg_factory.clamav(clamav_config_name)
     return client_from_config(clamav_config)

--- a/ccc/elasticsearch.py
+++ b/ccc/elasticsearch.py
@@ -20,9 +20,9 @@ import json
 
 import elasticsearch
 
-import model.elasticsearch
-import concourse.util
 import ci.util
+import concourse.util
+import model.elasticsearch
 
 
 def from_cfg(

--- a/ccc/elasticsearch.py
+++ b/ccc/elasticsearch.py
@@ -22,7 +22,7 @@ import elasticsearch
 
 import model.elasticsearch
 import concourse.util
-import util
+import ci.util
 
 
 def from_cfg(
@@ -46,12 +46,12 @@ def _from_cfg(
 @functools.lru_cache()
 def _metadata_dict():
     # XXX mv to concourse package; deduplicate with notify step
-    if not util._running_on_ci():
+    if not ci.util._running_on_ci():
         return {}
 
     build = concourse.util.find_own_running_build()
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    config_set = util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
+    config_set = ci.util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
     concourse_cfg = config_set.concourse()
 
     meta_dict = {
@@ -64,7 +64,7 @@ def _metadata_dict():
     }
 
     # XXX deduplicate; mv to concourse package
-    meta_dict['concourse_url'] = util.urljoin(
+    meta_dict['concourse_url'] = ci.util.urljoin(
         meta_dict['atc-external-url'],
         'teams',
         meta_dict['build-team-name'],
@@ -99,8 +99,8 @@ class ElasticSearchClient(object):
         *args,
         **kwargs,
     ):
-        util.check_type(index, str)
-        util.check_type(body, dict)
+        ci.util.check_type(index, str)
+        ci.util.check_type(body, dict)
         if 'doc_type' in kwargs:
             raise ValueError(
                 '''
@@ -154,7 +154,7 @@ class ElasticSearchClient(object):
         *args,
         **kwargs,
     ):
-        util.check_type(body, str)
+        ci.util.check_type(body, str)
 
         if inject_metadata and _metadata_dict():
             def inject_meta(line):

--- a/ccc/github.py
+++ b/ccc/github.py
@@ -28,9 +28,9 @@ import ccc.elasticsearch
 import github.util
 import http_requests
 import model
-import util
+import ci.util
 
-if util._running_on_ci():
+if ci.util._running_on_ci():
     log_github_access = False
 else:
     log_github_access = False
@@ -151,7 +151,7 @@ def github_api(
     )
 
     if not github_api:
-        util.fail("Could not connect to GitHub-instance {url}".format(url=github_url))
+        ci.util.fail("Could not connect to GitHub-instance {url}".format(url=github_url))
 
     return github_api
 
@@ -162,9 +162,9 @@ def github_cfg_for_hostname(
     cfg_factory=None,
     require_labels=('ci',), # XXX unhardcode label
 ):
-    util.not_none(host_name)
+    ci.util.not_none(host_name)
     if not cfg_factory:
-        ctx = util.ctx()
+        ctx = ci.util.ctx()
         cfg_factory = ctx.cfg_factory()
 
     if isinstance(require_labels, str):
@@ -188,14 +188,14 @@ def log_stack_trace_information_hook(resp, *args, **kwargs):
     This function stores the current stacktrace in elastic search.
     It must not return anything, otherwise the return value is assumed to replace the response
     '''
-    if not util._running_on_ci():
+    if not ci.util._running_on_ci():
         return # early exit if not running in ci job
 
-    config_set_name = util.check_env('CONCOURSE_CURRENT_CFG')
+    config_set_name = ci.util.check_env('CONCOURSE_CURRENT_CFG')
     try:
         els_index = 'github_access_stacktrace'
         try:
-            config_set = util.ctx().cfg_factory().cfg_set(config_set_name)
+            config_set = ci.util.ctx().cfg_factory().cfg_set(config_set_name)
         except KeyError:
             # do nothing: external concourse does not have config set 'internal_active'
             return
@@ -216,4 +216,4 @@ def log_stack_trace_information_hook(resp, *args, **kwargs):
         )
 
     except Exception as e:
-        util.info(f'Could not log stack trace information: {e}')
+        ci.util.info(f'Could not log stack trace information: {e}')

--- a/ccc/github.py
+++ b/ccc/github.py
@@ -25,10 +25,10 @@ import github3.github
 import github3.session
 
 import ccc.elasticsearch
+import ci.util
 import github.util
 import http_requests
 import model
-import ci.util
 
 if ci.util._running_on_ci():
     log_github_access = False

--- a/ccc/secrets_server.py
+++ b/ccc/secrets_server.py
@@ -17,7 +17,7 @@ import os
 import requests
 import json
 
-from util import urljoin
+from ci.util import urljoin
 
 
 class SecretsServerClient(object):

--- a/ci/util.py
+++ b/ci/util.py
@@ -247,7 +247,7 @@ def create_url_from_attributes(
 def check_env(name: str):
     '''
     returns: the specified environment variable's value.
-    raises: util.Failure if no environment variable with the given name is defined
+    raises: ci.util.Failure if no environment variable with the given name is defined
     '''
     not_none(name)
     if name in os.environ:
@@ -285,7 +285,7 @@ def urljoin(*parts):
 
 def which(cmd_name: str) -> str:
     '''
-    wrapper around shutil.which that calls util.fail if the requested executable is not
+    wrapper around shutil.which that calls ci.util.fail if the requested executable is not
     found in the PATH.
     '''
     cmd_path = shutil.which(cmd_name)

--- a/clamav/routes.py
+++ b/clamav/routes.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from ensure import ensure_annotations
-from util import urljoin
+from ci.util import urljoin
 
 
 class ClamAVRoutes(object):

--- a/cli/gardener_ci/cli_gen.py
+++ b/cli/gardener_ci/cli_gen.py
@@ -24,14 +24,14 @@ import itertools
 import sys
 
 import ctx
-import util
+import ci.util
 
 import_errs = []
 
 
 def print_import_errs():
     for ie in import_errs:
-        util.verbose(ie)
+        ci.util.verbose(ie)
 
 
 if ctx.Config.TERMINAL.value.output_columns() is not None:
@@ -75,14 +75,14 @@ def main():
         sys.exit(1)
     parsed = parser.parse_args()
     # write parsed args to global ctx module so called module functions may
-    # retrieve if (see util.ctx)
+    # retrieve if (see ci.util.ctx)
     ctx.args = parsed
 
     config_from_args = ctx.load_config_from_args()
     ctx.add_config_source(config_from_args)
 
     # mark 'cli' mode
-    util._set_cli(True)
+    ci.util._set_cli(True)
     if hasattr(parsed, 'module'):
         parsed.module.args = parsed
         parsed.func(parsed)
@@ -144,7 +144,7 @@ def add_module(module_name, parser):
             action = None
             kwargs = {}
             if annotation:
-                from util import CliHint
+                from ci.util import CliHint
                 # special case: CliHint
                 if type(annotation) == CliHint:
                     typehint = annotation.typehint

--- a/cli/gardener_ci/cli_gen.py
+++ b/cli/gardener_ci/cli_gen.py
@@ -23,8 +23,8 @@ import inspect
 import itertools
 import sys
 
-import ctx
 import ci.util
+import ctx
 
 import_errs = []
 

--- a/cli/gardener_ci/concourseutil.py
+++ b/cli/gardener_ci/concourseutil.py
@@ -19,8 +19,8 @@ import yaml
 import kube.ctx
 import landscape_setup.concourse as setup_concourse
 
-from ci.util import ctx
 from ci.util import (
+    ctx,
     info,
     fail,
     CliHints,

--- a/cli/gardener_ci/concourseutil.py
+++ b/cli/gardener_ci/concourseutil.py
@@ -19,8 +19,8 @@ import yaml
 import kube.ctx
 import landscape_setup.concourse as setup_concourse
 
-from util import ctx
-from util import (
+from ci.util import ctx
+from ci.util import (
     info,
     fail,
     CliHints,

--- a/cli/gardener_ci/config.py
+++ b/cli/gardener_ci/config.py
@@ -17,7 +17,7 @@ import pathlib
 import json as json_m
 import yaml
 
-from util import CliHints, ctx,existing_dir
+from ci.util import CliHints, ctx,existing_dir
 from model import ConfigFactory, ConfigSetSerialiser as CSS
 
 

--- a/cli/gardener_ci/containerutil.py
+++ b/cli/gardener_ci/containerutil.py
@@ -1,6 +1,6 @@
+import ci.util
 import container.registry
 import container.util
-import ci.util
 
 
 def filter_image_file(

--- a/cli/gardener_ci/containerutil.py
+++ b/cli/gardener_ci/containerutil.py
@@ -1,6 +1,6 @@
 import container.registry
 import container.util
-import util
+import ci.util
 
 
 def filter_image_file(
@@ -18,7 +18,7 @@ def filter_image_file(
     [0] https://github.com/opencontainers/image-spec
     '''
     if not remove_files:
-        util.warning('no files to remove were specified - the output will remain unaltered')
+        ci.util.warning('no files to remove were specified - the output will remain unaltered')
 
     container.util.filter_container_image(
         image_file=in_file,

--- a/cli/gardener_ci/elastic.py
+++ b/cli/gardener_ci/elastic.py
@@ -17,11 +17,11 @@ import json
 
 import os
 import ccc.elasticsearch
-import util
+import ci.util
 
 
 def store(index: str, body: str, cfg_name: str):
-    elastic_cfg = util.ctx().cfg_factory().elasticsearch(cfg_name)
+    elastic_cfg = ci.util.ctx().cfg_factory().elasticsearch(cfg_name)
     elastic_client = ccc.elasticsearch.from_cfg(elasticsearch_cfg=elastic_cfg)
     json_body = json.loads(body)
 
@@ -33,11 +33,11 @@ def store(index: str, body: str, cfg_name: str):
 
 
 def store_files(index: str, files: [str], cfg_name: str):
-    elastic_cfg = util.ctx().cfg_factory().elasticsearch(cfg_name)
+    elastic_cfg = ci.util.ctx().cfg_factory().elasticsearch(cfg_name)
     elastic_client = ccc.elasticsearch.from_cfg(elasticsearch_cfg=elastic_cfg)
 
     for file in files:
-        util.existing_file(file)
+        ci.util.existing_file(file)
 
     for file in files:
         with open(file) as file_handle:
@@ -50,10 +50,10 @@ def store_files(index: str, files: [str], cfg_name: str):
 
 
 def store_bulk(file: str, cfg_name: str):
-    elastic_cfg = util.ctx().cfg_factory().elasticsearch(cfg_name)
+    elastic_cfg = ci.util.ctx().cfg_factory().elasticsearch(cfg_name)
     elastic_client = ccc.elasticsearch.from_cfg(elasticsearch_cfg=elastic_cfg)
 
-    util.existing_file(file)
+    ci.util.existing_file(file)
 
     with open(file) as file_handle:
         result = elastic_client.store_bulk(
@@ -62,7 +62,7 @@ def store_bulk(file: str, cfg_name: str):
         print(result)
 
 
-def store_dir(index: str, directory: util.CliHints.existing_dir(), cfg_name: str):
+def store_dir(index: str, directory: ci.util.CliHints.existing_dir(), cfg_name: str):
     json_files = list()
     for (dirpath, dirnames, filenames) in os.walk(directory):
         for file in filenames:

--- a/cli/gardener_ci/elastic.py
+++ b/cli/gardener_ci/elastic.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import json
-
 import os
+
 import ccc.elasticsearch
 import ci.util
 

--- a/cli/gardener_ci/githubutil.py
+++ b/cli/gardener_ci/githubutil.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import (
+from ci.util import (
     CliHint,
     ctx,
 )

--- a/cli/gardener_ci/landscape.py
+++ b/cli/gardener_ci/landscape.py
@@ -15,8 +15,8 @@
 import enum
 import os
 
-from ci.util import ctx
 from ci.util import (
+    ctx,
     existing_dir,
     info,
     which,

--- a/cli/gardener_ci/landscape.py
+++ b/cli/gardener_ci/landscape.py
@@ -15,8 +15,8 @@
 import enum
 import os
 
-from util import ctx
-from util import (
+from ci.util import ctx
+from ci.util import (
     existing_dir,
     info,
     which,

--- a/cli/gardener_ci/productutil.py
+++ b/cli/gardener_ci/productutil.py
@@ -19,7 +19,7 @@ import yaml
 import json
 
 import container.registry
-from util import CliHints, CliHint, parse_yaml_file, ctx, fail
+from ci.util import CliHints, CliHint, parse_yaml_file, ctx, fail
 from product.model import (
     Component,
     ComponentReference,

--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -16,7 +16,7 @@
 import bjoern
 
 import whd.server as whd_server
-import util
+import ci.util
 
 
 def start_whd(
@@ -25,7 +25,7 @@ def start_whd(
     production: bool=False,
     workers: int=4,
 ):
-    cfg_factory = util.ctx().cfg_factory()
+    cfg_factory = ci.util.ctx().cfg_factory()
     cfg_set = cfg_factory.cfg_set(cfg_set_name)
     webhook_dispatcher_cfg = cfg_set.webhook_dispatcher()
 

--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -15,8 +15,8 @@
 
 import bjoern
 
-import whd.server as whd_server
 import ci.util
+import whd.server as whd_server
 
 
 def start_whd(

--- a/concourse/client/__init__.py
+++ b/concourse/client/__init__.py
@@ -20,7 +20,7 @@ from urllib3.exceptions import InsecureRequestWarning
 
 import functools
 
-import util
+import ci.util
 from .api import (
     ConcourseApiV5,
 )
@@ -68,7 +68,7 @@ def from_cfg(concourse_cfg: ConcourseConfig, team_name: str, verify_ssl=False):
     Factory method to get Concourse API object
     '''
     base_url = concourse_cfg.ingress_url()
-    cfg_factory = util.ctx().cfg_factory()
+    cfg_factory = ci.util.ctx().cfg_factory()
     concourse_uam_cfg_name = concourse_cfg.concourse_uam_config()
     concourse_uam_cfg = cfg_factory.concourse_uam(concourse_uam_cfg_name)
     concourse_team = concourse_uam_cfg.team(team_name)

--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -35,7 +35,7 @@ from model.concourse import (
     ConcourseTeam,
 )
 from http_requests import AuthenticatedRequestBuilder
-from util import not_empty
+from ci.util import not_empty
 
 warnings.filterwarnings('ignore', 'Unverified HTTPS request is being made.*', InsecureRequestWarning)
 

--- a/concourse/client/model.py
+++ b/concourse/client/model.py
@@ -21,7 +21,7 @@ from urllib.parse import urlparse
 
 import sseclient
 
-from util import warning
+from ci.util import warning
 
 
 class SetPipelineResult(Enum):

--- a/concourse/client/routes.py
+++ b/concourse/client/routes.py
@@ -16,7 +16,7 @@
 from ensure import ensure_annotations
 from urllib.parse import urljoin
 
-import util
+import ci.util
 
 CONCOURSE_API_SUFFIX = 'api/v1'
 
@@ -56,7 +56,7 @@ class ConcourseApiRoutesBase(object):
         return self._api_url('teams', team, prefix_team=False)
 
     def login(self):
-        return util.urljoin(
+        return ci.util.urljoin(
             self.base_url,
             'sky',
             'token'

--- a/concourse/enumerator.py
+++ b/concourse/enumerator.py
@@ -24,7 +24,7 @@ import yaml
 
 from github3.exceptions import NotFoundError
 
-from util import (
+from ci.util import (
     parse_yaml_file,
     info,
     fail,

--- a/concourse/factory.py
+++ b/concourse/factory.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from itertools import chain
 import toposort
 
-from util import merge_dicts, not_none
+from ci.util import merge_dicts, not_none
 from model.base import ModelValidationError
 from concourse.model.step import (
     PipelineStep,

--- a/concourse/model/base.py
+++ b/concourse/model/base.py
@@ -18,7 +18,7 @@ from abc import abstractmethod
 from enum import Enum
 import typing
 
-import util
+import ci.util
 from model.base import(
     ModelValidationError,
     ModelValidationMixin,
@@ -43,7 +43,7 @@ class AttribSpecMixin(object):
         return set(AttributeSpec.required_attr_names(cls._attribute_specs()))
 
     def _apply_defaults(self, raw_dict):
-        self.raw = util.merge_dicts(
+        self.raw = ci.util.merge_dicts(
             self._defaults_dict(),
             raw_dict,
         )
@@ -51,7 +51,7 @@ class AttribSpecMixin(object):
 
 class ModelBase(AttribSpecMixin, ModelValidationMixin):
     def __init__(self, raw_dict: dict):
-        util.not_none(raw_dict)
+        ci.util.not_none(raw_dict)
 
         self._apply_defaults(raw_dict=raw_dict)
         self.custom_init(self.raw)
@@ -93,23 +93,23 @@ class AttributeSpec(object):
     @staticmethod
     def filter_attrs(attrs: 'typing.Iterable[AttributeSpec]', required: RequiredPolicy):
         if required:
-            util.check_type(required, RequiredPolicy)
+            ci.util.check_type(required, RequiredPolicy)
         else:
             # no filtering
             yield from attrs
 
         for attr in attrs:
-            util.check_type(attr, AttributeSpec)
+            ci.util.check_type(attr, AttributeSpec)
             if attr.required_policy() is required:
                 yield attr
 
     @staticmethod
     def select_name(attr):
-        util.check_type(attr, AttributeSpec)
+        ci.util.check_type(attr, AttributeSpec)
         return attr.name()
 
     def select_name_and_default(attr):
-        util.check_type(attr, AttributeSpec)
+        ci.util.check_type(attr, AttributeSpec)
         return attr.name(), attr.default_value()
 
     @staticmethod
@@ -144,8 +144,8 @@ class AttributeSpec(object):
         required=None,
         type=str,
     ):
-        self._name = util.check_type(name, str)
-        self._doc = util.check_type(doc, str)
+        self._name = ci.util.check_type(name, str)
+        self._doc = ci.util.check_type(doc, str)
         self._type = type
 
         # validate
@@ -181,8 +181,8 @@ class AttributeSpec(object):
 
 class Trait(ModelBase):
     def __init__(self, name: str, variant_name: str, raw_dict: dict):
-        self.name = util.not_none(name)
-        self.variant_name = util.not_none(variant_name)
+        self.name = ci.util.not_none(name)
+        self.variant_name = ci.util.not_none(variant_name)
         super().__init__(raw_dict=raw_dict)
 
     @abstractmethod
@@ -197,7 +197,7 @@ class TraitTransformer(object):
     name = None # subclasses must overwrite
 
     def __init__(self):
-        util.not_none(self.name)
+        ci.util.not_none(self.name)
 
     def inject_steps(self):
         return []

--- a/concourse/model/job.py
+++ b/concourse/model/job.py
@@ -19,7 +19,7 @@ from concourse.model.base import (
     ModelBase,
     select_attr,
 )
-from util import not_none
+from ci.util import not_none
 from concourse.model.resources import RepositoryConfig, ResourceIdentifier
 
 

--- a/concourse/model/resources.py
+++ b/concourse/model/resources.py
@@ -19,7 +19,7 @@ from concourse.model.base import (
     AttributeSpec,
     ModelBase
 )
-from util import not_none
+from ci.util import not_none
 
 
 def sane_env_var_name(name):

--- a/concourse/model/step.py
+++ b/concourse/model/step.py
@@ -18,7 +18,7 @@ import os
 import string
 import shlex
 
-import util
+import ci.util
 
 from concourse.model.base import (
     AttributeSpec,
@@ -185,7 +185,7 @@ class PipelineStep(ModelBase):
         *args,
         **kwargs
     ):
-        self.name = util.not_empty(name)
+        self.name = ci.util.not_empty(name)
         self.is_synthetic = is_synthetic
         self._script_type = script_type
         self._outputs_dict = {}
@@ -303,15 +303,15 @@ class PipelineStep(ModelBase):
         return self.inputs()[name]
 
     def add_input(self, name, variable_name):
-        util.not_none(name)
-        util.not_none(variable_name)
+        ci.util.not_none(name)
+        ci.util.not_none(variable_name)
 
         if name in self._inputs_dict:
             raise ValueError('input already exists: ' + str(name))
         self._inputs_dict[name] = variable_name
 
     def remove_input(self, name):
-        util.not_none(name)
+        ci.util.not_none(name)
 
         if not name in self._inputs_dict:
             raise ValueError('input does not exist: ' + str(name))
@@ -339,7 +339,7 @@ class PipelineStep(ModelBase):
         return self.raw['timeout']
 
     def set_timeout(self, duration_string: str):
-        util.not_empty(duration_string)
+        ci.util.not_empty(duration_string)
         self.raw['timeout'] = duration_string
 
     def retries(self):

--- a/concourse/model/traits/__init__.py
+++ b/concourse/model/traits/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import not_none
+from ci.util import not_none
 
 from concourse.model.base import ModelValidationError
 

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import not_none
+from ci.util import not_none
 
 from concourse.model.job import (
     JobVariant,

--- a/concourse/model/traits/options.py
+++ b/concourse/model/traits/options.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import not_none
+from ci.util import not_none
 from concourse.model.base import (
     AttributeSpec,
     Trait,

--- a/concourse/model/traits/publish.py
+++ b/concourse/model/traits/publish.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import typing
 
-from util import not_none
+from ci.util import not_none
 from model import NamedModelElement
 
 from concourse.model.job import (

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -23,7 +23,7 @@ import traceback
 
 import mako.template
 
-from util import (
+from ci.util import (
     warning,
     existing_dir,
     not_none,

--- a/concourse/steps/__init__.py
+++ b/concourse/steps/__init__.py
@@ -17,14 +17,14 @@ import os
 
 import mako.template
 
-import util
+import ci.util
 
 
 steps_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 def step_template(name):
-    step_file = util.existing_file(os.path.join(steps_dir, name + '.mako'))
+    step_file = ci.util.existing_file(os.path.join(steps_dir, name + '.mako'))
 
     return mako.template.Template(filename=step_file)
 

--- a/concourse/steps/alter_container_images.py
+++ b/concourse/steps/alter_container_images.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import container.util
 import ci.util
+import container.util
 
 
 def alter_image(

--- a/concourse/steps/alter_container_images.py
+++ b/concourse/steps/alter_container_images.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import container.util
-import util
+import ci.util
 
 
 def alter_image(
@@ -22,12 +22,12 @@ def alter_image(
     tgt_ref: str,
     filter_path_file: str,
 ):
-    util.not_none(src_ref)
-    util.not_none(tgt_ref)
+    ci.util.not_none(src_ref)
+    ci.util.not_none(tgt_ref)
     if src_ref == tgt_ref:
         raise ValueError(f'src and tgt must not be be equal: {src_ref} {tgt_ref}')
 
-    with open(util.existing_file(filter_path_file)) as f:
+    with open(ci.util.existing_file(filter_path_file)) as f:
         rm_paths = [
             p.strip() for p in f.readlines()
             if p.strip() and not p.strip().startswith('#')

--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -24,7 +24,7 @@ import yaml
 
 from product.model import ComponentDescriptor, Component, ContainerImage
 from product.util import ComponentDescriptorResolver
-from util import info, fail, parse_yaml_file, ctx
+from ci.util import info, fail, parse_yaml_file, ctx
 
 ${step_lib('component_descriptor')}
 

--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import util
+import ci.util
 from product.util import (
     ComponentResolver,
     ComponentDescriptorResolver,
@@ -29,7 +29,7 @@ def component_diff_since_last_release(
     component_descriptor,
     cfg_factory,
 ):
-    component = util.not_none(component_descriptor.component((component_name, component_version)))
+    component = ci.util.not_none(component_descriptor.component((component_name, component_version)))
 
     resolver = ComponentResolver(cfg_factory=cfg_factory)
     last_release_version = resolver.greatest_release_before(
@@ -38,10 +38,10 @@ def component_diff_since_last_release(
     )
 
     if not last_release_version:
-        util.warning('could not determine last release version')
+        ci.util.warning('could not determine last release version')
         return None
     last_release_version = str(last_release_version)
-    util.info('last released version: ' + str(last_release_version))
+    ci.util.info('last released version: ' + str(last_release_version))
 
     descriptor_resolver = ComponentDescriptorResolver(cfg_factory=cfg_factory)
     last_released_component_descriptor = descriptor_resolver.retrieve_descriptor(
@@ -52,7 +52,7 @@ def component_diff_since_last_release(
     )
 
     if not last_released_component:
-        util.fail(
+        ci.util.fail(
             f"Component '{component_name}' not found in the component "
             f"descriptor of the last release ({last_release_version})."
         )

--- a/concourse/steps/component_descriptor_util.py
+++ b/concourse/steps/component_descriptor_util.py
@@ -1,16 +1,16 @@
 import os
-import util
+import ci.util
 
 import product.model
 
 
 def parse_component_descriptor():
     component_descriptor_file = os.path.join(
-      util.check_env('COMPONENT_DESCRIPTOR_DIR'),
+      ci.util.check_env('COMPONENT_DESCRIPTOR_DIR'),
       'component_descriptor'
     )
 
     component_descriptor = product.model.ComponentDescriptor.from_dict(
-      raw_dict=util.parse_yaml_file(component_descriptor_file)
+      raw_dict=ci.util.parse_yaml_file(component_descriptor_file)
     )
     return component_descriptor

--- a/concourse/steps/component_descriptor_util.py
+++ b/concourse/steps/component_descriptor_util.py
@@ -1,5 +1,5 @@
-import os
 import ci.util
+import os
 
 import product.model
 

--- a/concourse/steps/draft_release.mako
+++ b/concourse/steps/draft_release.mako
@@ -12,7 +12,7 @@ version_operation = draft_release_trait._preprocess()
 import version
 import pathlib
 
-import util
+import ci.util
 
 from gitutil import GitHelper
 from github.release_notes.util import (
@@ -30,13 +30,13 @@ if '${version_operation}' != 'finalize':
         "Version-processing other than 'finalize' is not supported for draft release creation"
     )
 
-version_file = util.existing_file(pathlib.Path('${version_file}'))
+version_file = ci.util.existing_file(pathlib.Path('${version_file}'))
 processed_version = version.process_version(
     version_str=version_file.read_text().strip(),
     operation='${version_operation}',
 )
 
-github_cfg = util.ctx().cfg_factory().github('${github_cfg.name()}')
+github_cfg = ci.util.ctx().cfg_factory().github('${github_cfg.name()}')
 
 githubrepobranch = GitHubRepoBranch(
     github_config=github_cfg,
@@ -71,6 +71,6 @@ else:
     if not draft_release.body == release_notes_md:
         draft_release.edit(body=release_notes_md)
     else:
-        util.info('draft release notes are already up to date')
+        ci.util.info('draft release notes are already up to date')
 
 </%def>

--- a/concourse/steps/meta.py
+++ b/concourse/steps/meta.py
@@ -2,7 +2,7 @@ import json
 import os
 import uuid
 
-import util
+import ci.util
 
 import concourse.model.traits.meta
 
@@ -13,7 +13,7 @@ jobmetadata_filename='jobmetadata.json'
 
 def get_out_dir():
     return os.path.join(
-        util.check_env('CC_ROOT_DIR'),
+        ci.util.check_env('CC_ROOT_DIR'),
         concourse.model.traits.meta.META_INFO_DIR_NAME,
     )
 

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -31,8 +31,8 @@ import sys
 import os
 
 import ccc.github
-import github
 import ci.util
+import github
 import mailutil
 
 

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -32,11 +32,11 @@ import os
 
 import ccc.github
 import github
-import util
+import ci.util
 import mailutil
 
 
-from util import ctx
+from ci.util import ctx
 
 CC_ROOT_DIR = os.path.abspath('.')
 os.environ['CC_ROOT_DIR'] = CC_ROOT_DIR
@@ -51,7 +51,7 @@ meta_build_job_name = meta_vars_dict.get('build-job-name').strip()
 meta_resource_inconsistent = False
 if meta_build_job_name != env_build_job_name:
     meta_resource_inconsistent = True
-    util.warning(
+    ci.util.warning(
         'Inconsistent META resource. Job URL in email cannot be determined\n'
         f'Expected job name: {env_build_job_name}\n'
         f'Job name in META resource: {meta_build_job_name}'
@@ -61,9 +61,9 @@ concourse_api = from_cfg(cfg_set.concourse(), team_name=meta_vars_dict['build-te
 ## TODO: Replace with MAIN_REPO_DIR once it is available in synthetic steps
 path_to_main_repository = "${job_variant.main_repository().resource_name()}"
 
-util.info('Notification cfg: ${notification_cfg_name}')
-util.info('Triggering policy: ${triggering_policy}')
-util.info("Will notify: ${on_error_cfg.recipients()}")
+ci.util.info('Notification cfg: ${notification_cfg_name}')
+ci.util.info('Triggering policy: ${triggering_policy}')
+ci.util.info("Will notify: ${on_error_cfg.recipients()}")
 
 if not should_notify(
     NotificationTriggeringPolicy('${triggering_policy.value}'),
@@ -84,13 +84,13 @@ email_cfg = {
 }
 if os.path.isfile(notify_file):
 ## custom notification config found in error dir
-    notify_cfg = util.parse_yaml_file(notify_file)
+    notify_cfg = ci.util.parse_yaml_file(notify_file)
     email_cfg.update(notify_cfg.get('email', dict()))
     ## Convert elements of notify config to sets
     email_cfg['component_name_recipients'] = set(email_cfg.get('component_name_recipients', set()))
     email_cfg['recipients'] = set(email_cfg.get('recipients', set()))
     email_cfg['codeowner_files'] = set(email_cfg.get('codeowner_files', set()))
-    util.info(f'found notify.cfg - applying cfg: \n{notify_cfg}')
+    ci.util.info(f'found notify.cfg - applying cfg: \n{notify_cfg}')
 
 notify_cfg = {'email': email_cfg}
 
@@ -101,14 +101,14 @@ main_repo_github_api = ccc.github.github_api(main_repo_github_cfg)
 
 if 'component_diff_owners' in ${on_error_cfg.recipients()}:
     component_diff_path = os.path.join('component_descriptor_dir', 'dependencies.diff')
-    util.info('adding mail recipients from component diff since last release')
+    ci.util.info('adding mail recipients from component diff since last release')
     components = components_with_version_changes(component_diff_path)
     ## Recipient-address resolution from component names will be done at a later point
     email_cfg['component_name_recipients'] = email_cfg.get('component_name_recipients', set()) | set(components)
 
 if 'codeowners' in ${on_error_cfg.recipients()}:
     ## Add codeowners from main repository to recipients
-    util.info('adding codeowners from main repository as recipients')
+    ci.util.info('adding codeowners from main repository as recipients')
     recipients = set(
         mailutil.determine_local_repository_codeowners_recipients(
             github_api=main_repo_github_api,
@@ -119,7 +119,7 @@ if 'codeowners' in ${on_error_cfg.recipients()}:
 
 ## Also consider explicitly given CODEOWNERS files
 if email_cfg['codeowners_files']:
-    util.info("adding codeowners from explicitly configured 'CODEOWNERS' files")
+    ci.util.info("adding codeowners from explicitly configured 'CODEOWNERS' files")
     recipients = set(
         mailutil.determine_codeowner_file_recipients(
             github_api=main_repo_github_api,
@@ -129,12 +129,12 @@ if email_cfg['codeowners_files']:
     email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
 
 if 'email_addresses' in ${on_error_cfg.recipients()}:
-    util.info('adding excplicitly configured recipients')
+    ci.util.info('adding excplicitly configured recipients')
     recipients = set(${on_error_cfg.recipients().get('email_addresses',())})
     email_cfg['recipients'] = email_cfg.get('recipients', set()) | recipients
 
 if 'committers' in ${on_error_cfg.recipients()}:
-    util.info('adding committers of main repository to recipients')
+    ci.util.info('adding committers of main repository to recipients')
     recipients = set(mailutil.determine_head_commit_recipients(
             src_dirs=(path_to_main_repository,),
         ))

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -7,8 +7,8 @@ import concourse.util
 import os
 import traceback
 
-import mailutil
 import ci.util
+import mailutil
 
 
 def meta_vars():
@@ -95,9 +95,10 @@ def cfg_from_callback(
     callback_path,
     effective_cfg_file,
 ):
-    import subprocess
     import os
+    import subprocess
     import tempfile
+
     import ci.util
 
     tmp_file = tempfile.NamedTemporaryFile()

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -8,13 +8,13 @@ import os
 import traceback
 
 import mailutil
-import util
+import ci.util
 
 
 def meta_vars():
     build = concourse.util.find_own_running_build()
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    config_set = util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
+    config_set = ci.util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
     concourse_cfg = config_set.concourse()
     v = {
       'build-id': build.id(),
@@ -47,7 +47,7 @@ def determine_previous_build_status(v, cfg_set):
     try:
       build_number = int(v['build-name'])
       if build_number < 2:
-        util.info('this seems to be the first build - will notify')
+        ci.util.info('this seems to be the first build - will notify')
         return BuildStatus.SUCCEEDED
 
       previous_build = str(build_number - 1)
@@ -78,12 +78,12 @@ def should_notify(
     elif triggering_policy == NotificationTriggeringPolicy.ONLY_FIRST:
         previous_build_status = determine_previous_build_status(meta_vars, cfg_set)
         if not previous_build_status:
-          util.info('failed to determine previous build status - will notify')
+          ci.util.info('failed to determine previous build status - will notify')
           return True
 
         # assumption: current job failed
         if previous_build_status in (BuildStatus.FAILED, BuildStatus.ERRORED):
-          util.info('previous build was already broken - will not notify')
+          ci.util.info('previous build was already broken - will not notify')
           return False
         return True
     else:
@@ -98,7 +98,7 @@ def cfg_from_callback(
     import subprocess
     import os
     import tempfile
-    import util
+    import ci.util
 
     tmp_file = tempfile.NamedTemporaryFile()
     cb_env = os.environ.copy()
@@ -112,15 +112,15 @@ def cfg_from_callback(
         env=cb_env,
     )
 
-    return util.parse_yaml_file(tmp_file.name)
+    return ci.util.parse_yaml_file(tmp_file.name)
 
 
 def components_with_version_changes(component_diff_path: str):
   if not os.path.isfile(component_diff_path):
-    util.info('no component_diff found at: ' + str(component_diff_path))
+    ci.util.info('no component_diff found at: ' + str(component_diff_path))
     return set()
   else:
-    component_diff = util.parse_yaml_file(component_diff_path)
+    component_diff = ci.util.parse_yaml_file(component_diff_path)
     comp_names = component_diff.get('component_names_with_version_changes', set())
     return set(comp_names)
 

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -32,7 +32,7 @@ if has_component_descriptor_trait:
 release_callback_path = release_trait.release_callback_path()
 next_version_callback_path = release_trait.next_version_callback_path()
 %>
-import util
+import ci.util
 
 ${step_lib('release')}
 
@@ -42,7 +42,7 @@ with open('${version_file}') as f:
 repo_dir = existing_dir('${repo.resource_name()}')
 repository_branch = '${repo.branch()}'
 
-github_cfg = util.ctx().cfg_factory().github('${github_cfg.name()}')
+github_cfg = ci.util.ctx().cfg_factory().github('${github_cfg.name()}')
 github_repo_path = '${repo.repo_owner()}/${repo.repo_name()}'
 
 githubrepobranch = GitHubRepoBranch(

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -8,8 +8,8 @@ import typing
 
 from github3.exceptions import NotFoundError
 
-import util
-from util import (
+import ci.util
+from ci.util import (
     existing_file,
     existing_dir,
     not_empty,
@@ -108,10 +108,10 @@ class Transaction(object):
         ctx: TransactionContext,
         steps: typing.Iterable[TransactionalStep],
     ):
-        self._context = util.check_type(ctx, TransactionContext)
+        self._context = ci.util.check_type(ctx, TransactionContext)
         # validate type of args and set context
         for step in steps:
-            util.check_type(step, TransactionalStep)
+            ci.util.check_type(step, TransactionalStep)
             step.set_context(self._context)
         self._steps = steps
 

--- a/concourse/steps/rm_pr_label.mako
+++ b/concourse/steps/rm_pr_label.mako
@@ -12,7 +12,7 @@ main_repo = job_variant.main_repository()
 pr_id_path = main_repo.pr_id_path()
 %>
 % if require_label:
-from util import ctx, info, warning
+from ci.util import ctx, info, warning
 from github3.exceptions import NotFoundError
 import ccc.github
 

--- a/concourse/steps/scan_container_images.mako
+++ b/concourse/steps/scan_container_images.mako
@@ -21,11 +21,11 @@ import sys
 import tabulate
 import textwrap
 
+import ci.util
 import mailutil
 import product.model
 import product.util
 import protecode.util
-import ci.util
 
 from product.scanning import ProcessingMode
 

--- a/concourse/steps/scan_container_images.mako
+++ b/concourse/steps/scan_container_images.mako
@@ -25,7 +25,7 @@ import mailutil
 import product.model
 import product.util
 import protecode.util
-import util
+import ci.util
 
 from product.scanning import ProcessingMode
 
@@ -33,7 +33,7 @@ ${step_lib('scan_container_images')}
 ${step_lib('images')}
 ${step_lib('component_descriptor_util')}
 
-cfg_factory = util.ctx().cfg_factory()
+cfg_factory = ci.util.ctx().cfg_factory()
 cfg_set = cfg_factory.cfg_set("${cfg_set.name()}")
 
 component_descriptor = parse_component_descriptor()
@@ -93,12 +93,12 @@ image_references = [
   if filter_function(component, container_image)
 ]
 
-util.info('running virus scan for all container images')
+ci.util.info('running virus scan for all container images')
 malware_scan_results = [
   scan_result
   for scan_result in virus_scan_images(image_references, '${clam_av.clamav_cfg_name()}')
 ]
-util.info(f'{len(image_references)} image(s) scanned for virus signatures.')
+ci.util.info(f'{len(image_references)} image(s) scanned for virus signatures.')
 print(
   tabulate.tabulate(
     map(lambda dc: dataclasses.astuple(dc), malware_scan_results),
@@ -135,7 +135,7 @@ for email_recipient in email_recipients:
 % endif
 
   if not email_recipient.has_results():
-    util.info(f'skipping {email_recipient}, since there are not relevant results')
+    ci.util.info(f'skipping {email_recipient}, since there are not relevant results')
     continue
 
   body = email_recipient.mail_body()
@@ -145,7 +145,7 @@ for email_recipient in email_recipients:
   component_name = "${component_trait.component_name()}"
 
   if not email_addresses:
-    util.warning(f'no email addresses could be retrieved for {component_name}')
+    ci.util.warning(f'no email addresses could be retrieved for {component_name}')
     sys.exit(0)
 
   # notify about critical vulnerabilities
@@ -156,5 +156,5 @@ for email_recipient in email_recipients:
     subject=f'[Action Required] landscape {component_name} has critical Vulnerabilities',
     mimetype='html',
   )
-  util.info('sent notification emails to: ' + ','.join(email_addresses))
+  ci.util.info('sent notification emails to: ' + ','.join(email_addresses))
 </%def>

--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -19,12 +19,12 @@ from tempfile import TemporaryDirectory
 
 import semver
 
+import ci.util
 import ctx
 import github.util
 import gitutil
 import product.model
 import product.util
-import ci.util
 
 from concourse.model.traits.update_component_deps import (
     MergePolicy,

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -15,8 +15,8 @@
 
 import os
 
-import product.model
 import ci.util
+import product.model
 
 
 def current_product_descriptor():

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -16,14 +16,14 @@
 import os
 
 import product.model
-import util
+import ci.util
 
 
 def current_product_descriptor():
     component_descriptor = os.path.join(
-        util.check_env('COMPONENT_DESCRIPTOR_DIR'),
+        ci.util.check_env('COMPONENT_DESCRIPTOR_DIR'),
         'component_descriptor',
     )
     return product.model.ComponentDescriptor.from_dict(
-        util.parse_yaml_file(component_descriptor),
+        ci.util.parse_yaml_file(component_descriptor),
     )

--- a/concourse/steps/upload_container_images.mako
+++ b/concourse/steps/upload_container_images.mako
@@ -18,10 +18,10 @@ import functools
 import os
 import tabulate
 
+import ci.util
 import product.model
 import product.util
 import protecode.util
-import ci.util
 
 ${step_lib('images')}
 ${step_lib('upload_images')}

--- a/concourse/steps/upload_container_images.mako
+++ b/concourse/steps/upload_container_images.mako
@@ -21,13 +21,13 @@ import tabulate
 import product.model
 import product.util
 import protecode.util
-import util
+import ci.util
 
 ${step_lib('images')}
 ${step_lib('upload_images')}
 ${step_lib('component_descriptor_util')}
 
-cfg_factory = util.ctx().cfg_factory()
+cfg_factory = ci.util.ctx().cfg_factory()
 cfg_set = cfg_factory.cfg_set("${cfg_set.name()}")
 
 upload_registry_prefix = '${upload_registry_prefix}'
@@ -42,7 +42,7 @@ print(tabulate.tabulate(
 ))
 
 component_descriptor_path = os.path.join(
-  util.check_env('COMPONENT_DESCRIPTOR_DIR'),
+  ci.util.check_env('COMPONENT_DESCRIPTOR_DIR'),
   'component_descriptor'
 )
 

--- a/concourse/steps/upload_images.py
+++ b/concourse/steps/upload_images.py
@@ -1,7 +1,7 @@
 import tempfile
 
-import container.registry
 import ci.util
+import container.registry
 
 
 def republish_image(

--- a/concourse/steps/upload_images.py
+++ b/concourse/steps/upload_images.py
@@ -1,7 +1,7 @@
 import tempfile
 
 import container.registry
-import util
+import ci.util
 
 
 def republish_image(
@@ -13,7 +13,7 @@ def republish_image(
     if mangle:
         img_ref = img_ref.replace('.', '_')
 
-    tgt_ref = util.urljoin(tgt_prefix, ':'.join((img_ref, tag)))
+    tgt_ref = ci.util.urljoin(tgt_prefix, ':'.join((img_ref, tag)))
 
     with tempfile.NamedTemporaryFile() as tmp_file:
         container.registry.retrieve_container_image(image_reference=src_ref, outfileobj=tmp_file)

--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -41,10 +41,11 @@ def quote_str(value):
     raise ValueError
 
 %>
+import os
 import pathlib
+
 import ci.util
 import version
-import os
 
 version_file = ci.util.existing_file(pathlib.Path(${quote_str(path_to_repo_version_file)}))
 

--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -42,14 +42,14 @@ def quote_str(value):
 
 %>
 import pathlib
-import util
+import ci.util
 import version
 import os
 
-version_file = util.existing_file(pathlib.Path(${quote_str(path_to_repo_version_file)}))
+version_file = ci.util.existing_file(pathlib.Path(${quote_str(path_to_repo_version_file)}))
 
 if ${quote_str(version_operation)} == 'inject-commit-hash':
-  head_sha_file = util.existing_file(pathlib.Path(${quote_str(head_sha_file)}))
+  head_sha_file = ci.util.existing_file(pathlib.Path(${quote_str(head_sha_file)}))
   prerelease = 'dev-' + head_sha_file.read_text().strip()
 else:
   prerelease = ${quote_str(prerelease)}
@@ -59,12 +59,12 @@ processed_version = version.process_version(
     prerelease=prerelease,
     **${version_operation_kwargs},
 )
-util.info(f'effective version: {processed_version}')
+ci.util.info(f'effective version: {processed_version}')
 
 cc_version = '/metadata/VERSION'
 if os.path.isfile(cc_version):
   with open(cc_version) as f:
-    util.info(f'cc-utils version: {f.read()}')
+    ci.util.info(f'cc-utils version: {f.read()}')
 
 output_version_file = pathlib.Path(${quote_str(output_version_file)})
 legacy_version_file = pathlib.Path(${quote_str(legacy_version_file)})

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -2,7 +2,7 @@
 <%
 import itertools
 import os
-from util import urljoin
+from ci.util import urljoin
 from makoutil import indent_func
 from concourse.factory import DefinitionFactory
 from concourse.model.base import ScriptType
@@ -316,7 +316,7 @@ else:
         os.environ['CC_ROOT_DIR'] = CC_ROOT_DIR
         del os
         # init logging
-        import util; util.ctx().configure_default_logging(); del util
+        import ci.util; ci.util.ctx().configure_default_logging(); del ci.util
 % else:
   <% raise ValueError('unsupported script type') %>
 % endif

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -29,7 +29,7 @@ from model.concourse import (
 from model.webhook_dispatcher import (
     WebhookDispatcherDeploymentConfig,
 )
-from util import (
+from ci.util import (
     _running_on_ci,
     check_env,
     create_url_from_attributes,

--- a/container/registry.py
+++ b/container/registry.py
@@ -19,7 +19,7 @@ import logging
 import tarfile
 import tempfile
 
-import util
+import ci.util
 import model.container_registry
 from model.container_registry import Privileges
 
@@ -66,7 +66,7 @@ def _make_tag_if_digest(
 
 
 def normalise_image_reference(image_reference):
-  util.check_type(image_reference, str)
+  ci.util.check_type(image_reference, str)
   if '@' in image_reference:
     return image_reference
 
@@ -90,7 +90,7 @@ def normalise_image_reference(image_reference):
 
 
 def _parse_image_reference(image_reference):
-  util.check_type(image_reference, str)
+  ci.util.check_type(image_reference, str)
 
   if '@' in image_reference:
     name = docker_name.Digest(image_reference)
@@ -102,7 +102,7 @@ def _parse_image_reference(image_reference):
 
 @functools.lru_cache()
 def _credentials(image_reference: str, privileges:Privileges=None):
-    util.check_type(image_reference, str)
+    ci.util.check_type(image_reference, str)
     registry_cfg = model.container_registry.find_config(image_reference, privileges)
     if not registry_cfg:
         return None
@@ -144,7 +144,7 @@ def _mk_credentials(image_reference, privileges: Privileges=None):
 
     return creds
   except Exception as e:
-    util.fail(f'Error resolving credentials for {image_reference}: {e}')
+    ci.util.fail(f'Error resolving credentials for {image_reference}: {e}')
 
 
 def _image_exists(image_reference: str) -> bool:
@@ -170,9 +170,9 @@ def _image_exists(image_reference: str) -> bool:
 
 
 def _push_image(image_reference: str, image_file: str, threads=8):
-  import util
-  util.not_none(image_reference)
-  util.existing_file(image_file)
+  import ci.util
+  ci.util.not_none(image_reference)
+  ci.util.existing_file(image_file)
 
   transport = _mk_transport()
 
@@ -202,8 +202,8 @@ def _push_image(image_reference: str, image_file: str, threads=8):
 
 
 def _pull_image(image_reference: str, outfileobj=None):
-  import util
-  util.not_none(image_reference)
+  import ci.util
+  ci.util.not_none(image_reference)
 
   transport = _mk_transport()
 
@@ -225,7 +225,7 @@ def _pull_image(image_reference: str, outfileobj=None):
     # if outfile is given, we must use it instead of an ano
     outfileobj = outfileobj if outfileobj else tempfile.TemporaryFile()
     with tarfile.open(fileobj=outfileobj, mode='w:') as tar:
-      util.verbose(f'Pulling manifest list from {image_reference}..')
+      ci.util.verbose(f'Pulling manifest list from {image_reference}..')
       with image_list.FromRegistry(image_reference, creds, transport) as img_list:
         if img_list.exists():
           platform = image_list.Platform({
@@ -238,17 +238,17 @@ def _pull_image(image_reference: str, outfileobj=None):
             return outfileobj
           # pytype: enable=wrong-arg-types
 
-      util.info(f'Pulling v2.2 image from {image_reference}..')
+      ci.util.info(f'Pulling v2.2 image from {image_reference}..')
       with v2_2_image.FromRegistry(image_reference, creds, transport, accept) as v2_2_img:
         if v2_2_img.exists():
           save.tarball(_make_tag_if_digest(image_reference), v2_2_img, tar)
           return outfileobj
 
-      util.info(f'Pulling v2 image from {image_reference}..')
+      ci.util.info(f'Pulling v2 image from {image_reference}..')
       with v2_image.FromRegistry(image_reference, creds, transport) as v2_img:
         with v2_compat.V22FromV2(v2_img) as v2_2_img:
           save.tarball(_make_tag_if_digest(image_reference), v2_2_img, tar)
           return outfileobj
   except Exception as e:
     outfileobj.close()
-    util.fail(f'Error pulling and saving image {image_reference}: {e}')
+    ci.util.fail(f'Error pulling and saving image {image_reference}: {e}')

--- a/container/util.py
+++ b/container/util.py
@@ -22,7 +22,7 @@ import tempfile
 
 import container.model
 import container.registry
-import util
+import ci.util
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ def filter_container_image(
     out_file,
     remove_entries,
 ):
-    util.existing_file(image_file)
+    ci.util.existing_file(image_file)
     if not remove_entries:
         raise ValueError('remove_entries must not be empty')
     # allow absolute paths

--- a/container/util.py
+++ b/container/util.py
@@ -20,9 +20,9 @@ import logging
 import tarfile
 import tempfile
 
+import ci.util
 import container.model
 import container.registry
-import ci.util
 
 logger = logging.getLogger(__name__)
 

--- a/ctx.py
+++ b/ctx.py
@@ -19,7 +19,7 @@ import os
 
 from pathlib import Path
 
-import util
+import ci.util
 
 from model.base import ModelBase
 '''
@@ -35,7 +35,7 @@ class ConfigBase(ModelBase):
         super().__init__(raw_dict={})
 
     def _add_config_source(self, config: dict):
-        self.raw = util.merge_dicts(self.raw, config)
+        self.raw = ci.util.merge_dicts(self.raw, config)
 
 
 class ContextConfig(ConfigBase):
@@ -80,7 +80,7 @@ def load_config_from_env():
 def load_config_from_user_home():
     config_file = Path.home() / '.cc-utils.cfg'
     if config_file.is_file():
-        return util.parse_yaml_file(config_file)
+        return ci.util.parse_yaml_file(config_file)
     return {}
 
 
@@ -98,9 +98,9 @@ def add_config_source(config_source: dict):
 def load_config():
     home_config = load_config_from_user_home()
     env_config = load_config_from_env()
-    merged = util.merge_dicts(home_config, env_config)
+    merged = ci.util.merge_dicts(home_config, env_config)
     cli_cfg = load_config_from_args()
-    merged = util.merge_dicts(merged, cli_cfg)
+    merged = ci.util.merge_dicts(merged, cli_cfg)
     add_config_source(merged)
 
 
@@ -124,7 +124,7 @@ def _cfg_factory_from_dir():
     if Config.CONTEXT.value.config_dir() is None:
         return None
 
-    from util import existing_dir
+    from ci.util import existing_dir
     cfg_dir = existing_dir(Config.CONTEXT.value.config_dir())
 
     from model import ConfigFactory
@@ -161,7 +161,7 @@ def _cfg_factory_from_secrets_server():
 
 @functools.lru_cache()
 def cfg_factory():
-    from util import fail
+    from ci.util import fail
 
     factory = _cfg_factory_from_dir()
     # fallback to secrets-server

--- a/doc/lib/attributes.py
+++ b/doc/lib/attributes.py
@@ -21,7 +21,7 @@ import enum
 
 
 import concourse.model.base as base_model
-import util
+import ci.util
 
 
 # add repository root to pythonpath
@@ -36,7 +36,7 @@ class AttributesDocumentation(object):
     ):
         self._model_element_type = model_element_type
         self._child_elements = []
-        self._prefix = util.check_type(prefix, str)
+        self._prefix = ci.util.check_type(prefix, str)
 
     def add_child(
         self,

--- a/doc/lib/attributes.py
+++ b/doc/lib/attributes.py
@@ -20,8 +20,8 @@ import typing
 import enum
 
 
-import concourse.model.base as base_model
 import ci.util
+import concourse.model.base as base_model
 
 
 # add repository root to pythonpath

--- a/github/codeowners.py
+++ b/github/codeowners.py
@@ -18,7 +18,7 @@ from github3.exceptions import NotFoundError
 
 from github.util import GitHubRepositoryHelper
 
-from util import existing_dir, existing_file, not_none, warning
+from ci.util import existing_dir, existing_file, not_none, warning
 
 
 class CodeownersEnumerator(object):

--- a/github/release_notes/model.py
+++ b/github/release_notes/model.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from pydash import _
 
 from product.model import ComponentName
-from util import check_type
+from ci.util import check_type
 
 
 @dataclass

--- a/github/release_notes/util.py
+++ b/github/release_notes/util.py
@@ -32,7 +32,7 @@ from github.release_notes.model import (
 )
 from github.release_notes.renderer import MarkdownRenderer
 from gitutil import GitHelper
-from util import info, warning, fail, verbose, ctx
+from ci.util import info, warning, fail, verbose, ctx
 from product.model import ComponentName
 from model.base import ModelValidationError
 from slackclient.util import SlackHelper

--- a/github/util.py
+++ b/github/util.py
@@ -302,7 +302,9 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
             decoded_contents = contents.decoded.decode('utf-8')
             if decoded_contents == file_contents:
                 # Nothing to do
-                return ci.util.info('Repository file contents are identical to passed file contents.')
+                return ci.util.info(
+                    'Repository file contents are identical to passed file contents.'
+                )
             else:
                 response = contents.update(
                     message=commit_message,
@@ -582,25 +584,18 @@ def _add_user_to_team(
     organization = github.organization(organization_name)
     team = _retrieve_team_by_name_or_none(organization, team_name)
     if not team:
-        ci.util.fail("Team {name} does not exist".format(name=team_name))
+        ci.util.fail(f"Team '{team_name}' does not exist")
 
     if team.is_member(user_name):
-        ci.util.verbose("{username} is already assigned to team {teamname}".format(
-            username=user_name,
-            teamname=team_name
-        ))
+        ci.util.verbose(f"'{user_name}' is already assigned to team '{team_name}'")
         return
 
     if team.add_member(username=user_name):
-        ci.util.info("Added {username} to team {teamname}".format(
-            username=user_name,
-            teamname=team_name
-        ))
+        ci.util.info(f"Added '{user_name}' to team '{team_name}'")
     else:
-        ci.util.fail("Could not add {username} to team {teamname}. Check for missing privileges".format(
-            username=user_name,
-            teamname=team_name
-        ))
+        ci.util.fail(
+            f"Could not add '{user_name}' to team '{team_name}'. Check for missing privileges"
+        )
 
 
 def _add_all_repos_to_team(

--- a/gitutil.py
+++ b/gitutil.py
@@ -24,7 +24,7 @@ import git
 import git.objects.util
 
 from github.util import GitHubRepoBranch
-from util import not_empty, not_none, existing_dir, fail, info, random_str, urljoin
+from ci.util import not_empty, not_none, existing_dir, fail, info, random_str, urljoin
 from model.github import (
     GithubConfig,
     Protocol,

--- a/http_requests.py
+++ b/http_requests.py
@@ -20,7 +20,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from urllib3.util.retry import Retry
 
-from util import warning
+from ci.util import warning
 
 
 class LoggingRetry(Retry):

--- a/integrationtest.py
+++ b/integrationtest.py
@@ -21,7 +21,7 @@ from github.util import (
     GitHubRepositoryHelper,
     GitHubRepoBranch,
 )
-from util import fail, info
+from ci.util import fail, info
 from model import ConfigFactory
 from concourse.replicator import Renderer, ConcourseDeployer, DeployStatus
 from concourse.enumerator import (

--- a/kube/ctx.py
+++ b/kube/ctx.py
@@ -19,7 +19,7 @@ import kubernetes.client
 from kubernetes import config, client
 from kubernetes.config.kube_config import KubeConfigLoader
 
-from util import ctx as global_ctx, fail, existing_file, not_none
+from ci.util import ctx as global_ctx, fail, existing_file, not_none
 from kube.helper import (
     KubernetesConfigMapHelper,
     KubernetesSecretHelper,

--- a/kube/helper.py
+++ b/kube/helper.py
@@ -28,7 +28,7 @@ from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 from ensure import ensure_annotations
 
-from util import info, not_empty, not_none, fail
+from ci.util import info, not_empty, not_none, fail
 
 
 class KubernetesSecretHelper(object):

--- a/landscape_setup/clamav.py
+++ b/landscape_setup/clamav.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import os
 
-import util
+import ci.util
 import gitutil
 
 from tempfile import TemporaryDirectory
@@ -30,7 +30,7 @@ def deploy_clam_av(
     clamav_cfg_name,
     kubernetes_cfg_name,
 ):
-    cfg_factory = util.ctx().cfg_factory()
+    cfg_factory = ci.util.ctx().cfg_factory()
     clamav_config = cfg_factory.clamav(clamav_cfg_name)
     kubernetes_config = cfg_factory.kubernetes(kubernetes_cfg_name)
     clamav_deployment_name = clamav_config.namespace()
@@ -52,7 +52,7 @@ def deploy_clam_av(
 
 
 def create_clamav_helm_values(clamav_cfg_name):
-    cfg_factory = util.ctx().cfg_factory()
+    cfg_factory = ci.util.ctx().cfg_factory()
     clamav_config = cfg_factory.clamav(clamav_cfg_name)
     clamav_image_config = clamav_config.clamav_image_config()
     freshclam_image_config = clamav_config.freshclam_image_config()

--- a/landscape_setup/concourse.py
+++ b/landscape_setup/concourse.py
@@ -48,7 +48,7 @@ from model.container_registry import (
 from model.proxy import(
     ProxyConfig
 )
-from util import (
+from ci.util import (
     ctx as global_ctx,
     not_empty,
     not_none,

--- a/landscape_setup/monitoring.py
+++ b/landscape_setup/monitoring.py
@@ -43,7 +43,7 @@ from model.monitoring import (
 from model.concourse import (
     ConcourseConfig,
 )
-from util import (
+from ci.util import (
     info,
 )
 from .utils import(

--- a/landscape_setup/utils.py
+++ b/landscape_setup/utils.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from passlib.apache import HtpasswdFile
 
 from landscape_setup import kube_ctx
-from util import (
+from ci.util import (
     not_none,
     not_empty,
     fail,

--- a/landscape_setup/whd.py
+++ b/landscape_setup/whd.py
@@ -29,7 +29,7 @@ from model import (
 from model.webhook_dispatcher import (
     WebhookDispatcherDeploymentConfig
 )
-from util import (
+from ci.util import (
     ctx as global_ctx,
     not_empty,
     info,

--- a/mailutil.py
+++ b/mailutil.py
@@ -18,7 +18,7 @@ import smtplib
 import typing
 
 from model.email import EmailConfig
-from util import (
+from ci.util import (
     existing_dir,
     not_empty,
     not_none,

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -25,7 +25,7 @@ from model.base import (
     ModelValidationError,
     NamedModelElement,
 )
-from util import (
+from ci.util import (
     existing_dir,
     not_empty,
     not_none,

--- a/model/base.py
+++ b/model/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-import util
+import ci.util
 
 
 class ModelValidationError(ValueError):
@@ -75,7 +75,7 @@ class ModelDefaultsMixin(object):
         return {}
 
     def _apply_defaults(self, raw_dict):
-        self.raw = util.merge_dicts(
+        self.raw = ci.util.merge_dicts(
             self._defaults_dict(),
             raw_dict,
         )
@@ -92,7 +92,7 @@ class ModelBase(ModelValidationMixin, ModelDefaultsMixin):
     '''
 
     def __init__(self, raw_dict):
-        self.raw = util.not_none(raw_dict)
+        self.raw = ci.util.not_none(raw_dict)
 
     def __str__(self):
         return '{c} {a}'.format(
@@ -103,7 +103,7 @@ class ModelBase(ModelValidationMixin, ModelDefaultsMixin):
 
 class NamedModelElement(ModelBase):
     def __init__(self, name, raw_dict, *args, **kwargs):
-        self._name = util.not_none(name)
+        self._name = ci.util.not_none(name)
         super().__init__(raw_dict=raw_dict, *args, **kwargs)
 
     def _optional_attributes(self):

--- a/model/container_registry.py
+++ b/model/container_registry.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import enum
+
 import ci.util
 
 from model.base import (

--- a/model/container_registry.py
+++ b/model/container_registry.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import enum
-import util
+import ci.util
 
 from model.base import (
     BasicCredentials,
@@ -22,7 +22,7 @@ from model.base import (
     ModelDefaultsMixin,
 )
 
-from util import check_type
+from ci.util import check_type
 
 
 class Privileges(enum.Enum):
@@ -107,8 +107,8 @@ class GcrCredentials(BasicCredentials):
 
 
 def find_config(image_reference: str, privileges:Privileges=None) -> 'GcrCredentials':
-    util.check_type(image_reference, str)
-    cfg_factory = util.ctx().cfg_factory()
+    ci.util.check_type(image_reference, str)
+    cfg_factory = ci.util.ctx().cfg_factory()
 
     matching_cfgs = [
         cfg for cfg in

--- a/product/model.py
+++ b/product/model.py
@@ -20,7 +20,7 @@ from enum import Enum
 
 from model.base import ModelBase, ModelValidationError
 from protecode.model import AnalysisResult
-from util import not_none, urljoin, check_type
+from ci.util import not_none, urljoin, check_type
 
 #############################################################################
 ## product descriptor model

--- a/product/scanning.py
+++ b/product/scanning.py
@@ -26,7 +26,7 @@ from concourse.model.base import (
     AttribSpecMixin,
     AttributeSpec,
 )
-from util import not_none, warning, check_type, info
+from ci.util import not_none, warning, check_type, info
 from container.registry import retrieve_container_image
 from .model import ContainerImage, Component, UploadResult, UploadStatus
 

--- a/product/util.py
+++ b/product/util.py
@@ -26,7 +26,7 @@ import yaml
 import ccc.github
 import version
 from github.util import GitHubRepositoryHelper
-from util import not_none, check_type, FluentIterable
+from ci.util import not_none, check_type, FluentIterable
 from .model import (
     COMPONENT_DESCRIPTOR_ASSET_NAME,
     Component,

--- a/protecode/client.py
+++ b/protecode/client.py
@@ -21,7 +21,7 @@ from typing import List
 
 import requests
 
-from util import not_empty, not_none, none, urljoin
+from ci.util import not_empty, not_none, none, urljoin
 from http_requests import check_http_code, mount_default_adapter
 from .model import (
     AnalysisResult,

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -24,7 +24,7 @@ import container.registry
 import protecode.client
 import product.util
 from product.scanning import ProtecodeUtil, ProcessingMode
-from util import info, warning, verbose, error, success, urljoin
+from ci.util import info, warning, verbose, error, success, urljoin
 from product.model import (
     ComponentDescriptor,
     UploadResult,

--- a/slackclient/util.py
+++ b/slackclient/util.py
@@ -15,7 +15,7 @@
 
 import slack
 
-from util import info, warning
+from ci.util import info, warning
 from model.slack import SlackConfig
 
 

--- a/test/kubeutil_test.py
+++ b/test/kubeutil_test.py
@@ -21,7 +21,7 @@ import os
 
 from test._test_utils import capture_out
 import kube.ctx
-from util import Failure
+from ci.util import Failure
 
 kube_ctx = kube.ctx.Ctx()
 

--- a/test/model/factory_test.py
+++ b/test/model/factory_test.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from tempfile import TemporaryDirectory
 
 import model
-from util import Failure
+from ci.util import Failure
 from model import ConfigFactory
 
 

--- a/version.py
+++ b/version.py
@@ -23,7 +23,7 @@ from typing import (
     Set,
 )
 
-import util
+import ci.util
 
 own_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(own_dir, os.path.pardir))
@@ -145,6 +145,6 @@ def is_semver_parseable(version_string: str):
     try:
         semver.parse_version_info(version_string)
     except ValueError:
-        util.verbose(f"Could not parse '{version_string}' as semver version")
+        ci.util.verbose(f"Could not parse '{version_string}' as semver version")
         return False
     return True

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -33,7 +33,7 @@ from github.util import GitHubRepositoryHelper
 from .pipelines import update_repository_pipelines
 import ccc
 import concourse.client
-import util
+import ci.util
 
 
 class GithubWebhookDispatcher(object):
@@ -44,7 +44,7 @@ class GithubWebhookDispatcher(object):
     ):
         self.cfg_set = cfg_set
         self.whd_cfg = whd_cfg
-        self.cfg_factory = util.ctx().cfg_factory()
+        self.cfg_factory = ci.util.ctx().cfg_factory()
 
     @functools.lru_cache()
     def concourse_clients(self):

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -32,8 +32,8 @@ from github.util import GitHubRepositoryHelper
 
 from .pipelines import update_repository_pipelines
 import ccc
-import concourse.client
 import ci.util
+import concourse.client
 
 
 class GithubWebhookDispatcher(object):


### PR DESCRIPTION
changes all imports from util to the new location, ci.util.

Also:
- cleanup two instances of duplicate `from util import ` instances
- reorder imports where touched
- shorten line lengths where they grew beyond 100 characters by the refactoring. 