### PR TITLE
change attribute naming for alicloud to use underscore case

### DIFF
--- a/model/alicloud.py
+++ b/model/alicloud.py
@@ -23,10 +23,10 @@ class AlicloudConfig(NamedModelElement):
         return self.raw.get('region')
 
     def access_key_id(self):
-        return self.raw.get('accessKeyId')
+        return self.raw.get('access_key_id')
 
     def access_key_secret(self):
-        return self.raw.get('accessKeySecret')
+        return self.raw.get('access_key_secret')
 
     def _required_attributes(self):
         return ['region', 'access_key_id', 'access_key_secret']


### PR DESCRIPTION
align naming conventions with other models and fix pipeline failure.