### PR TITLE
full qualified image name as upload name for protocode

### DIFF
--- a/product/model.py
+++ b/product/model.py
@@ -282,6 +282,9 @@ class ContainerImage(ContainerImageReference):
     def image_reference(self):
         return self.raw.get('image_reference')
 
+    def image_name(self):
+        return self.raw.get('name')
+
     def validate(self):
         img_ref = check_type(self.image_reference(), str)
         # XXX this is an incomplete validation that will only detect some obvious errors,

--- a/product/scanning.py
+++ b/product/scanning.py
@@ -170,7 +170,7 @@ class ProtecodeUtil(object):
     def _upload_name(self, container_image, component):
         image_reference = container_image.image_reference()
         image_path, image_tag = image_reference.split(':')
-        image_name = image_path.split('/')[-1]
+        image_name = container_image.image_name()
         return '{i}_{v}_{c}'.format(
             i=image_name,
             v=image_tag,


### PR DESCRIPTION
The same image can have different image names. When uploading such an image it overrides existing images in protocode. To prevent this, the full qualified image name is used.
