### PR TITLE
Add status-badges for our existing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Continuous Integration utils for 'gardener' project
 
+![tests](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-head-update-job/badge?title=tests)
+![release](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-release_job_image-job/badge?title=build)
+
 ## What is it
 
 `cc-utils` is a collection of re-usable utils intended to be used in the


### PR DESCRIPTION
Initial pr to add a minimal set of badges to our readme, i.e.: ![tests](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-head-update-job/badge?title=tests) ![release](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-release_job_image-job/badge?title=build)

If we'd like to continue/expand using Concourse's badge I'd suggest to split our jobs into `lint`, `test` and `generate documentation` and add badges for each. Although Concourse's badge-feature currently fails to properly handle badge-text that just a little bit longer than the default "build", e.g.:

![tests](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-head-update-job/badge?title=tests) &nbsp;&nbsp; versus &nbsp;&nbsp; ![tests](https://concourse.ci.infra.gardener.cloud/api/v1/teams/gardener/pipelines/cc-utils-master/jobs/master-head-update-job/badge?title=documentation)