### PR TITLE
Fix release notes

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -557,6 +557,7 @@ class PublishReleaseNotesStep(TransactionalStep):
             github_cfg=self.githubrepobranch.github_config(),
             repo_dir=self.repo_dir,
             github_helper=self.github_helper,
+            release_version=self.release_version,
             repository_branch=self.githubrepobranch.branch(),
         )
         release_notes_md = release_notes.to_markdown()

--- a/gitutil.py
+++ b/gitutil.py
@@ -189,6 +189,11 @@ class GitHelper(object):
     def rebase(self, commit_ish: str):
         self.repo.git.rebase('--quiet', commit_ish)
 
+    def fetch_tags(self):
+        with self._authenticated_remote() as (cmd_env, remote):
+            with remote.repo.git.custom_environment(**cmd_env):
+                remote.fetch('--tags')
+
     def fetch_head(self, ref: str):
         with self._authenticated_remote() as (cmd_env, remote):
             with remote.repo.git.custom_environment(**cmd_env):


### PR DESCRIPTION
With the latest change to the release trait release notes are not correctly processed. This happens because the tagged commits are not directly reachable from master anymore. Thus all release notes since the most recent release commit on the release-branch are always fetched.

This PRaims to fix this by considering the parents of the release-commits (who are still on the release branch).