### PR TITLE
Refactor kubernetes-python-client usage

### DIFF
--- a/ccc/kubernetes.py
+++ b/ccc/kubernetes.py
@@ -55,26 +55,26 @@ class KubernetesClient:
     def get_cluster_version_info(self):
         return kubernetes.client.VersionApi(self.api_client).get_code()
 
-    def secret_helper(self) -> 'KubernetesSecretHelper':
+    def secret_helper(self) -> KubernetesSecretHelper:
         return KubernetesSecretHelper(kubernetes.client.CoreV1Api(self.api_client))
 
-    def service_account_helper(self) -> 'KubernetesServiceAccountHelper':
+    def service_account_helper(self) -> KubernetesServiceAccountHelper:
         return KubernetesServiceAccountHelper(kubernetes.client.CoreV1Api(self.api_client))
 
-    def namespace_helper(self) -> 'KubernetesNamespaceHelper':
+    def namespace_helper(self) -> KubernetesNamespaceHelper:
         return KubernetesNamespaceHelper(kubernetes.client.CoreV1Api(self.api_client))
 
-    def service_helper(self) -> 'KubernetesServiceHelper':
+    def service_helper(self) -> KubernetesServiceHelper:
         return KubernetesServiceHelper(kubernetes.client.CoreV1Api(self.api_client))
 
-    def deployment_helper(self) -> 'KubernetesDeploymentHelper':
+    def deployment_helper(self) -> KubernetesDeploymentHelper:
         return KubernetesDeploymentHelper(kubernetes.client.AppsV1Api(self.api_client))
 
-    def ingress_helper(self) -> 'KubernetesIngressHelper':
+    def ingress_helper(self) -> KubernetesIngressHelper:
         return KubernetesIngressHelper(kubernetes.client.ExtensionsV1beta1Api(self.api_client))
 
-    def pod_helper(self) -> 'KubernetesPodHelper':
+    def pod_helper(self) -> KubernetesPodHelper:
         return KubernetesPodHelper(kubernetes.client.CoreV1Api(self.api_client))
 
-    def config_map_helper(self) -> 'KubernetesConfigMapHelper':
+    def config_map_helper(self) -> KubernetesConfigMapHelper:
         return KubernetesConfigMapHelper(kubernetes.client.CoreV1Api(self.api_client))

--- a/cli/gardener_ci/landscape.py
+++ b/cli/gardener_ci/landscape.py
@@ -23,7 +23,6 @@ from ci.util import (
     CliHints,
     CliHint,
 )
-from landscape_setup import kube_ctx
 from landscape_setup.utils import (
     ensure_cluster_version,
     ensure_helm_setup,
@@ -100,7 +99,6 @@ def deploy_or_upgrade_landscape(
     # Set the global kubernetes cluster context to the cluster specified in the ConcourseConfig
     kubernetes_config_name = concourse_cfg.kubernetes_cluster_config()
     kubernetes_cfg = cfg_factory.kubernetes(kubernetes_config_name)
-    kube_ctx.set_kubecfg(kubernetes_cfg.kubeconfig())
     ensure_cluster_version(kubernetes_cfg)
 
     if LandscapeComponent.SECRETS_SERVER in components:

--- a/kube/client.py
+++ b/kube/client.py
@@ -1,0 +1,80 @@
+import os
+
+import yaml
+
+import kubernetes.client
+from kubernetes.config.kube_config import KubeConfigLoader
+
+from ci.util import (
+    ctx as global_ctx,
+    existing_file,
+    fail,
+    not_none,
+)
+
+from kube.helper import (
+    KubernetesConfigMapHelper,
+    KubernetesSecretHelper,
+    KubernetesServiceAccountHelper,
+    KubernetesNamespaceHelper,
+    KubernetesServiceHelper,
+    KubernetesDeploymentHelper,
+    KubernetesIngressHelper,
+    KubernetesPodHelper,
+)
+
+
+class KubernetesClient:
+    def __init__(self, kubeconfig_dict:dict = None):
+        if not kubeconfig_dict:
+            kubeconfig_dict = self._get_kubecfg_from_ctx()
+        config = self._config_from_kubeconfig_dict(kubeconfig_dict)
+        self.api_client = kubernetes.client.ApiClient(configuration=config)
+
+    def _get_kubecfg_from_ctx(self):
+        kubeconfig = os.environ.get('KUBECONFIG', None)
+        args = global_ctx().args
+        if args and hasattr(args, 'kubeconfig') and args.kubeconfig:
+            kubeconfig = args.kubeconfig
+
+        if not kubeconfig:
+            fail("Unable to determine kubeconfig from 'KUBECONFIG' env-var or args.")
+
+        kubeconfig = existing_file(kubeconfig)
+
+        with open(kubeconfig, 'r') as kubeconfig_file:
+            return yaml.safe_load(kubeconfig_file.read())
+
+    def _config_from_kubeconfig_dict(self, kubeconfig_dict):
+        not_none(kubeconfig_dict)
+        config = kubernetes.client.Configuration()
+        cfg_loader = KubeConfigLoader(dict(kubeconfig_dict))
+        cfg_loader.load_and_set(config)
+        return config
+
+    def get_cluster_version_info(self):
+        return kubernetes.client.VersionApi(self.api_client).get_code()
+
+    def secret_helper(self) -> 'KubernetesSecretHelper':
+        return KubernetesSecretHelper(kubernetes.client.CoreV1Api(self.api_client))
+
+    def service_account_helper(self) -> 'KubernetesServiceAccountHelper':
+        return KubernetesServiceAccountHelper(kubernetes.client.CoreV1Api(self.api_client))
+
+    def namespace_helper(self) -> 'KubernetesNamespaceHelper':
+        return KubernetesNamespaceHelper(kubernetes.client.CoreV1Api(self.api_client))
+
+    def service_helper(self) -> 'KubernetesServiceHelper':
+        return KubernetesServiceHelper(kubernetes.client.CoreV1Api(self.api_client))
+
+    def deployment_helper(self) -> 'KubernetesDeploymentHelper':
+        return KubernetesDeploymentHelper(kubernetes.client.AppsV1Api(self.api_client))
+
+    def ingress_helper(self) -> 'KubernetesIngressHelper':
+        return KubernetesIngressHelper(kubernetes.client.ExtensionsV1beta1Api(self.api_client))
+
+    def pod_helper(self) -> 'KubernetesPodHelper':
+        return KubernetesPodHelper(kubernetes.client.CoreV1Api(self.api_client))
+
+    def config_map_helper(self) -> 'KubernetesConfigMapHelper':
+        return KubernetesConfigMapHelper(kubernetes.client.CoreV1Api(self.api_client))

--- a/kube/ctx.py
+++ b/kube/ctx.py
@@ -34,7 +34,7 @@ from kube.helper import (
 
 
 @deprecated.deprecated(
-    reason='kube.ctx.Ctx was refactored. Please use kube.client.KubernetesClient instead'
+    reason='kube.ctx.Ctx was refactored. Please use ccc.kubernetes.KubernetesClient instead'
 )
 class Ctx(object):
     '''

--- a/kube/ctx.py
+++ b/kube/ctx.py
@@ -15,6 +15,7 @@
 
 import os
 
+import deprecated
 import kubernetes.client
 from kubernetes import config, client
 from kubernetes.config.kube_config import KubeConfigLoader
@@ -32,6 +33,9 @@ from kube.helper import (
 )
 
 
+@deprecated.deprecated(
+    reason='kube.ctx.Ctx was refactored. Please use kube.client.KubernetesClient instead'
+)
 class Ctx(object):
     '''
     handles the execution context of kubernetes-api calls.

--- a/landscape_setup/__init__.py
+++ b/landscape_setup/__init__.py
@@ -12,7 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import kube.ctx
-
-kube_ctx = kube.ctx.Ctx()

--- a/landscape_setup/concourse.py
+++ b/landscape_setup/concourse.py
@@ -28,7 +28,7 @@ import yaml
 import concourse.client as client
 import version
 
-from kube.client import KubernetesClient
+from ccc.kubernetes import KubernetesClient
 
 from landscape_setup.utils import (
     ensure_helm_setup,

--- a/landscape_setup/monitoring.py
+++ b/landscape_setup/monitoring.py
@@ -15,7 +15,7 @@
 
 from ensure import ensure_annotations
 
-from kube.client import KubernetesClient
+from ccc.kubernetes import KubernetesClient
 
 from kubernetes.client import(
     ExtensionsV1beta1Ingress as V1beta1Ingress,

--- a/landscape_setup/monitoring.py
+++ b/landscape_setup/monitoring.py
@@ -15,6 +15,8 @@
 
 from ensure import ensure_annotations
 
+from kube.client import KubernetesClient
+
 from kubernetes.client import(
     ExtensionsV1beta1Ingress as V1beta1Ingress,
     ExtensionsV1beta1IngressSpec as V1beta1IngressSpec,
@@ -26,7 +28,6 @@ from kubernetes.client import(
     V1ObjectMeta,
 )
 
-from landscape_setup import kube_ctx
 from landscape_setup.utils import (
     ensure_cluster_version,
     execute_helm_deployment,
@@ -64,7 +65,8 @@ def deploy_monitoring_landscape(
     ingress_cfg = cfg_set.ingress(concourse_cfg.ingress_config())
 
     # Set the global context to the cluster specified in KubernetesConfig
-    kube_ctx.set_kubecfg(kubernetes_cfg.kubeconfig())
+    kubeconfig = kubernetes_cfg.kubeconfig()
+    kubernetes_client = KubernetesClient(kubeconfig)
     ensure_cluster_version(kubernetes_cfg)
 
     monitoring_config_name = concourse_cfg.monitoring_config()
@@ -116,7 +118,7 @@ def deploy_monitoring_landscape(
     # multiple paths unless the premium version is used. NOTE: only one ingress should use
     # gardener-managed dns. Otherwise the dns-controller will periodically complain that the
     # dns-entry is busy as they share the same host
-    ingress_helper = kube_ctx.ingress_helper()
+    ingress_helper = kubernetes_client.ingress_helper()
     info('Create ingress for kube-state-metrics')
     ingress = generate_monitoring_ingress_object(
         basic_auth_secret_name=monitoring_basic_auth_secret_name,

--- a/landscape_setup/secrets_server.py
+++ b/landscape_setup/secrets_server.py
@@ -15,7 +15,7 @@
 
 from ensure import ensure_annotations
 
-from landscape_setup import kube_ctx
+from kube.client import KubernetesClient
 from model.secrets_server import (
     SecretsServerConfig,
 )
@@ -42,11 +42,12 @@ from kubernetes.client import (
 
 @ensure_annotations
 def deploy_secrets_server(secrets_server_config: SecretsServerConfig):
-    ctx = kube_ctx
-    service_helper = ctx.service_helper()
-    deployment_helper = ctx.deployment_helper()
-    secrets_helper = ctx.secret_helper()
-    namespace_helper = ctx.namespace_helper()
+    # TODO: Verify that config is set in context, otherwise split landscape deployments may happen
+    client = KubernetesClient()
+    service_helper = client.service_helper()
+    deployment_helper = client.deployment_helper()
+    secrets_helper = client.secret_helper()
+    namespace_helper = client.namespace_helper()
 
     namespace = secrets_server_config.namespace()
     namespace_helper.create_if_absent(namespace)

--- a/landscape_setup/secrets_server.py
+++ b/landscape_setup/secrets_server.py
@@ -15,7 +15,7 @@
 
 from ensure import ensure_annotations
 
-from kube.client import KubernetesClient
+from ccc.kubernetes import KubernetesClient
 from model.secrets_server import (
     SecretsServerConfig,
 )

--- a/landscape_setup/utils.py
+++ b/landscape_setup/utils.py
@@ -29,7 +29,7 @@ from ci.util import (
     not_none,
     which,
 )
-from kube.client import KubernetesClient
+from ccc.kubernetes import KubernetesClient
 from model.kubernetes import KubernetesConfig
 
 CONCOURSE_HELM_CHART_REPO = "https://concourse-charts.storage.googleapis.com/"

--- a/landscape_setup/whd.py
+++ b/landscape_setup/whd.py
@@ -17,8 +17,6 @@ import os
 
 from ensure import ensure_annotations
 
-from kube.client import KubernetesClient
-
 from landscape_setup.utils import (
     ensure_cluster_version,
     execute_helm_deployment,

--- a/landscape_setup/whd.py
+++ b/landscape_setup/whd.py
@@ -17,7 +17,8 @@ import os
 
 from ensure import ensure_annotations
 
-from landscape_setup import kube_ctx
+from kube.client import KubernetesClient
+
 from landscape_setup.utils import (
     ensure_cluster_version,
     execute_helm_deployment,
@@ -96,7 +97,6 @@ def deploy_webhook_dispatcher_landscape(
     # Set the global context to the cluster specified in KubernetesConfig
     kubernetes_config_name = webhook_dispatcher_deployment_cfg.kubernetes_config_name()
     kubernetes_config = cfg_factory.kubernetes(kubernetes_config_name)
-    kube_ctx.set_kubecfg(kubernetes_config.kubeconfig())
 
     ensure_cluster_version(kubernetes_config)
 


### PR DESCRIPTION
Refactors the existing `kube.ctx.Ctx` to `kubernetes.client.KubernetesClient` and cleans up the code.

Also adjusts all usage in cc-utils