### PR TITLE
fix whd erros

### DIFF
--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -122,6 +122,9 @@ class GithubWebhookDispatcher(object):
 
             if pr_event.action() in [PullRequestAction.OPENED, PullRequestAction.SYNCHRONIZE]:
                 self._set_pr_labels(pr_event, resources)
+                # no need to trigger resource here. Subsequent PR webhook with action LABELED
+                # should trigger resource.
+                continue
 
             self._trigger_resource_check(concourse_api=concourse_api, resources=resources)
             self._ensure_pr_resource_updates(

--- a/whd/model.py
+++ b/whd/model.py
@@ -97,7 +97,7 @@ class PullRequestEvent(EventBase):
 
     def label_names(self):
         return [
-            label.get('name') for label in self.raw.get('labels', ())
+            label.get('name') for label in self.raw.get('pull_request').get('labels')
         ]
 
     def sender(self):


### PR DESCRIPTION
* access the labels in the PR webhook correctly
* do not trigger resource if PullRequestAction.OPENED or SYNCHRONIZE
  only needs to be done if action = PullRequestAction.LABELED

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
