### PR TITLE
Add deployment of oauth2-proxy secured tekon-dashboard-ingress to deployment gear

### DIFF
--- a/cli/gardener_ci/landscape.py
+++ b/cli/gardener_ci/landscape.py
@@ -28,12 +28,14 @@ from landscape_setup.utils import (
     ensure_cluster_version,
     ensure_helm_setup,
 )
-import landscape_setup.clamav as setup_clamav
-import landscape_setup.concourse as setup_concourse
-import landscape_setup.gardenlinux_cache as setup_gardenlinux_cache
-import landscape_setup.monitoring as setup_monitoring
-import landscape_setup.secrets_server as setup_secrets_server
-import landscape_setup.whd as setup_whd
+from landscape_setup import (
+    clamav as setup_clamav,
+    concourse as setup_concourse,
+    gardenlinux_cache as setup_gardenlinux_cache,
+    monitoring as setup_monitoring,
+    secrets_server as setup_secrets_server,
+    whd as setup_whd,
+)
 
 
 class LandscapeComponent(enum.Enum):

--- a/landscape_setup/charts/tekton-dashboard-ingress/Chart.yaml
+++ b/landscape_setup/charts/tekton-dashboard-ingress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: tekton-dashboard-ingress
+version: 0.1.0
+appVersion: 0.1.0

--- a/landscape_setup/charts/tekton-dashboard-ingress/templates/ingress.yaml
+++ b/landscape_setup/charts/tekton-dashboard-ingress/templates/ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tekton-dashboard-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    cert.gardener.cloud/issuer: {{ .Values.ingress_issuer_name }}
+    cert.gardener.cloud/purpose: managed
+    dns.gardener.cloud/class: garden
+    dns.gardener.cloud/dnsnames: {{ .Values.ingress_host }}
+    dns.gardener.cloud/ttl: {{ quote .Values.ingress_ttl }}
+    nginx.ingress.kubernetes.io/auth-response-headers: Authorization
+    nginx.ingress.kubernetes.io/auth-signin: {{ .Values.oauthProxyAuthUrl }}/oauth2/start?rd=https://$host$request_uri
+    nginx.ingress.kubernetes.io/auth-url: {{ .Values.oauthProxyAuthUrl }}/oauth2/auth
+spec:
+  rules:
+  - host: {{ .Values.ingress_host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.serviceName }}
+          servicePort: {{ .Values.servicePort }}
+  - host: {{ .Values.external_url }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.serviceName }}
+          servicePort: {{ .Values.servicePort }}
+  tls:
+  - hosts:
+{{- range $host := .Values.ingress_tls_hosts }}
+    - "{{ $host }}"
+{{- end }}
+    secretName: tekton-dashboard-tls
+

--- a/landscape_setup/oauth2_proxy.py
+++ b/landscape_setup/oauth2_proxy.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ensure import ensure_annotations
+
+from ci.util import (
+    ctx as global_ctx,
+    not_empty,
+)
+from landscape_setup import kube_ctx
+from landscape_setup.utils import (
+    ensure_cluster_version,
+    execute_helm_deployment,
+)
+from model.oauth2_proxy import Oauth2ProxyConfig
+from model.ingress import IngressConfig
+from model.kubernetes import KubernetesConfig
+
+
+@ensure_annotations
+def create_oauth2_proxy_helm_values(
+    oauth2_proxy_config: Oauth2ProxyConfig,
+    ingress_config: IngressConfig,
+    deployment_name: str,
+):
+    oauth2_proxy_chart_config = oauth2_proxy_config.oauth2_proxy_chart_config()
+    github_oauth_cfg = oauth2_proxy_config.github_oauth_config()
+    github_cfg = global_ctx().cfg_factory().github(github_oauth_cfg.github_cfg_name())
+    ingress_host = oauth2_proxy_config.ingress_host()
+
+    helm_values = {
+        'config': {
+            'clientID': github_oauth_cfg.client_id(),
+            'clientSecret': github_oauth_cfg.client_secret(),
+            'cookieSecret': oauth2_proxy_chart_config.cookie_secret(),
+            # configFile is expected with yamls '|-' syntax, i.e. newlines except for the last line
+            'configFile': '\n'.join([
+                'provider = "github"',
+                'email_domains = [ "*" ]',
+                'upstreams = [ "file:///dev/null" ]',
+                f'cookie_name = "{oauth2_proxy_chart_config.cookie_name()}"',
+                f'github_org = "{github_oauth_cfg.github_org()}"',
+                f'github_team = "{github_oauth_cfg.github_team()}"',
+                f'login_url = "{github_cfg.http_url()}/login/oauth/authorize"',
+                f'redeem_url = "{github_cfg.http_url()}/login/oauth/access_token"',
+                f'validate_url = "{github_cfg.api_url()}"',
+                f'ssl_insecure_skip_verify = {str(github_oauth_cfg.no_ssl_verify()).lower()}',
+            ])
+        },
+        'ingress': {
+            'enabled': True,
+            'path': "/",
+            'annotations': {
+                'kubernetes.io/ingress.class': 'nginx',
+                'kubernetes.io/tls-acme': "true",
+                'cert.gardener.cloud/issuer': ingress_config.issuer_name(),
+                'cert.gardener.cloud/purpose': 'managed',
+                'dns.gardener.cloud/class': 'garden',
+                'dns.gardener.cloud/dnsnames': ingress_host,
+                'dns.gardener.cloud/ttl': str(ingress_config.ttl()),
+            },
+            'hosts': [ingress_host, oauth2_proxy_config.external_url()],
+            'tls': [{
+                'hosts': ingress_config.tls_host_names(),
+                'secretName': f'{deployment_name}-tls'
+            }],
+        },
+    }
+
+    return helm_values
+
+
+@ensure_annotations
+def deploy_oauth2_proxy(
+    kubernetes_config: KubernetesConfig,
+    oauth2_proxy_config: Oauth2ProxyConfig,
+    deployment_name: str,
+):
+    not_empty(deployment_name)
+
+    cfg_factory = global_ctx().cfg_factory()
+
+    kube_ctx.set_kubecfg(kubernetes_config.kubeconfig())
+    ensure_cluster_version(kubernetes_config)
+
+    ingress_config = cfg_factory.ingress(oauth2_proxy_config.ingress_config())
+    helm_values = create_oauth2_proxy_helm_values(
+        oauth2_proxy_config=oauth2_proxy_config,
+        ingress_config=ingress_config,
+        deployment_name=deployment_name,
+    )
+
+    execute_helm_deployment(
+        kubernetes_config,
+        oauth2_proxy_config.namespace(),
+        'stable/oauth2-proxy',
+        deployment_name,
+        helm_values,
+    )

--- a/landscape_setup/tekton_dashboard_ingress.py
+++ b/landscape_setup/tekton_dashboard_ingress.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ensure import ensure_annotations
+
+from ci.util import (
+    ctx as global_ctx,
+    not_empty,
+)
+from landscape_setup import kube_ctx
+from landscape_setup.utils import (
+    ensure_cluster_version,
+    execute_helm_deployment,
+)
+from model.tekton_dashboard_ingress import TektonDashboardIngressConfig
+from model.ingress import IngressConfig
+from model.kubernetes import KubernetesConfig
+
+
+@ensure_annotations
+def create_tekton_dashboard_helm_values(
+    tekton_dashboard_ingress_config: TektonDashboardIngressConfig,
+    ingress_config: IngressConfig,
+):
+    oauth2_proxy_config = global_ctx().cfg_factory().oauth2_proxy(
+        tekton_dashboard_ingress_config.oauth2_proxy_config_name()
+    )
+    helm_values = {
+        'external_url': tekton_dashboard_ingress_config.external_url(),
+        'ingress_host': tekton_dashboard_ingress_config.ingress_host(),
+        'ingress_issuer_name': ingress_config.issuer_name(),
+        'ingress_tls_hosts': ingress_config.tls_host_names(),
+        'ingress_ttl': str(ingress_config.ttl()),
+        'serviceName': tekton_dashboard_ingress_config.service_name(),
+        'servicePort': tekton_dashboard_ingress_config.service_port(),
+        'oauthProxyAuthUrl': oauth2_proxy_config.external_url(),
+    }
+    return helm_values
+
+
+@ensure_annotations
+def deploy_tekton_dashboard_ingress(
+    kubernetes_config: KubernetesConfig,
+    tekton_dashboard_ingress_config: TektonDashboardIngressConfig,
+    chart_dir: str,
+    deployment_name: str,
+):
+    not_empty(deployment_name)
+
+    cfg_factory = global_ctx().cfg_factory()
+    chart_dir = os.path.abspath(chart_dir)
+
+    kube_ctx.set_kubecfg(kubernetes_config.kubeconfig())
+    ensure_cluster_version(kubernetes_config)
+
+    ingress_config = cfg_factory.ingress(tekton_dashboard_ingress_config.ingress_config())
+    helm_values = create_tekton_dashboard_helm_values(
+        tekton_dashboard_ingress_config=tekton_dashboard_ingress_config,
+        ingress_config=ingress_config,
+    )
+
+    execute_helm_deployment(
+        kubernetes_config,
+        tekton_dashboard_ingress_config.namespace(),
+        chart_dir,
+        deployment_name,
+        helm_values,
+    )

--- a/model/oauth2_proxy.py
+++ b/model/oauth2_proxy.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from model.base import NamedModelElement
+
+
+class Oauth2ProxyConfig(NamedModelElement):
+    '''Not intended to be instantiated by users of this module
+    '''
+
+    def oauth2_proxy_chart_config(self):
+        return Oauth2ProxyChartConfig(
+            '',
+            self.raw.get('oauth2_proxy_chart_config')
+        )
+
+    def github_oauth_config(self):
+        return GithubOauthConfig(
+            '',
+            self.raw.get('github_oauth_config')
+        )
+
+    def external_url(self):
+        return self.raw.get('external_url')
+
+    def ingress_config(self):
+        return self.raw.get('ingress_config')
+
+    def ingress_host(self):
+        return self.raw.get('ingress_host')
+
+    def namespace(self):
+        return self.raw.get('namespace')
+
+    def _required_attributes(self):
+        yield from super()._required_attributes()
+        yield from [
+            'external_url',
+            'github_oauth_config',
+            'ingress_config',
+            'ingress_host',
+            'namespace',
+            'oauth2_proxy_chart_config',
+        ]
+
+
+class Oauth2ProxyChartConfig(NamedModelElement):
+    def cookie_secret(self):
+        return self.raw.get('cookie_secret')
+
+    def cookie_name(self):
+        return self.raw.get('cookie_name')
+
+    def _required_attributes(self):
+        yield from super()._required_attributes()
+        yield from [
+            'cookie_secret',
+        ]
+
+    def _optional_attributes(self):
+        yield from super()._optional_attributes()
+        yield from [
+            'cookie_name',
+        ]
+
+
+class GithubOauthConfig(NamedModelElement):
+    # Move to github.py?
+
+    def client_id(self):
+        return self.raw.get('client_id')
+
+    def client_secret(self):
+        return self.raw.get('client_secret')
+
+    def github_cfg_name(self):
+        return self.raw.get('github_cfg_name')
+
+    def github_org(self):
+        return self.raw.get('github_org')
+
+    def github_team(self):
+        return self.raw.get('github_team')
+
+    def no_ssl_verify(self):
+        return self.raw.get('no_ssl_verify', False)
+
+    def _required_attributes(self):
+        yield from super()._required_attributes()
+        yield from [
+            'client_id',
+            'client_secret',
+            'github_cfg_name',
+            'github_org',
+            'github_team',
+        ]
+
+    def _optional_attributes(self):
+        yield from super()._optional_attributes()
+        yield from [
+            'no_ssl_verify',
+        ]

--- a/model/tekton_dashboard_ingress.py
+++ b/model/tekton_dashboard_ingress.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from model.base import NamedModelElement
+
+
+class TektonDashboardIngressConfig(NamedModelElement):
+    '''Not intended to be instantiated by users of this module
+    '''
+
+    def namespace(self):
+        return self.raw.get('namespace')
+
+    def external_url(self):
+        return self.raw.get('external_url')
+
+    def ingress_config(self):
+        return self.raw.get('ingress_config')
+
+    def ingress_host(self):
+        return self.raw.get('ingress_host')
+
+    def service_name(self):
+        return self.raw.get('service_name')
+
+    def service_port(self):
+        return self.raw.get('service_port')
+
+    def oauth2_proxy_config_name(self):
+        return self.raw.get('oauth2_proxy_config_name')
+
+    def _required_attributes(self):
+        yield from super()._required_attributes()
+        yield from [
+            'external_url',
+            'ingress_config',
+            'ingress_host',
+            'namespace',
+            'service_name',
+            'service_port',
+        ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for two new charts to our deployment gear:
- Oauth2-Proxy, based on the official chart.
- A newly created chart that deploys an oauth2-Proxy secured ingress for the tekton-dashboard

_Note_: These are not added to the general landscape-deployment automation, as deploying these only makes sense if tekton is also deployed.

