### PR TITLE
Add support for optional initial-dev-cycle-commit prefix

### DIFF
--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -171,6 +171,15 @@ ATTRIBUTES = (
         an optional prefix for release commit messages
         ''',
         type=str,
+    ),
+        AttributeSpec.optional(
+        name='next_version_commit_message_prefix',
+        default=None,
+        doc='''
+        an optional prefix for the commit message of the commit bumping the release version
+        immediately after the release-commit
+        ''',
+        type=str,
     )
 )
 
@@ -203,6 +212,9 @@ class ReleaseTrait(Trait):
 
     def release_commit_message_prefix(self) -> str:
         return self.raw.get('commit_message_prefix')
+
+    def next_cycle_commit_message_prefix(self) -> str:
+        return self.raw.get('next_version_commit_message_prefix')
 
     def validate(self):
         super().validate()

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -226,7 +226,7 @@ class ReleaseTraitTransformer(TraitTransformer):
             is_synthetic=True,
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
             script_type=ScriptType.PYTHON3,
-            )
+        )
         yield self.release_step
 
     def process_pipeline_args(self, pipeline_args: JobVariant):

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -201,7 +201,7 @@ class ReleaseTrait(Trait):
     def release_commit_publishing_policy(self) -> ReleaseCommitPublishingPolicy:
         return ReleaseCommitPublishingPolicy(self.raw['release_commit_publishing_policy'])
 
-    def commit_message_prefix(self) -> str:
+    def release_commit_message_prefix(self) -> str:
         return self.raw.get('commit_message_prefix')
 
     def validate(self):

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -145,7 +145,8 @@ ATTRIBUTES = (
         an optional callback that is called during next version commit creation.
         The callback is passed the absolute path to the main repository's work tree via environment
         variable `REPO_DIR`.
-        Any changes left inside the worktree are added to the resulting release commit.
+        Any changes left inside the worktree are added to the commit bumping the version
+        immediately after the release-commit.
         ''',
     ),
     AttributeSpec.optional(

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -10,7 +10,7 @@ version_file = job_step.input('version_path') + '/version'
 release_trait = job_variant.trait('release')
 version_trait = job_variant.trait('version')
 version_op = release_trait.nextversion()
-commit_message_prefix = release_trait.commit_message_prefix()
+release_commit_message_prefix = release_trait.release_commit_message_prefix()
 
 has_slack_trait = job_variant.has_trait('slack')
 if has_slack_trait:
@@ -76,8 +76,8 @@ release_and_prepare_next_dev_cycle(
   version_operation='${version_op}',
   release_notes_policy='${release_trait.release_notes_policy().value}',
   release_commit_publishing_policy='${release_trait.release_commit_publishing_policy().value}',
-  % if commit_message_prefix:
-  commit_message_prefix='${commit_message_prefix}',
+  % if release_commit_message_prefix:
+  release_commit_message_prefix='${release_commit_message_prefix}',
   % endif
 )
 </%def>

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -11,6 +11,7 @@ release_trait = job_variant.trait('release')
 version_trait = job_variant.trait('version')
 version_op = release_trait.nextversion()
 release_commit_message_prefix = release_trait.release_commit_message_prefix()
+next_cycle_commit_message_prefix = release_trait.next_cycle_commit_message_prefix()
 
 has_slack_trait = job_variant.has_trait('slack')
 if has_slack_trait:
@@ -78,6 +79,9 @@ release_and_prepare_next_dev_cycle(
   release_commit_publishing_policy='${release_trait.release_commit_publishing_policy().value}',
   % if release_commit_message_prefix:
   release_commit_message_prefix='${release_commit_message_prefix}',
+  % endif
+  % if next_cycle_commit_message_prefix:
+  next_cycle_commit_message_prefix='${next_cycle_commit_message_prefix}',
   % endif
 )
 </%def>

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -718,23 +718,23 @@ def _calculate_next_cycle_dev_version(
 
 def release_and_prepare_next_dev_cycle(
     githubrepobranch: GitHubRepoBranch,
-    repository_version_file_path: str,
+    release_commit_publishing_policy: str,
+    release_notes_policy: str,
     release_version: str,
     repo_dir: str,
-    release_notes_policy: str,
-    release_commit_publishing_policy: str,
-    release_commit_callback: str=None,
-    next_version_callback: str=None,
-    version_operation: str="bump_minor",
-    prerelease_suffix: str="dev",
-    author_name: str="gardener-ci",
+    repository_version_file_path: str,
     author_email: str="gardener.ci.user@gmail.com",
+    author_name: str="gardener-ci",
     component_descriptor_file_path: str=None,
     next_cycle_commit_message_prefix: str=None,
+    next_version_callback: str=None,
+    prerelease_suffix: str="dev",
+    rebase_before_release: bool=False,
+    release_commit_callback: str=None,
     release_commit_message_prefix: str=None,
     slack_cfg_name: str=None,
     slack_channel: str=None,
-    rebase_before_release: bool=False,
+    version_operation: str="bump_minor",
 ):
     transaction_ctx = TransactionContext() # shared between all steps/trxs
 

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -179,7 +179,7 @@ class ReleaseCommitStep(TransactionalStep):
         release_version: str,
         repository_version_file_path: str,
         repository_branch: str,
-        commit_message_prefix: str,
+        release_commit_message_prefix: str,
         publishing_policy: ReleaseCommitPublishingPolicy,
         release_commit_callback: str=None,
     ):
@@ -192,7 +192,7 @@ class ReleaseCommitStep(TransactionalStep):
             repo_dir_absolute,
             repository_version_file_path,
         )
-        self.commit_message_prefix = commit_message_prefix
+        self.release_commit_message_prefix = release_commit_message_prefix
         self.publishing_policy = publishing_policy
 
         if release_commit_callback:
@@ -205,10 +205,10 @@ class ReleaseCommitStep(TransactionalStep):
 
         self.head_commit = None # stored while applying - used for revert
 
-    def _release_commit_message(self, version: str, commit_message_prefix: str=''):
+    def _release_commit_message(self, version: str, release_commit_message_prefix: str=''):
         message = f'Release {version}'
-        if commit_message_prefix:
-            return f'{commit_message_prefix} {message}'
+        if release_commit_message_prefix:
+            return f'{release_commit_message_prefix} {message}'
         else:
             return message
 
@@ -246,7 +246,10 @@ class ReleaseCommitStep(TransactionalStep):
             )
 
         release_commit = self.git_helper.index_to_commit(
-            message=self._release_commit_message(self.release_version, self.commit_message_prefix),
+            message=self._release_commit_message(
+                self.release_version,
+                self.release_commit_message_prefix
+            ),
         )
 
         self.context().release_commit = release_commit # pass to other steps
@@ -715,10 +718,10 @@ def release_and_prepare_next_dev_cycle(
     author_name: str="gardener-ci",
     author_email: str="gardener.ci.user@gmail.com",
     component_descriptor_file_path: str=None,
+    release_commit_message_prefix: str=None,
     slack_cfg_name: str=None,
     slack_channel: str=None,
     rebase_before_release: bool=False,
-    commit_message_prefix: str=None,
 ):
     transaction_ctx = TransactionContext() # shared between all steps/trxs
 
@@ -747,7 +750,7 @@ def release_and_prepare_next_dev_cycle(
         release_version=release_version,
         repository_version_file_path=repository_version_file_path,
         repository_branch=githubrepobranch.branch(),
-        commit_message_prefix=commit_message_prefix,
+        release_commit_message_prefix=release_commit_message_prefix,
         release_commit_callback=release_commit_callback,
         publishing_policy=release_commit_publishing_policy,
     )

--- a/test/concourse/steps/release_test.py
+++ b/test/concourse/steps/release_test.py
@@ -29,7 +29,7 @@ class TestReleaseCommitStep(object):
                 release_version=release_version,
                 repository_version_file_path=repository_version_file_path,
                 repository_branch=repository_branch,
-                commit_message_prefix=None,
+                release_commit_message_prefix=None,
                 release_commit_callback=release_commit_callback,
                 publishing_policy=ReleaseCommitPublishingPolicy.TAG_ONLY,
             )


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new attribute to the release trait, `next_cycle_commit_message_prefix`, that allows one to add a prefix to the commit message of the auto-generated initial-dev-cycle-commit. The prefix will usually be `[ci skip]`, I suspect.