### PR TITLE
Make whd more resilient to push events without commits

### DIFF
--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -255,8 +255,11 @@ class GithubWebhookDispatcher(object):
                 if not event.ref().endswith(ghs.branch_name()):
                     continue
             if isinstance(event, PushEvent):
-                if any(skip in event.commit_message() for skip in ('[skip ci]', '[ci skip]')):
-                    if not ghs.disable_ci_skip():
+                if msg := event.commit_message():
+                    if (
+                        not ghs.disable_ci_skip()
+                        and any(skip in msg for skip in ('[skip ci]', '[ci skip]'))
+                    ):
                         logger.info(
                             f"Do not trigger resource {resource.name}. Found [skip ci] or [ci skip]"
                         )

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -254,7 +254,6 @@ class GithubWebhookDispatcher(object):
             if isinstance(event, PushEvent):
                 if not event.ref().endswith(ghs.branch_name()):
                     continue
-            # TODO: remove for Concourse 6.0 see https://github.com/concourse/concourse/issues/3463
             if isinstance(event, PushEvent):
                 if any(skip in event.commit_message() for skip in ('[skip ci]', '[ci skip]')):
                     if not ghs.disable_ci_skip():

--- a/whd/model.py
+++ b/whd/model.py
@@ -68,7 +68,10 @@ class PushEvent(EventBase):
         yield from head_commit.get('modified', ())
 
     def commit_message(self):
-        return self.raw.get('head_commit').get('message')
+        # not all push events have a head_commit (e.g. push events sent on branch deletion)
+        if head_commit := self.raw.get('head_commit'):
+            return head_commit.get('message')
+        return None
 
 
 class PullRequestAction(enum.Enum):


### PR DESCRIPTION
A minor fix to make the whd resilient against push events that have no associated commit (and thus no commit message)