### PR TITLE
Add auth_url property for OS projects

### DIFF
--- a/model/ccee.py
+++ b/model/ccee.py
@@ -30,6 +30,9 @@ class CCEEProject(ModelBase):
     def domain(self):
         return self.raw.get('domain')
 
+    def auth_url(self):
+        return self.raw.get('auth_url')
+
 
 class CCEEConfig(NamedModelElement):
     '''


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `auth_url` property for Openstack project model.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```NONE

```
