### PR TITLE
Add support for Concourse 6.3.0 API changes

### DIFF
--- a/concourse/client/__init__.py
+++ b/concourse/client/__init__.py
@@ -75,14 +75,15 @@ def from_cfg(concourse_cfg: ConcourseConfig, team_name: str, verify_ssl=False):
     team_name = concourse_team.teamname()
     username = concourse_team.username()
     password = concourse_team.password()
-    concourse_version = concourse_cfg.concourse_version()
+    concourse_api_version = concourse_cfg.compatible_api_version()
 
     request_builder = AuthenticatedRequestBuilder(
         basic_auth_username=AUTH_TOKEN_REQUEST_USER,
         basic_auth_passwd=AUTH_TOKEN_REQUEST_PWD,
         verify_ssl=verify_ssl
     )
-    if concourse_version is ConcourseApiVersion.V5:
+
+    if concourse_api_version is ConcourseApiVersion.V5:
         routes = ConcourseApiRoutesV5(base_url=base_url, team=team_name)
         concourse_api = ConcourseApiV5(
             routes=routes,
@@ -91,7 +92,7 @@ def from_cfg(concourse_cfg: ConcourseConfig, team_name: str, verify_ssl=False):
         )
     else:
         raise NotImplementedError(
-            "Concourse version {v} not supported".format(v=concourse_version.value)
+            "Concourse version {v} not supported".format(v=concourse_api_version.value)
         )
 
     concourse_api.login(

--- a/concourse/client/__init__.py
+++ b/concourse/client/__init__.py
@@ -23,9 +23,11 @@ import functools
 import ci.util
 from .api import (
     ConcourseApiV5,
+    ConcourseApiV6_3_0,
 )
 from .routes import (
     ConcourseApiRoutesV5,
+    ConcourseApiRoutesV6_3_0,
 )
 from model.concourse import (
     ConcourseApiVersion,
@@ -86,6 +88,13 @@ def from_cfg(concourse_cfg: ConcourseConfig, team_name: str, verify_ssl=False):
     if concourse_api_version is ConcourseApiVersion.V5:
         routes = ConcourseApiRoutesV5(base_url=base_url, team=team_name)
         concourse_api = ConcourseApiV5(
+            routes=routes,
+            request_builder=request_builder,
+            verify_ssl=verify_ssl,
+        )
+    elif concourse_api_version is ConcourseApiVersion.V6_3_0:
+        routes = ConcourseApiRoutesV6_3_0(base_url=base_url, team=team_name)
+        concourse_api = ConcourseApiV6_3_0(
             routes=routes,
             request_builder=request_builder,
             verify_ssl=verify_ssl,

--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -50,7 +50,7 @@ def select_attr(name: str):
     return lambda o: o.get(name)
 
 
-class ConcourseApiBase(object):
+class ConcourseApiBase:
     '''
     Implements a subset of concourse REST API functionality.
 

--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -61,6 +61,9 @@ class ConcourseApiBase(object):
     @param team_name: the team name used for authentication
     @param verify_ssl: whether or not certificate validation is to be done
     '''
+
+    AUTH_TOKEN_ATTRIBUTE_NAME = 'access_token'
+
     @ensure_annotations
     def __init__(
         self,
@@ -97,7 +100,7 @@ class ConcourseApiBase(object):
             body=form_data,
             headers={"content-type": "application/x-www-form-urlencoded"}
         )
-        auth_token = response.json()['access_token']
+        auth_token = response.json()[self.AUTH_TOKEN_ATTRIBUTE_NAME]
         self.request_builder = AuthenticatedRequestBuilder(
             auth_token=auth_token,
             verify_ssl=self.verify_ssl

--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -313,7 +313,9 @@ class ConcourseApiBase(object):
         self._put(url, pin_comment)
 
 
-class ConcourseApiV5(ConcourseApiBase):
+class SetTeamAPIUpdateMixin:
+    '''Mixin for 'set team' API changed in Concourse 5.0.0
+    '''
     def set_team(self, concourse_team: ConcourseTeam):
         role = concourse_team.role() if concourse_team.role() else "member"
         body = {
@@ -334,3 +336,12 @@ class ConcourseApiV5(ConcourseApiBase):
 
         team_url = self.routes.team_url(concourse_team.teamname())
         self._put(team_url, json.dumps(body))
+
+
+class ConcourseApiV5(ConcourseApiBase, SetTeamAPIUpdateMixin):
+    pass
+
+
+class ConcourseApiV6_3_0(ConcourseApiBase, SetTeamAPIUpdateMixin):
+
+    AUTH_TOKEN_ATTRIBUTE_NAME = 'id_token'

--- a/concourse/client/routes.py
+++ b/concourse/client/routes.py
@@ -148,3 +148,15 @@ class ConcourseApiRoutesBase(object):
 
 class ConcourseApiRoutesV5(ConcourseApiRoutesBase):
     '''Routes for Concourse V5'''
+
+
+class ConcourseApiRoutesV6_3_0(ConcourseApiRoutesBase):
+    '''Routes for Concourse v6.3.0'''
+
+    def login(self):
+        return ci.util.urljoin(
+            self.base_url,
+            'sky',
+            'issuer',
+            'token',
+        )

--- a/landscape_setup/concourse.py
+++ b/landscape_setup/concourse.py
@@ -165,19 +165,19 @@ def create_instance_specific_helm_values(
                         'mainTeam': {
                             'localUser': main_team.username(),
                             'github': {
-                                'team': main_team.github_auth_team()
-                            }
+                                'team': main_team.github_auth_team(),
+                            },
                         },
                         'github': {
                             'host': github_host
-                        }
-                    }
-                }
+                        },
+                    },
+                },
             },
             'secrets': {
                 'localUsers': main_team.username() + ':' + bcrypted_pwd,
                 'githubClientId': main_team.github_auth_client_id(),
-                'githubClientSecret': main_team.github_auth_client_secret()
+                'githubClientSecret': main_team.github_auth_client_secret(),
             },
             'web': {
                 'ingress': {
@@ -193,8 +193,8 @@ def create_instance_specific_helm_values(
                         'secretName': concourse_cfg.tls_secret_name(),
                         'hosts': ingress_cfg.tls_host_names(),
                     }],
-                }
-            }
+                },
+            },
         }
     else:
         raise NotImplementedError(

--- a/landscape_setup/concourse.py
+++ b/landscape_setup/concourse.py
@@ -141,7 +141,9 @@ def create_instance_specific_helm_values(
     ingress_cfg = config_factory.ingress(concourse_cfg.ingress_config())
     concourse_api_version = concourse_cfg.compatible_api_version()
 
-    if concourse_api_version is ConcourseApiVersion.V5:
+    SUPPORTED_API_VERSIONS = [ConcourseApiVersion.V5, ConcourseApiVersion.V6_3_0]
+
+    if concourse_api_version in SUPPORTED_API_VERSIONS:
         github_config_name = concourse_cfg.github_enterprise_host()
         # 'github_enterprise_host' only configured in case of internal concourse
         # using github enterprise

--- a/landscape_setup/concourse.py
+++ b/landscape_setup/concourse.py
@@ -139,9 +139,9 @@ def create_instance_specific_helm_values(
     external_host = urlparse(external_url).netloc
     ingress_host = concourse_cfg.ingress_host()
     ingress_cfg = config_factory.ingress(concourse_cfg.ingress_config())
-    concourse_version = concourse_cfg.concourse_version()
+    concourse_api_version = concourse_cfg.compatible_api_version()
 
-    if concourse_version is ConcourseApiVersion.V5:
+    if concourse_api_version is ConcourseApiVersion.V5:
         github_config_name = concourse_cfg.github_enterprise_host()
         # 'github_enterprise_host' only configured in case of internal concourse
         # using github enterprise
@@ -198,7 +198,7 @@ def create_instance_specific_helm_values(
         }
     else:
         raise NotImplementedError(
-            "Concourse version {v} not supported".format(v=concourse_version)
+            "Concourse version {v} not supported".format(v=concourse_api_version)
         )
 
     return instance_specific_values

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -27,6 +27,7 @@ from model.base import (
 class ConcourseApiVersion(Enum):
     '''Enum to define different Concourse versions'''
     V5 = '5'
+    V6_3_0 = '6.3.0'
 
 
 class ConcourseConfig(NamedModelElement):
@@ -86,7 +87,9 @@ class ConcourseConfig(NamedModelElement):
     def compatible_api_version(self) -> ConcourseApiVersion:
         cc_version = semver.VersionInfo.parse(self.raw.get('concourse_version'))
 
-        if cc_version >= semver.VersionInfo.parse('5.0.0'):
+        if cc_version >= semver.VersionInfo.parse('6.3.0'):
+            return ConcourseApiVersion.V6_3_0
+        elif cc_version >= semver.VersionInfo.parse('5.0.0'):
             return ConcourseApiVersion.V5
         else:
             raise NotImplementedError


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for the changes in the login flow in Concourse version `6.3.0`. Without this, our automations won't be able to authenticate against Concourse.
