### PR TITLE
Move checkmarx functions to utils

### DIFF
--- a/ccc/github.py
+++ b/ccc/github.py
@@ -29,6 +29,7 @@ import ci.util
 import github.util
 import http_requests
 import model
+import product.model
 
 if ci.util._running_on_ci():
     log_github_access = False
@@ -217,3 +218,8 @@ def log_stack_trace_information_hook(resp, *args, **kwargs):
 
     except Exception as e:
         ci.util.info(f'Could not log stack trace information: {e}')
+
+
+def github_api_from_component(component: product.model.Component):
+    github_cfg = github_cfg_for_hostname(host_name=component.github_host())
+    return github_api(github_cfg=github_cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
While implementing WhiteSource I noticed that some functions introduced with checkmarx can be reused.
Thus I moved the corresponding functions and adjusted the import / calls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I did some testing already but please feel free to re-run a workflow to double check the functionality @jkrayl .

**Release note**:
```noteworthy developer
NONE
```
