### PR TITLE
add schema-version to component-descriptor

### DIFF
--- a/product/model.py
+++ b/product/model.py
@@ -352,6 +352,8 @@ class ComponentDescriptor(ProductModelBase):
             self.raw['components'] = []
         if 'component_overwrites' not in self.raw:
             self.raw['component_overwrites'] = []
+        if 'meta' not in self.raw:
+            self.raw['meta'] = {'schemaVersion': SchemaVersion.V1.value}
 
     def _optional_attributes(self):
         return {'components', 'component_overwrites', 'meta'}

--- a/test/concourse/steps/update_component_deps_test.py
+++ b/test/concourse/steps/update_component_deps_test.py
@@ -66,6 +66,7 @@ def test_current_product_descriptor(tmpdir):
     tmpdir.join('component_descriptor').write('{}')
 
     assert current_product_descriptor().raw == {
+        'meta': {'schemaVersion': 'v1'},
         'components': [],
         'component_overwrites': [],
     }


### PR DESCRIPTION
note: merge only after next "live-update"

this change will help to identify locations w/ outdated copies of `product/model`, as the `meta` attribute has only been introduced recently, and will lead to schema validation errors from older implementations.