### PR TITLE
Add license scanning to protecode trait

### DIFF
--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -84,6 +84,26 @@ PROTECODE_ATTRS = (
         doc='CVSS version used to evaluate the severity of vulnerabilities',
         type=CVSSVersion,
     ),
+    AttributeSpec.optional(
+        name='allowed_licenses',
+        default=[],
+        doc=(
+            'A list of regular expressions. If configured, licenses detected by protecode '
+            'that do not match at least one of regular expressions will result in a report mail '
+            'being sent. If not configured or empty, **all** licenses will be accepted.'
+        ),
+        type=list,
+    ),
+    AttributeSpec.optional(
+        name='prohibited_licenses',
+        default=[],
+        doc=(
+            'A list of regular expressions. If configured, licenses detected by protecode that '
+            'match one of the regular expressions will result in a report mail being sent, even '
+            'if they are included in `allowed_licenses` (e.g. due to the default value).'
+        ),
+        type=list,
+    ),
 )
 
 
@@ -112,6 +132,12 @@ class ProtecodeScanCfg(ModelBase):
 
     def cvss_version(self):
         return CVSSVersion(self.raw.get('cvss_version'))
+
+    def allowed_licenses(self):
+        return self.raw.get('allowed_licenses')
+
+    def prohibited_licenses(self):
+        return self.raw.get('prohibited_licenses')
 
     def validate(self):
         super().validate()

--- a/concourse/steps/scan_container_images.mako
+++ b/concourse/steps/scan_container_images.mako
@@ -78,7 +78,7 @@ print_protecode_info_table(
   exclude_component_names=${filter_cfg.exclude_component_names()},
 )
 
-protecode_results, license_report = protecode.util.upload_grouped_images((
+protecode_results, license_report = protecode.util.upload_grouped_images(
   protecode_cfg=protecode_cfg,
   protecode_group_id = protecode_group_id,
   component_descriptor = component_descriptor,
@@ -91,6 +91,13 @@ protecode_results, license_report = protecode.util.upload_grouped_images((
 )
 
 print_license_report(license_report)
+
+allowed_licenses = ${protecode_scan.allowed_licenses()}
+prohibited_licenses = ${protecode_scan.prohibited_licenses()}
+
+updated_license_report = list(
+  determine_rejected_licenses(license_report, allowed_licenses, prohibited_licenses)
+)
 
 % endif
 
@@ -122,7 +129,7 @@ print(
 )
 % endif
 
-if not protecode_results and not malware_scan_results:
+if not protecode_results and not malware_scan_results and not updated_license_report:
   sys.exit(0)
 
 email_recipients = ${image_scan_trait.email_recipients()}
@@ -145,6 +152,7 @@ email_recipients = tuple(
 
 for email_recipient in email_recipients:
   email_recipient.add_protecode_results(results=protecode_results)
+  email_recipient.add_license_scan_results(results=updated_license_report)
 % if clam_av:
   email_recipient.add_clamav_results(results=malware_scan_results)
 % endif

--- a/concourse/steps/scan_container_images.mako
+++ b/concourse/steps/scan_container_images.mako
@@ -78,17 +78,20 @@ print_protecode_info_table(
   exclude_component_names=${filter_cfg.exclude_component_names()},
 )
 
-protecode_results, license_report = protecode_scan(
+protecode_results, license_report = protecode.util.upload_grouped_images((
   protecode_cfg=protecode_cfg,
   protecode_group_id = protecode_group_id,
   component_descriptor = component_descriptor,
-  reference_protecode_group_ids = ${protecode_scan.reference_protecode_group_ids()},
+  reference_group_ids = ${protecode_scan.reference_protecode_group_ids()},
   processing_mode = ProcessingMode('${protecode_scan.processing_mode().value}'),
   parallel_jobs=${protecode_scan.parallel_jobs()},
   cve_threshold=${protecode_scan.cve_threshold()},
   image_reference_filter=filter_function,
   cvss_version = CVSSVersion('${protecode_scan.cvss_version().value}'),
 )
+
+print_license_report(license_report)
+
 % endif
 
 malware_scan_results = None

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -89,7 +89,7 @@ class MailRecipients(object):
             component_names=(self._recipients_component.name(),),
         )
 
-    def add_protecode_results(self, results: typing.Iterable[typing.Tuple[UploadResult, int]]):
+    def add_protecode_results(self, results: typing.Iterable[typing.Tuple[UploadResult, float]]):
         logger.info(f'adding protecode results for {self}')
         for result in results:
             if self._result_filter:

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -25,7 +25,6 @@ import tabulate
 import ccc.clamav
 import ci.util
 import mailutil
-import protecode.util
 
 from concourse.model.traits.image_scan import Notify
 from product.model import ComponentName, UploadResult
@@ -274,7 +273,7 @@ def protecode_results_table(protecode_cfg, upload_results: typing.Iterable[Uploa
     return table
 
 
-def create_license_report(license_report):
+def print_license_report(license_report):
     def to_table_row(upload_result, licenses):
         component_name = upload_result.result.display_name()
         license_names = {license.name() for license in licenses}
@@ -320,32 +319,3 @@ def print_protecode_info_table(
         ('Component name filter (exclude)', exclude_component_names),
     )
     print(tabulate.tabulate(entries, headers=headers))
-
-
-def protecode_scan(
-    protecode_cfg,
-    protecode_group_id: int,
-    reference_protecode_group_ids,
-    component_descriptor,
-    processing_mode,
-    parallel_jobs: int,
-    cve_threshold,
-    image_reference_filter,
-    cvss_version,
-):
-    protecode_results, license_report = protecode.util.upload_grouped_images(
-        protecode_cfg=protecode_cfg,
-        component_descriptor=component_descriptor,
-        processing_mode=processing_mode,
-        protecode_group_id=protecode_group_id,
-        parallel_jobs=parallel_jobs,
-        cve_threshold=cve_threshold,
-        image_reference_filter=image_reference_filter,
-        reference_group_ids=reference_protecode_group_ids,
-        cvss_version=cvss_version,
-    )
-
-    # XXX also include in email
-    create_license_report(license_report=license_report)
-
-    return protecode_results, license_report

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -174,17 +174,20 @@ def download_images(
 def license_report(
     upload_results: typing.Sequence[UploadResult],
 ) -> typing.Sequence[typing.Tuple[UploadResult, typing.Set[License]]]:
-    for upload_result in upload_results:
-        if isinstance(upload_result, UploadResult):
-            analysis_result = upload_result.result
-        else:
-            analysis_result = upload_result
+    def create_component_reports():
+        for upload_result in upload_results:
+            if isinstance(upload_result, UploadResult):
+                analysis_result = upload_result.result
+            else:
+                analysis_result = upload_result
 
-        licenses = {
-            component.license() for component in analysis_result.components()
-            if component.license()
-        }
-        yield (upload_result, licenses)
+            licenses = {
+                component.license() for component in analysis_result.components()
+                if component.license()
+            }
+            yield (upload_result, licenses)
+
+    return list(create_component_reports())
 
 
 def filter_and_display_upload_results(

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -192,7 +192,7 @@ def filter_and_display_upload_results(
     cvss_version: CVSSVersion,
     cve_threshold=7,
     ignore_if_triaged=True,
-) -> typing.Iterable[typing.Tuple[UploadResult, int]]:
+) -> typing.Iterable[typing.Tuple[UploadResult, float]]:
     # we only require the analysis_results for now
 
     results_without_components = []


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows configuration of licenses to check for in protecode scans and add information about them to generated report-mails