### PR TITLE
Rename Concourse-Pipeline objects

### DIFF
--- a/concourse/model/resources.py
+++ b/concourse/model/resources.py
@@ -235,7 +235,7 @@ class RepositoryConfig(Resource):
         else:
             type_name = ResourceType.GIT.value
 
-        base_name = kwargs['raw_dict']['path'].replace('/', '_')
+        base_name = kwargs['raw_dict']['path'].replace('/', '.')
 
         # hack: use branch name as qualifier to support referencing the same repo
         #       multiple times (if branch differs)
@@ -270,7 +270,7 @@ class RepositoryConfig(Resource):
 
     def resource_name(self):
         # TODO: replace usages with access to resource_id
-        return self._resource_identifier.name() + '_' + self.branch()
+        return self._resource_identifier.name() + '.' + self.branch()
 
     def name(self):
         # TODO: replace usages with access to resource_id

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -47,10 +47,13 @@ class ValidationPolicy(EnumWithDocumentation):
     )
 
 
+DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME = 'component_descriptor'
+
+
 ATTRIBUTES = (
     AttributeSpec.optional(
         name='step',
-        default={'name': 'component_descriptor'},
+        default={'name': DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME},
         doc='The build step name injected by this trait',
         type=dict,
     ),
@@ -106,8 +109,10 @@ class ComponentDescriptorTrait(Trait):
 
         # todo: make step name actually configurable (need concept to express
         # step-specific behaviour, first)
-        if not self.step_name() == 'component_descriptor':
-            raise ModelValidationError('component_descriptor step name must be component_descriptor')
+        if not self.step_name() == DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME:
+            raise ModelValidationError(
+                f"component-descriptor step name must be '{DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME}'"
+            )
 
     @classmethod
     def _attribute_specs(cls):

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -268,7 +268,9 @@ class ImageScanTraitTransformer(TraitTransformer):
 
     def process_pipeline_args(self, pipeline_args: JobVariant):
         # our step depends on dependency descriptor step
-        component_descriptor_step = pipeline_args.step('component_descriptor')
+        component_descriptor_step = pipeline_args.step(
+            concourse.model.traits.component_descriptor.DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME
+        )
         self.image_scan_step._add_dependency(component_descriptor_step)
 
         for trait_name in self.trait.trait_depends():

--- a/concourse/model/traits/image_upload.py
+++ b/concourse/model/traits/image_upload.py
@@ -95,7 +95,9 @@ class ImageUploadTraitTransformer(TraitTransformer):
 
     def process_pipeline_args(self, pipeline_args: JobVariant):
         # our step depends on dependency descriptor step
-        component_descriptor_step = pipeline_args.step('component_descriptor')
+        component_descriptor_step = pipeline_args.step(
+            concourse.model.traits.component_descriptor.DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME
+        )
         self.image_upload_step._add_dependency(component_descriptor_step)
 
     @classmethod

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -200,7 +200,9 @@ class SourceScanTraitTransformer(TraitTransformer):
 
     def process_pipeline_args(self, pipeline_args: JobVariant):
         # our step depends on dependency descriptor step
-        component_descriptor_step = pipeline_args.step('component_descriptor')
+        component_descriptor_step = pipeline_args.step(
+            concourse.model.traits.component_descriptor.DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME
+        )
         self.source_scan_step._add_dependency(component_descriptor_step)
 
     @classmethod

--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -141,7 +141,9 @@ class UpdateComponentDependenciesTraitTransformer(TraitTransformer):
 
     def process_pipeline_args(self, pipeline_args: JobVariant):
         # our step depends on dependendency descriptor step
-        component_descriptor_step = pipeline_args.step('component_descriptor')
+        component_descriptor_step = pipeline_args.step(
+            concourse.model.traits.component_descriptor.DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME
+        )
         self.update_component_deps_step._add_dependency(component_descriptor_step)
 
         upstream_component_name = self.trait.upstream_component_name()

--- a/concourse/resources/email.mako
+++ b/concourse/resources/email.mako
@@ -14,7 +14,7 @@ import concourse.steps
 notification_step = concourse.steps.step_def('notification')
 from makoutil import indent_func
 %>
-- task: '${job_step.name}_failed'
+- task: '${job_step.name}.failed'
   config:
     inputs:
 % for input in inputs:

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -3,12 +3,14 @@
 import itertools
 import os
 
+import model.container_registry
+
 from ci.util import urljoin
 from makoutil import indent_func
 from concourse.factory import DefinitionFactory
 from concourse.model.base import ScriptType
 from concourse.model.step import StepNotificationPolicy, PrivilegeMode
-import model.container_registry
+from concourse.model.traits.component_descriptor import DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME
 
 # use pipeline_name for debugging / tracing purposes
 pipeline_name = pipeline.get('name')
@@ -381,7 +383,7 @@ else:
         ${meta_step(job_step=job_step, job_variant=job_variant, indent=8)}
 % elif job_step.name == 'rm_pr_label':
         ${rm_pr_label_step(job_step=job_step, job_variant=job_variant, github_cfg=github, concourse_cfg=concourse_cfg, indent=8)}
-% elif job_step.name == 'component_descriptor':
+% elif job_step.name == DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME:
 <%
   if has_publish_trait(job_variant):
     image_descriptors_for_variant = {

--- a/test/concourse/steps/component_descriptor_test.py
+++ b/test/concourse/steps/component_descriptor_test.py
@@ -43,7 +43,9 @@ class ComponentDescriptorStepTest(unittest.TestCase):
         for step in self.component_descriptor_transformer.inject_steps():
             self.job_variant._steps_dict[step.name] = step
 
-        self.component_descriptor_step = self.job_variant.step('component_descriptor')
+        self.component_descriptor_step = self.job_variant.step(
+            component_descriptor.DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME,
+        )
         self.component_descriptor_step.add_input('version_path', 'version_path')
 
         self.old_cwd = os.getcwd()


### PR DESCRIPTION
**What this PR does / why we need it**:
Pipeline-object-names with an underscore in them are marked as deprecated and will raise an error in a future, as of yet unspecified Concourse version.

This PR contains two commits in preparation for this:
- Pipeline-Objects whose names are generated now use `.` as separator instead of `_`
- The step-name of our `component_descriptor` step was hard-coded in many places. This was changed to help with future work.

Still left to do, for a future PR:
- Switch all our hard-coded step names (e.g.: `scan_images`). This would require fixing all pipelines that define custom steps dependent on our steps.

