### PR TITLE
Add method for fetching jobs to Concourse API

### DIFF
--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -27,8 +27,9 @@ from .routes import (
 )
 from .model import (
     Build,
-    BuildPlan,
     BuildEvents,
+    BuildPlan,
+    Job,
     PipelineConfig,
     PipelineConfigResource,
     PipelineResource,
@@ -367,6 +368,10 @@ class ConcourseApiBase:
         url = self.routes.pin_comment(pipeline_name, resource_name)
         pin_comment = json.dumps({'pin_comment': comment})
         self._put(url, pin_comment)
+
+    def get_job(self, pipeline_name:str, job_name:str):
+        url = self.routes.job(pipeline_name, job_name)
+        return Job(self._get(url))
 
 
 class SetTeamAPIUpdateMixin:

--- a/concourse/client/model.py
+++ b/concourse/client/model.py
@@ -120,6 +120,16 @@ class Job:
                 return True
         return False
 
+    def is_paused(self):
+        return self.raw['paused']
+
+    def next_build(self):
+        # Build class requires the Concourse-API, which we do not have here. Return the dict
+        # instead
+        if build_raw := self.raw.get('next_build'):
+            return build_raw
+        return None
+
 
 class Plan:
     '''

--- a/concourse/client/model.py
+++ b/concourse/client/model.py
@@ -72,7 +72,7 @@ class ResourceVersion(ModelBase):
         return self.raw['enabled']
 
 
-class PipelineConfig(object):
+class PipelineConfig:
     '''
     Wrapper around the dictionary received from invoking the concourse
     `pipelines/<pipeline>/config` REST API
@@ -91,7 +91,7 @@ class PipelineConfig(object):
         self.resources = [PipelineConfigResource(r, self) for r in resources]
 
     def jobs(self):
-        return [Job(job, self) for job in self.raw.get('jobs')]
+        return [Job(job) for job in self.raw.get('jobs')]
 
     def resources_of_types(self, types):
         return [r for r in self.resources if r.type in types]
@@ -105,10 +105,9 @@ class Job:
     Not intended to be instantiated by users of this module
     '''
     @ensure_annotations
-    def __init__(self, raw: dict, pipeline: PipelineConfig):
-        self.pipeline = pipeline
-        self.concourse_api = pipeline.concourse_api
+    def __init__(self, raw: dict):
         self.raw = raw
+        self.pipeline = raw['pipeline_name']
         self.name = raw['name']
 
     def plan(self):
@@ -136,7 +135,7 @@ class Plan:
         return [step for step in self.raw if 'get' in step]
 
 
-class PipelineConfigResource(object):
+class PipelineConfigResource:
     '''
     Wrapper around the dictionary representing a resource as part of a
     concourse.client.model.PipelineConfig
@@ -175,7 +174,7 @@ class PipelineConfigResource(object):
         )
 
 
-class GithubSource(object):
+class GithubSource:
     '''
     Wrapper around the source attribute of a concourse.client.model.PipelineConfigResource
     instance in the special case said resource is a "githubby" resource (either a git
@@ -299,7 +298,7 @@ class BuildPlan(ModelBase):
         return has_version_ref(self.raw.get('plan'))
 
 
-class BuildEvents(object):
+class BuildEvents:
     '''
     Wrapper around the event stream returned by concourse when querying the events for a
     certain build execution. The event stream is consumed using the `process_events`

--- a/concourse/client/routes.py
+++ b/concourse/client/routes.py
@@ -124,6 +124,10 @@ class ConcourseApiRoutesBase(object):
         return self._api_url('pipelines', pipeline_name, 'jobs', job_name, 'builds', build_name)
 
     @ensure_annotations
+    def job(self, pipeline_name: str, job_name: str):
+        return self._api_url('pipelines', pipeline_name, 'jobs', job_name)
+
+    @ensure_annotations
     def build_events(self, build_id):
         return self._api_url('builds', str(build_id), 'events', prefix_team=False)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a method to get a specific job to our Concourse API. Also adds some getters to help determine whether the Job is paused and whether a new build is already pending.