### PR TITLE
Add Release Note Categories

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,7 +22,7 @@ uses for building the release notes. ::
 
 Possible values:
 
-  - category: improvement\|noteworthy\|action
+  - category: breaking\|feature\|bugfix\|doc\|other
   - target\_group: user\|operator\|developer
 
 Example: ::

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,7 +23,7 @@ uses for building the release notes. ::
 Possible values:
 
   - category: breaking\|feature\|bugfix\|doc\|other
-  - target\_group: user\|operator\|developer
+  - target\_group: user\|operator\|developer\|dependency
 
 Example: ::
 

--- a/github/release_notes/renderer.py
+++ b/github/release_notes/renderer.py
@@ -27,24 +27,24 @@ def get_or_call(obj, path):
     return value
 
 
-TitleNode = namedtuple("TitleNode", ["identifier", "title", "nodes", "matches_rls_note_field_path"])
+TitleNode = namedtuple("TitleNode", ["identifiers", "title", "nodes", "matches_rls_note_field_path"])
 TARGET_GROUP_USER_ID = 'user'
 TARGET_GROUP_USER = TitleNode(
-    identifier=TARGET_GROUP_USER_ID,
+    identifiers=[TARGET_GROUP_USER_ID],
     title='USER',
     nodes=None,
     matches_rls_note_field_path='target_group_id'
 )
 TARGET_GROUP_OPERATOR_ID = 'operator'
 TARGET_GROUP_OPERATOR = TitleNode(
-    identifier=TARGET_GROUP_OPERATOR_ID,
+    identifiers=[TARGET_GROUP_OPERATOR_ID],
     title='OPERATOR',
     nodes=None,
     matches_rls_note_field_path='target_group_id'
 )
 TARGET_GROUP_DEVELOPER_ID = 'developer'
 TARGET_GROUP_DEVELOPER = TitleNode(
-    identifier=TARGET_GROUP_DEVELOPER_ID,
+    identifiers=[TARGET_GROUP_DEVELOPER_ID],
     title='DEVELOPER',
     nodes=None,
     matches_rls_note_field_path='target_group_id'
@@ -52,27 +52,57 @@ TARGET_GROUP_DEVELOPER = TitleNode(
 TARGET_GROUPS = [TARGET_GROUP_USER, TARGET_GROUP_OPERATOR, TARGET_GROUP_DEVELOPER]
 
 CATEGORY_ACTION_ID = 'action'
-CATEGORY_ACTION = TitleNode(
-    identifier=CATEGORY_ACTION_ID,
-    title='Action Required',
+CATEGORY_BREAKING_ID = 'breaking'
+CATEGORY_BREAKING = TitleNode(
+    identifiers=[CATEGORY_BREAKING_ID, CATEGORY_ACTION_ID],
+    title='⚠️ Breaking Changes',
     nodes=TARGET_GROUPS,
     matches_rls_note_field_path='category_id'
 )
 CATEGORY_NOTEWORTHY_ID = 'noteworthy'
 CATEGORY_NOTEWORTHY = TitleNode(
-    identifier=CATEGORY_NOTEWORTHY_ID,
-    title='Most notable changes',
+    identifiers=[CATEGORY_NOTEWORTHY_ID],
+    title='📰 Noteworthy',
     nodes=TARGET_GROUPS,
     matches_rls_note_field_path='category_id'
 )
 CATEGORY_IMPROVEMENT_ID = 'improvement'
-CATEGORY_IMPROVEMENT = TitleNode(
-    identifier=CATEGORY_IMPROVEMENT_ID,
-    title='Improvements',
+CATEGORY_OTHER_ID = 'other'
+CATEGORY_OTHER = TitleNode(
+    identifiers=[CATEGORY_OTHER_ID, CATEGORY_IMPROVEMENT_ID],
+    title='🏃 Others',
     nodes=TARGET_GROUPS,
     matches_rls_note_field_path='category_id'
 )
-CATEGORIES = [CATEGORY_ACTION, CATEGORY_NOTEWORTHY, CATEGORY_IMPROVEMENT]
+CATEGORY_FEATURE_ID = 'feature'
+CATEGORY_FEATURE = TitleNode(
+    identifiers=[CATEGORY_FEATURE_ID],
+    title='✨ New Features',
+    nodes=TARGET_GROUPS,
+    matches_rls_note_field_path='category_id'
+)
+CATEGORY_BUGFIX_ID = 'bugfix'
+CATEGORY_BUGFIX = TitleNode(
+    identifiers=[CATEGORY_BUGFIX_ID],
+    title='🐛 Bug Fixes',
+    nodes=TARGET_GROUPS,
+    matches_rls_note_field_path='category_id'
+)
+CATEGORY_DOC_ID = 'doc'
+CATEGORY_DOC = TitleNode(
+    identifiers=[CATEGORY_DOC_ID],
+    title='📖 Documentation',
+    nodes=TARGET_GROUPS,
+    matches_rls_note_field_path='category_id'
+)
+CATEGORIES = [
+  CATEGORY_BREAKING,
+  CATEGORY_FEATURE,
+  CATEGORY_BUGFIX,
+  CATEGORY_DOC,
+  CATEGORY_OTHER,
+  CATEGORY_NOTEWORTHY,
+]
 
 
 class Renderer(object):
@@ -86,7 +116,7 @@ class Renderer(object):
             .sort_by(lambda rls_note_obj: rls_note_obj.is_current_repo, reverse=True)\
             .uniq_by(lambda rls_note_obj: rls_note_obj.cn_source_repo.name())\
             .map(lambda rls_note_obj: TitleNode(
-                identifier=rls_note_obj.cn_source_repo.name(),
+                identifiers=[rls_note_obj.cn_source_repo.name()],
                 title='[{origin_name}]'.format(
                     origin_name=rls_note_obj.cn_source_repo.github_repo()
                 ),
@@ -116,7 +146,7 @@ class Renderer(object):
             filtered_rls_note_objects = _.filter(
                 rls_note_objs,
                 lambda rls_note_obj:
-                    node.identifier == get_or_call(rls_note_obj, node.matches_rls_note_field_path)
+                    get_or_call(rls_note_obj, node.matches_rls_note_field_path) in node.identifiers
             )
             if not filtered_rls_note_objects:
                 continue

--- a/github/release_notes/renderer.py
+++ b/github/release_notes/renderer.py
@@ -49,7 +49,19 @@ TARGET_GROUP_DEVELOPER = TitleNode(
     nodes=None,
     matches_rls_note_field_path='target_group_id'
 )
-TARGET_GROUPS = [TARGET_GROUP_USER, TARGET_GROUP_OPERATOR, TARGET_GROUP_DEVELOPER]
+TARGET_GROUP_DEPENDENCY_ID = 'dependency'
+TARGET_GROUP_DEPENDENCY = TitleNode(
+    identifiers=[TARGET_GROUP_DEPENDENCY_ID],
+    title='DEPENDENCY',
+    nodes=None,
+    matches_rls_note_field_path='target_group_id'
+)
+TARGET_GROUPS = [
+  TARGET_GROUP_USER,
+  TARGET_GROUP_OPERATOR,
+  TARGET_GROUP_DEVELOPER,
+  TARGET_GROUP_DEPENDENCY
+]
 
 CATEGORY_ACTION_ID = 'action'
 CATEGORY_BREAKING_ID = 'breaking'

--- a/test/github/release_notes/renderer_test.py
+++ b/test/github/release_notes/renderer_test.py
@@ -33,6 +33,7 @@ from github.release_notes.renderer import (
     TARGET_GROUP_DEVELOPER_ID,
     TARGET_GROUP_OPERATOR_ID,
     TARGET_GROUP_USER_ID,
+    TARGET_GROUP_DEPENDENCY_ID,
 )
 from test.github.release_notes.default_util import (
     release_note_block_with_defaults,
@@ -412,6 +413,13 @@ class RendererTest(unittest.TestCase):
                 user_login=None,
             ),
             release_note_block_with_defaults(
+                target_group_id=TARGET_GROUP_DEPENDENCY_ID,
+                text='dependency release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
                 target_group_id=TARGET_GROUP_DEVELOPER_ID,
                 text='developer release note',
                 reference_type=None,
@@ -426,7 +434,8 @@ class RendererTest(unittest.TestCase):
             '## 🏃 Others\n'\
             '* *[USER]* user release note\n'\
             '* *[OPERATOR]* operator release note\n'\
-            '* *[DEVELOPER]* developer release note'
+            '* *[DEVELOPER]* developer release note\n'\
+            '* *[DEPENDENCY]* dependency release note'
         self.assertEqual(expected_md_str, actual_md_str)
 
     def test_get_or_call(self):

--- a/test/github/release_notes/renderer_test.py
+++ b/test/github/release_notes/renderer_test.py
@@ -23,11 +23,16 @@ from github.release_notes.renderer import (
     MarkdownRenderer,
     get_or_call,
     CATEGORY_ACTION_ID,
-    CATEGORY_NOTEWORTHY_ID,
+    CATEGORY_BUGFIX_ID,
+    CATEGORY_BREAKING_ID,
+    CATEGORY_DOC_ID,
+    CATEGORY_FEATURE_ID,
     CATEGORY_IMPROVEMENT_ID,
-    TARGET_GROUP_USER_ID,
-    TARGET_GROUP_OPERATOR_ID,
+    CATEGORY_OTHER_ID,
+    CATEGORY_NOTEWORTHY_ID,
     TARGET_GROUP_DEVELOPER_ID,
+    TARGET_GROUP_OPERATOR_ID,
+    TARGET_GROUP_USER_ID,
 )
 from test.github.release_notes.default_util import (
     release_note_block_with_defaults,
@@ -50,7 +55,7 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* first line with header (#42, @foo)\n'\
             '  * second line\n'\
             '  * third line'
@@ -67,7 +72,7 @@ class RendererTest(unittest.TestCase):
         expected_md_str = \
             '\n'.join((
                 '# [s]',
-                '## Improvements',
+                '## 🏃 Others',
                 '* *[USER]* default release note text '
                 '([o/s#42](https://madeup.enterprise.github.corp/o/s/pull/42), '
                 '[@foo](https://madeup.enterprise.github.corp/foo))'
@@ -92,10 +97,10 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* default release note text (#42, @foo)\n'\
             '# [a-foo-bar]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* other component, same github instance rls note (madeup/a-foo-bar#1, @foo)'
         self.assertEqual(expected_md_str, actual_md_str)
 
@@ -132,14 +137,14 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = ''\
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* rls note 1 (commit-id-1, @foo)\n'\
             '# [a-foo-bar]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* other component rls note ' \
             '(madeup/a-foo-bar@very-long-commit-id-that-will-not-be-shortened, @bar)\n'\
             '# [s]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* release note from different github instance ' \
             '([o/s@very-long-co](https://madeup.enterprise.github.corp/o/s/commit/'\
             'very-long-commit-id-that-will-be-shortened), '\
@@ -165,10 +170,10 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* default release note text (@foo)\n'\
             '# [a-foo-bar]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* default release note text (@bar)'
         self.assertEqual(expected_md_str, actual_md_str)
 
@@ -191,10 +196,10 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* default release note text\n'\
             '# [a-foo-bar]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* default release note text'
         self.assertEqual(expected_md_str, actual_md_str)
 
@@ -219,7 +224,7 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* duplicate'
         self.assertEqual(expected_md_str, actual_md_str)
 
@@ -251,7 +256,7 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* first line1\n'\
             '  * second line1\n'\
             '* *[USER]* first line2\n'\
@@ -289,7 +294,7 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* first line1\n'\
             '  * second line1\n'\
             '* *[USER]* first line2\n'\
@@ -303,8 +308,69 @@ class RendererTest(unittest.TestCase):
     def test_render_categories(self):
         release_note_objs = [
             release_note_block_with_defaults(
+                category_id=CATEGORY_OTHER_ID,
+                text='other release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_DOC_ID,
+                text='documentation release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_BREAKING_ID,
+                text='breaking change release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_BUGFIX_ID,
+                text='bug fix release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_FEATURE_ID,
+                text='new feature release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+        ]
+
+        actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
+        expected_md_str = \
+            '# [current-repo]\n'\
+            '## ⚠️ Breaking Changes\n'\
+            '* *[USER]* breaking change release note\n'\
+            '## ✨ New Features\n'\
+            '* *[USER]* new feature release note\n'\
+            '## 🐛 Bug Fixes\n'\
+            '* *[USER]* bug fix release note\n'\
+            '## 📖 Documentation\n'\
+            '* *[USER]* documentation release note\n'\
+            '## 🏃 Others\n'\
+            '* *[USER]* other release note'
+        self.assertEqual(expected_md_str, actual_md_str)
+
+    def test_render_deprecated_categories(self):
+        release_note_objs = [
+            release_note_block_with_defaults(
                 category_id=CATEGORY_IMPROVEMENT_ID,
-                text='improvement release note',
+                text='improvement / other release note',
+                reference_type=None,
+                reference_id=None,
+                user_login=None,
+            ),
+            release_note_block_with_defaults(
+                category_id=CATEGORY_ACTION_ID,
+                text='action / breaking change release note',
                 reference_type=None,
                 reference_id=None,
                 user_login=None,
@@ -316,24 +382,17 @@ class RendererTest(unittest.TestCase):
                 reference_id=None,
                 user_login=None,
             ),
-            release_note_block_with_defaults(
-                category_id=CATEGORY_ACTION_ID,
-                text='action required release note',
-                reference_type=None,
-                reference_id=None,
-                user_login=None,
-            ),
         ]
 
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Action Required\n'\
-            '* *[USER]* action required release note\n'\
-            '## Most notable changes\n'\
-            '* *[USER]* noteworthy release note\n'\
-            '## Improvements\n'\
-            '* *[USER]* improvement release note'
+            '## ⚠️ Breaking Changes\n'\
+            '* *[USER]* action / breaking change release note\n'\
+            '## 🏃 Others\n'\
+            '* *[USER]* improvement / other release note\n'\
+            '## 📰 Noteworthy\n'\
+            '* *[USER]* noteworthy release note'
         self.assertEqual(expected_md_str, actual_md_str)
 
     def test_render_target_group(self):
@@ -364,7 +423,7 @@ class RendererTest(unittest.TestCase):
         actual_md_str = MarkdownRenderer(release_note_objs=release_note_objs).render()
         expected_md_str = \
             '# [current-repo]\n'\
-            '## Improvements\n'\
+            '## 🏃 Others\n'\
             '* *[USER]* user release note\n'\
             '* *[OPERATOR]* operator release note\n'\
             '* *[DEVELOPER]* developer release note'


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, new release note categories and a new target group will be introduced.

Today we have:
```
Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
```

Which changes to:
```
Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
```

The "old" categories are still kept for compatibility reasons, but can be removed in the future. This is how the old categories are mapped to the new ones:
`improvement` -> `other`
`noteworthy` -> remains as is, but the category title changes from `Most notable changes` to `📰 Noteworthy`
`action` -> `breaking`

As discussed offline with @timebertt, the `dependency` target could be used for the scenario listed in #482
> [...] a dedicated release note type for changes in g/g/ext that affect extension developers and that contain improvements for all extension controllers (e.g. in the generic worker actuator)

The release notes will look like

---


# [dummy-component]
## ⚠️ Breaking Changes
- [DEVELOPER] Allow to specify a custom network in Cluster.Spec (#196 @petersutter)
- ...

## ✨ New Features
- [USER] Allow the ability to configure frontend and backend port for LB (#215 @petersutter)
- ...

## 🐛 Bug Fixes
- [DEVELOPER] Support running alongside other Cluster API pods in the same namespace with leader election enabled (#211 @petersutter)
- ...

## 📖 Documentation
- [DEVELOPER] Dev oriented doc for the conformance tests (#208 @petersutter)
- ...

## 🏃 Others
- [DEVELOPER] Go mod files and generated files (#212 @petersutter)
- ...

---

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
