### PR TITLE
Add support for aborting running jobs on push-events to whd

### DIFF
--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+
+import ci.util
+import concourse.client
+
+from ensure import ensure_annotations
+
+
+@functools.lru_cache()
+@ensure_annotations
+def client_from_cfg_name(concourse_cfg_name: str, team_name: str):
+    cfg_factory = ci.util.ctx().cfg_factory()
+    cc_cfg = cfg_factory.concourse(concourse_cfg_name)
+    return concourse.client.from_cfg(
+        concourse_cfg=cc_cfg,
+        team_name=team_name,
+        verify_ssl=True,
+    )

--- a/ci/util.py
+++ b/ci/util.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import collections
+import functools
 import hashlib
 import os
 import pathlib
@@ -496,7 +497,7 @@ def which(cmd_name: str) -> str:
     return cmd_path
 
 
-def merge_dicts(base: dict, other: dict, list_semantics='merge'):
+def merge_dicts(base: dict, *other: dict, list_semantics='merge'):
     '''
     merges copies of the given dict instances and returns the merge result.
     The arguments remain unmodified. However, it must be possible to copy them
@@ -508,10 +509,10 @@ def merge_dicts(base: dict, other: dict, list_semantics='merge'):
     By default, different from the original implementation, a merge will be applied to
     lists. This results in deduplication retaining element order. The elements from `other` are
     appended to those from `base`.
-
     '''
+
     not_none(base)
-    not_none(other)
+    not_empty(other)
 
     from deepmerge import Merger
 
@@ -530,8 +531,12 @@ def merge_dicts(base: dict, other: dict, list_semantics='merge'):
         raise NotImplementedError
 
     from copy import deepcopy
-    # copy dicts, so they remain unmodified
-    return merger.merge(deepcopy(base), deepcopy(other))
+
+    return functools.reduce(
+        lambda b, o: merger.merge(b, deepcopy(o)),
+        [base, *other],
+        {},
+    )
 
 
 class FluentIterable(object):

--- a/concourse/client/model.py
+++ b/concourse/client/model.py
@@ -117,7 +117,7 @@ class Job:
     def is_triggered_by_resource(self, resource_name: str):
         get_steps = self.plan().get_steps()
         for get_step in get_steps:
-            if get_step['get'] == resource_name and get_step['trigger']:
+            if get_step['get'] == resource_name and get_step.get('trigger', False):
                 return True
         return False
 

--- a/concourse/client/util.py
+++ b/concourse/client/util.py
@@ -99,12 +99,13 @@ def determine_pr_resource_versions(
 
 
 def determine_jobs_to_be_triggered(
-    resource: PipelineConfigResource,
+    *resources: PipelineConfigResource,
 ) -> typing.Iterator[Job]:
 
-    yield from (
-        job for job in resource.pipeline.jobs() if job.is_triggered_by_resource(resource.name)
-    )
+    for resource in resources:
+        yield from (
+            job for job in resource.pipeline.jobs() if job.is_triggered_by_resource(resource.name)
+        )
 
 
 def wait_for_job_to_be_triggered(

--- a/concourse/enumerator.py
+++ b/concourse/enumerator.py
@@ -420,6 +420,9 @@ class DefinitionDescriptor:
     def template_name(self):
         return self.pipeline_definition.get('template', 'default')
 
+    def effective_pipeline_name(self):
+        return '-'.join((self.pipeline_name, self.main_repo['branch']))
+
     def concourse_target(self):
         return (self.concourse_target_cfg, self.concourse_target_team)
 

--- a/concourse/model/job.py
+++ b/concourse/model/job.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import toposort
 
 from concourse.model.base import (
@@ -21,6 +22,12 @@ from concourse.model.base import (
 )
 from ci.util import not_none
 from concourse.model.resources import RepositoryConfig, ResourceIdentifier
+
+
+class AbortObsoleteJobs(enum.Enum):
+    ALWAYS = 'always'
+    ON_FORCE_PUSH_ONLY = 'on_force_push_only'
+    NEVER = 'never'
 
 
 class JobVariant(ModelBase):
@@ -36,10 +43,11 @@ class JobVariant(ModelBase):
 
     def _known_attributes(self):
         return {
-            'steps',
-            'traits',
+            'abort_obsolete_jobs',
             'repo',
             'repos',
+            'steps',
+            'traits',
         }
 
     def _children(self):

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -226,7 +226,7 @@ class ReleaseTrait(Trait):
         self.raw = ci.util.merge_dicts(
             self._defaults_dict(),
             raw_dict,
-            None,
+            list_semantics=None,
         )
 
     def transformer(self):

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -156,20 +156,12 @@ class Renderer(object):
         if bg := effective_definition.get('background_image'):
             pipeline_metadata['background_image'] = bg
 
-        # determine pipeline name (if there is main-repo, append the configured branch name)
         for variant in pipeline_metadata.get('definition').variants():
-            # hack: take the first "main_repository" we find
             if not variant.has_main_repository():
-                continue
-            main_repo = variant.main_repository()
-            pipeline_metadata['pipeline_name'] = '-'.join(
-                [pipeline_definition.name, main_repo.branch()]
-            )
-            break
-        else:
-            # fallback in case no main_repository was found
-            pipeline_metadata['pipeline_name'] = pipeline_definition.name
-            main_repo = None
+                raise RuntimeError(
+                    f"No main repository for pipeline definition {pipeline_definition.name}."
+                )
+            pipeline_metadata['pipeline_name'] = definition_descriptor.effective_pipeline_name()
 
         t = mako.template.Template(template_contents, lookup=self.lookup)
 

--- a/test/ci/util_test.py
+++ b/test/ci/util_test.py
@@ -139,6 +139,40 @@ class UtilTest(unittest.TestCase):
             {1: [3, 1, 0, 2, 4]},
         )
 
+    def test_merge_dicts_does_not_modify_args(self):
+        from copy import deepcopy
+        first = {1: {2: 3}}
+        second = {1: {4: 5}, 6: 7}
+        first_arg = deepcopy(first)
+        second_arg = deepcopy(second)
+
+        merged = examinee.merge_dicts(first_arg, second_arg)
+
+        self.assertEqual(
+            merged,
+            {
+                1: {2: 3, 4: 5},
+                6: 7,
+            }
+        )
+        self.assertEqual(first, first_arg)
+        self.assertEqual(second, second_arg)
+
+    def test_merge_dicts_three_way_merge(self):
+        first = {1: [3, 1, 0]}
+        second = {1: [1, 2, 4]}
+        third = {1: [1, 2, 5], 2: [1, 2, 3]}
+
+        merged = examinee.merge_dicts(first, second, third, list_semantics='merge')
+
+        self.assertEqual(
+            merged,
+            {
+                1: [3, 1, 0, 2, 4, 5],
+                2: [1, 2, 3],
+            }
+        )
+
 
 def test_count_elements():
     count = ci.util._count_elements

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -273,7 +273,6 @@ class GithubWebhookDispatcher(object):
             if isinstance(event, PushEvent):
                 if not event.ref().endswith(ghs.branch_name()):
                     continue
-            if isinstance(event, PushEvent):
                 if msg := event.commit_message():
                     if (
                         not ghs.disable_ci_skip()

--- a/whd/model.py
+++ b/whd/model.py
@@ -73,6 +73,12 @@ class PushEvent(EventBase):
             return head_commit.get('message')
         return None
 
+    def is_forced_push(self):
+        return self.raw['forced']
+
+    def previous_ref(self):
+        return self.raw['before']
+
 
 class PullRequestAction(enum.Enum):
     ASSIGNED = 'assigned'

--- a/whd/model.py
+++ b/whd/model.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import enum
 import urllib.parse
 
+import dacite
+
+from concourse.model.job import AbortObsoleteJobs
 from model.base import ModelBase
 
 
@@ -115,3 +119,23 @@ class PullRequestEvent(EventBase):
         the user who performed the event
         '''
         return self.raw['sender']
+
+
+@dataclasses.dataclass
+class Pipeline:
+    pipeline_name: str
+    target_team: str
+    effective_definition: dict
+
+
+@dataclasses.dataclass
+class AbortConfig:
+    abort_obsolete_jobs: AbortObsoleteJobs
+
+    @staticmethod
+    def from_dict(d: dict):
+        return dacite.from_dict(
+            data_class=AbortConfig,
+            data=d,
+            config=dacite.Config(cast=[AbortObsoleteJobs]),
+        )


### PR DESCRIPTION
Allows one to configure whether a build should be aborted on follow-up push. Old behaviour (no aborting) is preserved if no config is given. Aborting can be configured on a per-job basis. Config example:

```yaml
…
  jobs:
    foo:
      abort_outdated_jobs: 'all' # all | forced_only
      steps:
        …
      traits:
        …
…
```
