### PR TITLE
Fix issues in default component descriptor

### DIFF
--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 import typing
-import yaml
 
+import git
+import yaml
 
 import ci.util
 from product.util import (
@@ -143,3 +144,16 @@ def write_component_diff(component_diff, out_path):
 
     with open(out_path, 'w') as f:
         yaml.dump(diff_dict, f)
+
+
+def head_commit_hexsha(repo_path):
+    git_repo = git.Repo(repo_path)
+    if not git_repo.head.is_valid():
+        commit_hash = None
+    else:
+        try:
+            commit_hash = git_repo.head.commit.hexsha
+        except:
+            commit_hash = None
+
+    return commit_hash

--- a/test/concourse/factory_test.py
+++ b/test/concourse/factory_test.py
@@ -1,5 +1,8 @@
 import unittest
 
+import model
+import model.github
+
 from model.base import ModelValidationError
 from concourse.factory import (
     RawPipelineDefinitionDescriptor as DefDescriptor,
@@ -87,9 +90,17 @@ class DefinitionFactoryTest(unittest.TestCase):
             },
         }
         descriptor = DefDescriptor(name='foo', base_definition=base_def, variants=variants)
+
+        cfg_set = model.ConfigurationSet('dummy','dummy', raw_dict={})
+        cfg_set.github = unittest.mock.MagicMock(
+            return_value=model.github.GithubConfig(
+                name='dontcare',
+                raw_dict={'available_protocols': ('https',)}
+                ),
+            )
         factory = DefinitionFactory(
             raw_definition_descriptor=descriptor,
-            cfg_set=None,
+            cfg_set=cfg_set,
         )
 
         result = factory.create_pipeline_definition()

--- a/test/concourse/steps/component_descriptor_test.py
+++ b/test/concourse/steps/component_descriptor_test.py
@@ -60,7 +60,7 @@ class ComponentDescriptorStepTest(unittest.TestCase):
             job_step=self.job_variant.step('component_descriptor'),
             job_variant=self.job_variant,
             output_image_descriptors={},
-            indent=0
+            indent=0,
         )
 
         # try to compile (-> basic syntax check)


### PR DESCRIPTION
Changes default component descriptor so that a github-config is always available for additional repositories. The config taken will be the default config for the location of the pipeline if no config is explicitly configured, mimicking the behaviour of the replication.

Also, for additional sources (created by having additional repositories defined) it will now be attempted to determine the _actual_ commit hash before falling back to the main-repositories' commit-hash.
