### PR TITLE
Make base cd compliant

### DIFF
--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -74,7 +74,7 @@ if not (repo_commit_hash := head_commit_hexsha(os.path.abspath('${repository.res
   warning('Could not determine commit hash')
 component_v2.sources.append(
   cm.ComponentSource(
-    name='${repository.name()}',
+    name='${repository.logical_name().replace('/', '_').replace('.', '_')}',
     type=cm.SourceType.GIT,
     access=cm.GithubAccess(
       type=cm.AccessType.GITHUB,

--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -59,6 +59,9 @@ def base_component_descriptor_v2(
         else:
             src_ref = f'{parsed_version.prerelease}'
 
+    # logical names must not contain slashes or dots
+    logical_name = component_name_v2.replace('/', '_').replace('.', '_')
+
     base_descriptor_v2 = cm.ComponentDescriptor(
       meta=cm.Metadata(schemaVersion=cm.SchemaVersion.V2),
       component=cm.Component(
@@ -73,7 +76,7 @@ def base_component_descriptor_v2(
         provider=cm.Provider.INTERNAL,
         sources=[
           cm.ComponentSource(
-            name=component_name_v2, # XXX only valid for gardener-components
+            name=logical_name,
             type=cm.SourceType.GIT,
             access=cm.GithubAccess(
               type=cm.AccessType.GITHUB,


### PR DESCRIPTION
Currently, generated base cds are not compliant with component-descriptor v2 spec. Consider the following shortened cd (taken from our release jobs):

```yaml
component:
  componentReferences:
  - componentName: github.com/gardener/component-spec
    extraIdentity: {}
    labels: []
    name: github.com_gardener_component-spec
    version: v0.0.24
  labels: []
  name: github.com/gardener/cc-utils
  provider: internal
  repositoryContexts:
  - baseUrl: eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development
    type: ociRegistry
  resources:
  - access:
      imageReference: eu.gcr.io/gardener-project/cc/job-image:1.1030.0
      type: ociRegistry
    extraIdentity: {}
    labels:
    - name: cloud.cnudie/examples
      value: 'this is an example label (btw: value may be also e.g. a dict)'
    name: job-image
    relation: local
    srcRefs: []
    type: ociImage
    version: 1.1030.0
  - access:
      imageReference: eu.gcr.io/gardener-project/cc/job-image-kaniko:1.1030.0
      type: ociRegistry
    extraIdentity: {}
    labels: []
    name: kaniko-image
    relation: local
    srcRefs: []
    type: ociImage
    version: 1.1030.0
  sources:
  - access:
      commit: 60cec2381381a6eebc305cb595dd50f13f19a855
      ref: refs/tags/1.1030.0
      repoUrl: github.com/gardener/cc-utils
      type: github
    extraIdentity: {}
    labels: []
    name: github.com/gardener/cc-utils
    type: git
    version: 1.1030.0
  - access:
      commit: 60cec2381381a6eebc305cb595dd50f13f19a855
      ref: gh-pages
      repoUrl: github.com/gardener/cc-utils
      type: github
    extraIdentity: {}
    labels: []
    name: git-gardener.cc-utils-gh-pages
    type: git
    version: 1.1030.0
  version: 1.1030.0
meta:
  schemaVersion: v2
```
Here, both entries of `component.sources` have invalid logical names, as they both contain `.` and the first one also contains `/`. (there is also another mistake caused by our cd script, but that's not part of this PR)

This PR changes the way logical names are generated/used in the base component descriptor as follows:
- the main-repository is assigned a sanitized component-name as its logical name (e.g. `github_com_gardener_cc-utils`).
- additional repositories are assigned their logical name as per pipeline-definition (e.g. `gh_pages` in the above example).
