### PR TITLE
Use SAF Client in Malware Scanning

### DIFF
--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -21,6 +21,7 @@ import os
 import sys
 import tabulate
 import textwrap
+import uuid
 
 import gci.componentmodel as cm
 
@@ -34,6 +35,7 @@ try:
   ctx.configure_default_logging()
 except:
   pass
+import ccc.clamav
 import concourse.util
 import ci.util
 import cnudie.retrieve
@@ -48,6 +50,7 @@ import saf.model as sm
 from concourse.model.traits.image_scan import Notify
 from protecode.model import CVSSVersion
 from protecode.scanning_util import ProcessingMode
+from clamav.util import virus_scan_images
 
 ${step_lib('scan_container_images')}
 ${step_lib('images')}
@@ -66,35 +69,36 @@ filter_function = create_composite_filter_function(
   include_component_names=${filter_cfg.include_component_names()},
   exclude_component_names=${filter_cfg.exclude_component_names()},
 )
-
-image_references = [
-  resource.access.imageReference
-  for component, resource
-  in product.v2.enumerate_oci_resources(
-    component_descriptor=component_descriptor,
-  )
-  if filter_function(component, resource)
-]
+uuid_marker = uuid.uuid4()
+clamav_client = ccc.clamav.client_from_config_name('${clam_av.clamav_cfg_name()}')
 
 ci.util.info('running malware scan for all container images')
 malware_scan_results = [
   scan_result
-  for scan_result in virus_scan_images(image_references, '${clam_av.clamav_cfg_name()}')
+  for scan_result in virus_scan_images(
+    component_descriptor,
+    filter_function,
+    clamav_client,
+  )
 ]
 malware_scan_results_with_findings = [
   sr for sr in malware_scan_results
-  if sr.finding != 'No malware detected.'
+  if sr.findings
 ]
-ci.util.info(f'{len(image_references)} image(s) scanned for virus signatures.')
 print(
   tabulate.tabulate(
-    map(lambda dc: dataclasses.astuple(dc), malware_scan_results),
-    headers=MalwareScanResult.headers(),
+    (
+      (sr.resource.name, sr.scan_state, '\n'.join(sr.findings))
+      for sr in malware_scan_results
+    ),
+    headers=('Resource Name', 'Scan State', 'Findings'),
     tablefmt='fancy_grid',
   )
 )
 
 # publish evidence to SAF-API
+print(str(uuid_marker))
+
 try:
   clamav_cfg = cfg_set.clamav('${clam_av.clamav_cfg_name()}')
   saf_client = saf.client.SafClient(saf_cfg=cfg_set.saf())
@@ -110,10 +114,9 @@ try:
       scanning_endpoint=clamav_cfg.service_url(),
       scanning_cfg='${clam_av.clamav_cfg_name()}',
       scan_results=malware_scan_results, # XXX need to convert to proper format
+      scan_log=retrieve_buildlog(uuid=uuid_marker),
     ),
   )
-  ci.util.info('posting evidence to saf-api')
-  print(evidence_rq)
   saf_client.post_evidence(evidence=evidence_rq)
 except:
   import traceback

--- a/saf/client.py
+++ b/saf/client.py
@@ -1,4 +1,6 @@
 import dataclasses
+import enum
+import json
 
 import requests
 
@@ -20,7 +22,7 @@ class SafClient:
             headers={
                 'Authorization': f'Bearer {self._saf_cfg.credentials().bearer_token}',
             },
-            json=raw,
+            data=json.dumps(raw, cls=EnumJSONEncoder),
         )
 
         res.raise_for_status()
@@ -31,3 +33,13 @@ class SafClient:
         raw = dataclasses.asdict(evidence)
 
         return self._post_evidence_dict(raw=raw)
+
+
+class EnumJSONEncoder(json.JSONEncoder):
+    '''
+    a json.JSONEncoder that will encode enum objects using their values
+    '''
+    def default(self, o):
+        if isinstance(o, enum.Enum):
+            return o.value
+        return super().default(o)

--- a/saf/model.py
+++ b/saf/model.py
@@ -34,7 +34,6 @@ class MalwarescanResult:
     resource: cm.Resource
     scan_state: MalwareScanState
     findings: typing.List[str]
-    scan_log: str
 
 
 @dc
@@ -45,6 +44,7 @@ class MalwarescanEvidenceData:
     scanning_endpoint: str
     scanning_cfg: str
     scan_results: typing.List[MalwarescanResult]
+    scan_log: str
 
 
 @dc


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the malware scanning to use the SAF-Client and its associated model classes and report its findings to the SAF-API.
Currently, will still generate and send e-mail reports, if configured.

