### PR TITLE
Fix kaniko build some more

### DIFF
--- a/concourse/steps/build_oci_image.mako
+++ b/concourse/steps/build_oci_image.mako
@@ -36,6 +36,8 @@ import ccc.oci
 import container.registry as cr
 import oci
 
+import shutil
+
 ${step_lib('build_oci_image')}
 
 home = os.path.join('/', 'kaniko')
@@ -51,6 +53,7 @@ write_docker_cfg(
 subproc_env = os.environ.copy()
 subproc_env['HOME'] = home
 subproc_env['GOOGLE_APPLICATION_CREDENTIALS'] = docker_cfg_path
+subproc_env['PATH'] = os.path.join('/', 'kaniko', 'bin')
 
 image_outfile = '${image_descriptor.name()}.oci-image.tar'
 
@@ -86,6 +89,10 @@ os.link(
   (ca_certs_path := os.path.join('/', 'etc', 'ssl', 'certs', 'ca-certificates.crt')),
   (ca_certs_bak := os.path.join('/', 'kaniko', 'ca-certificates.crt')),
 )
+
+# HACK remove '/usr/lib' and '/cc/utils' to avoid pip from failing in the first stage of builds
+shutil.rmtree(os.path.join('/', 'usr', 'lib'))
+shutil.rmtree(os.path.join('/', 'cc', 'utils'))
 
 # XXX final hack (I hope): cp entire python-dir
 import sys


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds using Kaniko might not succeed if they use pip in their first stage, as pip is already pre-installed in the image _building_ the container image and any incompatibilities of the existing source files will cause the installation in the _built_ image to fail.
The workaround here is to set PATH to an empty directory (currently `/kaniko/bin`, but not 100% sure about that) and remove all existing python files.

As a follow up, installation of cc-utils _using_ pip fails for similar reasons (as the file already exists in `/cc/utils` and a link is to be created during installation), thus `/cc/utils` is removed as well.

For all following stages these problems do not appear, as kaniko purges the image between every stage.

