### PR TITLE
Configure File-Logger with Logrotation for WHD

### DIFF
--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -26,6 +26,7 @@ def start_whd(
     production: bool=False,
     workers: int=4,
 ):
+    import whd
     import whd.server
 
     cfg_factory = ci.util.ctx().cfg_factory()
@@ -41,6 +42,7 @@ def start_whd(
     any_interface = '0.0.0.0'
 
     if production:
+        whd.configure_whd_logging()
         import bjoern
         multiprocessing.set_start_method('fork')
 

--- a/ctx.py
+++ b/ctx.py
@@ -15,6 +15,8 @@
 
 import enum
 import functools
+import logging
+import logging.config
 import os
 
 from pathlib import Path
@@ -203,13 +205,8 @@ def cfg_factory():
     return factory
 
 
-def configure_default_logging(stdout_level=None):
-    import logging
-    import logging.config
-    if not stdout_level:
-        stdout_level = logging.INFO
-
-    cfg = {
+def _default_logging_config(stdout_level):
+    return {
         'version': 1,
         'formatters': {
             'default': {
@@ -228,6 +225,15 @@ def configure_default_logging(stdout_level=None):
             'level': logging.DEBUG,
             'handlers': ['console',],
         },
+    }
+
+
+def configure_default_logging(stdout_level=None):
+    if not stdout_level:
+        stdout_level = logging.INFO
+
+    cfg = _default_logging_config(stdout_level)
+    cfg.update({
         'loggers': {
             'github3': {
                 'level': logging.WARNING,
@@ -236,6 +242,5 @@ def configure_default_logging(stdout_level=None):
                 'level': logging.WARNING,
             },
         }
-    }
-
+    })
     logging.config.dictConfig(cfg)

--- a/whd/__init__.py
+++ b/whd/__init__.py
@@ -12,3 +12,34 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
+import os
+
+import ctx
+
+
+def configure_whd_logging(stdout_level=None):
+    if not stdout_level:
+        stdout_level = logging.INFO
+
+    cfg = ctx._default_logging_config(stdout_level)
+    cfg['handlers'].update({
+        'rotating_file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'default',
+            'level': stdout_level,
+            'filename': os.path.join('/', 'tmp', 'whd_log'),
+            'backupCount': 1,
+            'maxBytes': 50*1024*1024,  # 50 MiB
+        },
+    })
+    cfg.update({
+        'loggers': {
+            'whd': {
+                'level': logging.DEBUG,
+                'handlers': ['rotating_file',],
+            },
+        },
+    })
+    logging.config.dictConfig(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures our WHD to _also_ log to a file (`/tmp/whd_log` by default). Log rotation is configured to take place as soon as this file has a size of 50 MiB with one backup (will then be named `whd_log.1`)
