### PR TITLE
Remove final dependencies on product.model

### DIFF
--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -296,7 +296,7 @@ def diff_resources(
     return resource_diff
 
 
-def component_descriptor_from_ctf_archive(
+def component_descriptors_from_ctf_archive(
     ctf_archive: typing.Union[str, typing.IO[bytes]],
 ) -> typing.Generator[cm.ComponentDescriptor, None, None]:
     if isinstance(ctf_archive, str):

--- a/test/concourse/steps/release_test.py
+++ b/test/concourse/steps/release_test.py
@@ -173,6 +173,27 @@ class TestGitHubReleaseStep(object):
 class TestPublishReleaseNotesStep(object):
     @pytest.fixture()
     def examinee(self, tmp_path):
+        component_descriptor_v2 = os.path.join(tmp_path, 'component_descriptor_v2')
+        ctf_path = os.path.join(tmp_path, product.v2.CTF_OUT_DIR_NAME)
+        cd_v2 = cm.ComponentDescriptor(
+            component=cm.Component(
+                name='a_name',
+                version='1.2.3',
+                repositoryContexts=[],
+                provider=cm.Provider.INTERNAL,
+                sources=[],
+                componentReferences=[],
+                resources=[],
+            ),
+            meta=cm.Metadata(),
+        )
+        with open(component_descriptor_v2, 'w') as f:
+            yaml.dump(
+                data=dataclasses.asdict(cd_v2),
+                stream=f,
+                Dumper=cm.EnumValueYamlDumper,
+            )
+
         def _examinee(
             github_helper=MagicMock(),
             githubrepobranch=GitHubRepoBranch(
@@ -189,6 +210,8 @@ class TestPublishReleaseNotesStep(object):
                 githubrepobranch=githubrepobranch,
                 repo_dir=repo_dir,
                 release_version=release_version,
+                component_descriptor_v2_path=component_descriptor_v2,
+                ctf_path=ctf_path,
             )
         return _examinee
 

--- a/test/github/release_notes/renderer_test.py
+++ b/test/github/release_notes/renderer_test.py
@@ -37,7 +37,9 @@ from github.release_notes.renderer import (
 )
 from test.github.release_notes.default_util import (
     release_note_block_with_defaults,
-    CURRENT_REPO_NAME,
+    CURRENT_COMPONENT_HOSTNAME,
+    CURRENT_COMPONENT_ORG_NAME,
+    CURRENT_COMPONENT_REPO_NAME,
 )
 
 
@@ -65,7 +67,9 @@ class RendererTest(unittest.TestCase):
     def test_render_from_other_github_should_auto_link(self):
         release_note_objs = [
             release_note_block_with_defaults(
-                source_repo='madeup.enterprise.github.corp/o/s',
+                source_component_hostname='madeup.enterprise.github.corp',
+                source_component_org_name='o',
+                source_component_repo_name='s',
             )
         ]
 
@@ -85,13 +89,17 @@ class RendererTest(unittest.TestCase):
             release_note_block_with_defaults(
                 reference_type=REF_TYPE_PULL_REQUEST,
                 reference_id='42',
-                source_repo=CURRENT_REPO_NAME,
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name=CURRENT_COMPONENT_ORG_NAME,
+                source_component_repo_name=CURRENT_COMPONENT_REPO_NAME,
             ),
             release_note_block_with_defaults(
                 reference_type=REF_TYPE_PULL_REQUEST,
                 reference_id='1',
                 text='other component, same github instance rls note',
-                source_repo='github.com/madeup/a-foo-bar',
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name='madeup',
+                source_component_repo_name='a-foo-bar',
             )
         ]
 
@@ -111,7 +119,6 @@ class RendererTest(unittest.TestCase):
                 text='rls note 1',
                 reference_type=REF_TYPE_COMMIT,
                 reference_id='commit-id-1',
-                source_repo=CURRENT_REPO_NAME,
             ),
             # As the source repository is on the same github instance as the current repository
             # it can be auto linked by github, hence we do not need to build a link to the commit
@@ -121,7 +128,7 @@ class RendererTest(unittest.TestCase):
                 reference_type=REF_TYPE_COMMIT,
                 reference_id='very-long-commit-id-that-will-not-be-shortened',
                 user_login='bar',
-                source_repo='github.com/madeup/a-foo-bar',
+                source_component_repo_name='a-foo-bar',
             ),
             # the source repository is on a different github instance as the current repository.
             # It can not be auto linked by github, hence we need to build a link to the commit
@@ -131,7 +138,9 @@ class RendererTest(unittest.TestCase):
                 reference_type=REF_TYPE_COMMIT,
                 reference_id='very-long-commit-id-that-will-be-shortened',
                 user_login='bar',
-                source_repo='madeup.enterprise.github.corp/o/s',
+                source_component_hostname='madeup.enterprise.github.corp',
+                source_component_org_name='o',
+                source_component_repo_name='s',
             )
         ]
 
@@ -158,13 +167,18 @@ class RendererTest(unittest.TestCase):
                 reference_type=None,
                 reference_id=None,
                 user_login='bar',
-                source_repo='github.com/madeup/a-foo-bar',
+                # TODO: why change org/repo?
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name='madeup',
+                source_component_repo_name='a-foo-bar',
             ),
             release_note_block_with_defaults(
                 reference_type=None,
                 reference_id=None,
                 user_login='foo',
-                source_repo=CURRENT_REPO_NAME,
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name=CURRENT_COMPONENT_ORG_NAME,
+                source_component_repo_name=CURRENT_COMPONENT_REPO_NAME,
             )
         ]
 
@@ -184,13 +198,17 @@ class RendererTest(unittest.TestCase):
                 reference_type=None,
                 reference_id=None,
                 user_login=None,
-                source_repo='github.com/madeup/a-foo-bar',
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name='madeup',
+                source_component_repo_name='a-foo-bar',
             ),
             release_note_block_with_defaults(
                 reference_type=None,
                 reference_id=None,
                 user_login=None,
-                source_repo=CURRENT_REPO_NAME,
+                source_component_hostname=CURRENT_COMPONENT_HOSTNAME,
+                source_component_org_name=CURRENT_COMPONENT_ORG_NAME,
+                source_component_repo_name=CURRENT_COMPONENT_REPO_NAME,
             )
         ]
 
@@ -211,14 +229,12 @@ class RendererTest(unittest.TestCase):
                 reference_type=None,
                 reference_id=None,
                 user_login=None,
-                source_repo=CURRENT_REPO_NAME,
             ),
             release_note_block_with_defaults(
                 text='duplicate',
                 reference_type=None,
                 reference_id=None,
                 user_login=None,
-                source_repo=CURRENT_REPO_NAME,
             )
         ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the remaining dependencies on product.model from our codebase.

**Special notes for your reviewer**:
Draft, as tests need to be adjusted and CTF still is not supported. Manual testing so far indicates that the generated release-notes are the same as before.
