### PR TITLE
Configure root logger in cli.py

### DIFF
--- a/checkmarx/project.py
+++ b/checkmarx/project.py
@@ -1,13 +1,11 @@
 import logging
 import time
 
-import ctx
 import checkmarx.client
 import checkmarx.model as model
 import checkmarx.util
 
 
-ctx.configure_default_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/ci/log.py
+++ b/ci/log.py
@@ -48,6 +48,9 @@ def configure_default_logging(stdout_level=None):
     if not stdout_level:
         stdout_level = logging.INFO
 
+    # make sure to have a clean root logger (in case setup is called multiple times)
+    logging.root.handlers.clear()
+
     sh = logging.StreamHandler(stream=sys.stdout)
     sh.setLevel(stdout_level)
     sh.setFormatter(CCFormatter(fmt='%(asctime)s [%(levelprefix)s] %(name)s: %(message)s'))

--- a/cli/gardener_ci/cli_gen.py
+++ b/cli/gardener_ci/cli_gen.py
@@ -40,7 +40,7 @@ except ModuleNotFoundError:
     )
     sys.path.insert(1, repo_dir)
     import ci.util
-import ctx
+import ctx  # noqa: E402
 
 import_errs = []
 

--- a/cli/gardener_ci/cli_gen.py
+++ b/cli/gardener_ci/cli_gen.py
@@ -23,6 +23,11 @@ import inspect
 import itertools
 import sys
 
+
+import ci.log
+ci.log.configure_default_logging()
+
+
 try:
     import ci.util
 except ModuleNotFoundError:

--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import multiprocessing
 
 import ci.util
-ci.util.ctx().configure_default_logging(stdout_level=logging.INFO)
 
 
 def start_whd(
@@ -26,7 +24,6 @@ def start_whd(
     production: bool=False,
     workers: int=4,
 ):
-    import whd
     import whd.server
 
     cfg_factory = ci.util.ctx().cfg_factory()

--- a/protecode/scanning_util.py
+++ b/protecode/scanning_util.py
@@ -34,7 +34,7 @@ from ccc.grafeas_model import (
 )
 from ci.util import not_none, warning, check_type, info
 
-ci.util.ctx().configure_default_logging()
+
 logger = logging.getLogger(__name__)
 
 

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -22,7 +22,6 @@ import typing
 import ccc.gcp
 import ccc.protecode
 import cnudie.retrieve
-import ctx
 import product.util
 import product.v2
 
@@ -44,7 +43,6 @@ from protecode.model import (
     CVSSVersion,
     UploadResult,
 )
-ctx.configure_default_logging()
 
 logger = logging.getLogger(__name__)
 

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import logging
 import typing
 import websockets
 
@@ -8,8 +9,10 @@ import requests
 from whitesource_common import protocol
 
 import ci.util
-import dso.util
 import whitesource.model
+
+
+logger = logging.getLogger(__name__)
 
 
 class WebsocketException(Exception):
@@ -123,8 +126,7 @@ class WhitesourceClient:
             raise WebsocketException('unable to connect to ws endpoint')
 
     def get_product_risk_report(self):
-        clogger = dso.util.component_logger(__name__)
-        clogger.info('retrieving product risk report')
+        logger.info('retrieving product risk report')
         body = {
             'requestType': 'getProductRiskReport',
             'userKey': self.creds.user_key(),

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -45,7 +45,7 @@ def get_scan_artifacts_from_components(
 
 
 def download_component(
-    clogger,
+    logger,
     github_repo: github3.repos.repo.Repository,
     path_filter_func: typing.Callable,
     ref: str,
@@ -76,7 +76,7 @@ def download_component(
             else:
                 filtered_out_files += 1
 
-    clogger.info(f'{files_to_scan=}, {filtered_out_files=}')
+    logger.info(f'{files_to_scan=}, {filtered_out_files=}')
     tar_out_size = target.tell()
 
     return tar_out_size


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/gardener/cc-utils/commit/7ba48029c59f0a5623ba7e6908bdc6c9015043da configures the root logger for cc pipelines, this PR does the same for `cli.py` and ensures the root logger config is clear before applying custom configuration. Additionally the logger usage for the whitesource-client is updated and calls to the deprecated `ctx.configure_default_logging()` function are removed. Finally an unused `whd` import in `whdutil` is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
