### PR TITLE
Update WHD logging usage and introduce `force` flag

### DIFF
--- a/ci/log.py
+++ b/ci/log.py
@@ -46,14 +46,14 @@ class Bcolors:
 
 def configure_default_logging(
     stdout_level=None,
-    force=False,
+    force=True,
 ):
     if not stdout_level:
         stdout_level = logging.INFO
 
     # make sure to have a clean root logger (in case setup is called multiple times)
     if force:
-        for h in logging.root.handlers[:]:
+        for h in logging.root.handlers:
             logging.root.removeHandler(h)
             h.close()
 
@@ -63,7 +63,7 @@ def configure_default_logging(
     logging.root.addHandler(hdlr=sh)
     logging.root.setLevel(level=stdout_level)
 
-    # configure loggers
+    # both too verbose ...
     logging.getLogger('github3').setLevel(logging.WARNING)
     logging.getLogger('elasticsearch').setLevel(logging.WARNING)
 

--- a/ci/log.py
+++ b/ci/log.py
@@ -44,19 +44,29 @@ class Bcolors:
     BLUE = '\033[34m'
 
 
-def configure_default_logging(stdout_level=None):
+def configure_default_logging(
+    stdout_level=None,
+    force=False,
+):
     if not stdout_level:
         stdout_level = logging.INFO
 
     # make sure to have a clean root logger (in case setup is called multiple times)
-    logging.root.handlers.clear()
+    if force:
+        for h in logging.root.handlers[:]:
+            logging.root.removeHandler(h)
+            h.close()
 
     sh = logging.StreamHandler(stream=sys.stdout)
     sh.setLevel(stdout_level)
-    sh.setFormatter(CCFormatter(fmt='%(asctime)s [%(levelprefix)s] %(name)s: %(message)s'))
+    sh.setFormatter(CCFormatter(fmt=get_default_fmt_string()))
     logging.root.addHandler(hdlr=sh)
     logging.root.setLevel(level=stdout_level)
 
-    # both too verbose ...
+    # configure loggers
     logging.getLogger('github3').setLevel(logging.WARNING)
     logging.getLogger('elasticsearch').setLevel(logging.WARNING)
+
+
+def get_default_fmt_string():
+    return '%(asctime)s [%(levelprefix)s] %(name)s: %(message)s'

--- a/cli/gardener_ci/cli_gen.py
+++ b/cli/gardener_ci/cli_gen.py
@@ -23,9 +23,8 @@ import inspect
 import itertools
 import sys
 
-
 import ci.log
-ci.log.configure_default_logging()
+ci.log.configure_default_logging(force=True)
 
 
 try:

--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -24,6 +24,8 @@ def start_whd(
     production: bool=False,
     workers: int=4,
 ):
+    import whd
+    whd.configure_whd_logging()
     import whd.server
 
     cfg_factory = ci.util.ctx().cfg_factory()
@@ -39,7 +41,7 @@ def start_whd(
     any_interface = '0.0.0.0'
 
     if production:
-        whd.configure_whd_logging()
+
         import bjoern
         multiprocessing.set_start_method('fork')
 
@@ -50,6 +52,7 @@ def start_whd(
             p.start()
         serve()
     else:
+
         import werkzeug.serving
         werkzeug.serving.run_simple(
             hostname=any_interface,

--- a/cli/gardener_ci/whdutil.py
+++ b/cli/gardener_ci/whdutil.py
@@ -52,7 +52,6 @@ def start_whd(
             p.start()
         serve()
     else:
-
         import werkzeug.serving
         werkzeug.serving.run_simple(
             hostname=any_interface,

--- a/ctx.py
+++ b/ctx.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 
 import enum
+from deprecated import deprecated
 import functools
 import logging
-import logging.config
 import os
 
-import deprecated
 from pathlib import Path
 
 import ci.util
@@ -228,7 +227,7 @@ def _default_logging_config(stdout_level):
     }
 
 
-@deprecated.deprecated
+@deprecated
 def configure_default_logging(stdout_level=None):
     if not stdout_level:
         stdout_level = logging.INFO

--- a/whd/__init__.py
+++ b/whd/__init__.py
@@ -16,30 +16,18 @@
 import logging
 import os
 
-import ctx
+import ci.log
 
 
-def configure_whd_logging(stdout_level=None):
-    if not stdout_level:
-        stdout_level = logging.INFO
-
-    cfg = ctx._default_logging_config(stdout_level)
-    cfg['handlers'].update({
-        'rotating_file': {
-            'class': 'logging.handlers.RotatingFileHandler',
-            'formatter': 'default',
-            'level': stdout_level,
-            'filename': os.path.join('/', 'tmp', 'whd_log'),
-            'backupCount': 1,
-            'maxBytes': 50*1024*1024,  # 50 MiB
-        },
-    })
-    cfg.update({
-        'loggers': {
-            'whd': {
-                'level': logging.DEBUG,
-                'handlers': ['rotating_file',],
-            },
-        },
-    })
-    logging.config.dictConfig(cfg)
+def configure_whd_logging():
+    whd = logging.getLogger('whd')
+    whd.setLevel(logging.DEBUG)
+    whd_handler = logging.handlers.RotatingFileHandler(
+        filename=os.path.join('/', 'tmp', 'whd_log'),
+        backupCount=1,
+        maxBytes=50 * 1024 * 1024,  # 50 MiB
+    )
+    whd_handler.setFormatter(ci.log.CCFormatter(
+        fmt=ci.log.get_default_fmt_string()),
+    )
+    whd.addHandler(whd_handler)

--- a/whd/server.py
+++ b/whd/server.py
@@ -23,7 +23,7 @@ def webhook_dispatcher_app(
     cfg_set,
     whd_cfg: WebhookDispatcherConfig,
 ):
-    app = falcon.API(
+    app = falcon.App(
         middleware=[],
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The root logger configuration is loaded, a separate handler for file output initialized and attached to the `whd` logger. Additionally a `ci.log.get_default_fmt_string()` function returning the default logging format string is introduced. Logging configuration is moved from production only to top level of WHD initialization.

Apart from the WHD logging usage the root logger config now includes the `force` parameter which indicates whether all existing handlers shall be removed. Additionally the Falcon app is now initialized using `falcon.App` as `falcon.Api` is deprecated (see: https://github.com/falconry/falcon/blob/a5e72b287efb2b3da632cf6547ed3f07d8ec5380/falcon/app.py#L1060).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
