### PR TITLE
Build kaniko-image from scratch using pypi

### DIFF
--- a/Dockerfile.kaniko
+++ b/Dockerfile.kaniko
@@ -1,3 +1,13 @@
-FROM registry-1.docker.io/gardenerci/cc-job-image:latest
+FROM eu.gcr.io/gardener-project/cc/job-image-base:0.46.0
 COPY --from=gcr.io/kaniko-project/executor:latest /kaniko/executor /kaniko/executor.tmp
+
+RUN pip3 install --upgrade \
+  pip \
+  wheel \
+&& pip3 install --upgrade \
+  --find-links /cc/utils/dist \
+  gardener-cicd-libs \
+&& pip3 uninstall -y gardener-component-model \
+&& pip3 install gardener-component-model
+
 RUN mv /kaniko/executor.tmp /bin/kaniko


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using our job-image and installing kaniko within, use the job-image-base and install the latest version of our coding known to pypi.
This should prevent our kaniko-image from lagging behind one release version due to being based on the previous job-image.