### PR TITLE
Support oAuth in Protecode Client

### DIFF
--- a/ccc/protecode.py
+++ b/ccc/protecode.py
@@ -5,7 +5,6 @@ import protecode.client
 
 def client(
     protecode_cfg: model.protecode.ProtecodeConfig,
-    parallel_jobs=12,
 ):
     if isinstance(protecode_cfg, str):
         import ci.util
@@ -15,8 +14,7 @@ def client(
     routes = protecode.client.ProtecodeApiRoutes(base_url=protecode_cfg.api_url())
     api = protecode.client.ProtecodeApi(
         api_routes=routes,
-        basic_credentials=protecode_cfg.credentials(),
-        tls_verify=protecode_cfg.tls_verify(),
+        protecode_cfg=protecode_cfg,
     )
     return api
 

--- a/model/base.py
+++ b/model/base.py
@@ -144,3 +144,17 @@ class BasicCredentials(ModelBase):
 
     def _required_attributes(self):
         return ['username', 'password']
+
+
+class TokenCredentials(ModelBase):
+    '''
+    Base class for configuration objects that use token-based authentication
+
+    Not intended to be instantiated
+    '''
+
+    def token(self):
+        return self.raw['token']
+
+    def _required_attributes(self):
+        return ['token']

--- a/model/protecode.py
+++ b/model/protecode.py
@@ -12,11 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import enum
+import typing
 
 from model.base import (
     BasicCredentials,
     NamedModelElement,
+    TokenCredentials,
 )
+
+
+class ProtecodeAuthScheme(enum.Enum):
+    BASIC_AUTH = 'basic_auth'
+    BEARER_TOKEN = 'bearer_token'
 
 
 class ProtecodeConfig(NamedModelElement):
@@ -24,15 +32,39 @@ class ProtecodeConfig(NamedModelElement):
     Not intended to be instantiated by users of this module
     '''
 
-    def credentials(self):
-        return ProtecodeCredentials(self.raw.get('credentials'))
+    def auth_scheme(self) -> ProtecodeAuthScheme:
+        return ProtecodeAuthScheme(self.raw['credentials'].get('auth_scheme', 'basic_auth'))
 
-    def api_url(self):
+    def credentials(self) -> typing.Union[BasicCredentials, TokenCredentials]:
+        if (auth_scheme := self.auth_scheme()) is ProtecodeAuthScheme.BASIC_AUTH:
+            return BasicCredentials(
+                raw_dict={
+                    'password': self.raw['credentials']['password'],
+                    'username': self.raw['credentials']['username']
+                }
+            )
+        elif auth_scheme is ProtecodeAuthScheme.BEARER_TOKEN:
+            return TokenCredentials(
+                raw_dict={
+                    'token': self.raw['credentials']['token'],
+                }
+            )
+        else:
+            raise NotImplementedError(auth_scheme)
+
+    def api_url(self) -> str:
         return self.raw.get('api_url')
 
-    def tls_verify(self):
+    def tls_verify(self) -> bool:
         return self.raw.get('tls_verify', True)
 
+    def _required_attributes(self):
+        yield from super()._required_attributes()
+        yield from (
+            'api_url',
+            'credentials',
+        )
 
-class ProtecodeCredentials(BasicCredentials):
-    pass
+    def validate(self):
+        # call credentials method to validate credentials
+        self.credentials()


### PR DESCRIPTION
Switches our Protecode client to use bearer-auth _only_.

Not sure if that's the right approach currently. Also, WIP