### PR TITLE
Ignore dev component versions for update pull-request

### DIFF
--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -119,6 +119,15 @@ ATTRIBUTES = (
         doc='callback to be invoked after auto-merge',
     ),
     AttributeSpec.optional(
+        name='ignore_dev_versions',
+        default=False,
+        doc=(
+            'ignores dev versions like "0.1.0-dev-abc" and '
+            'only creates upgrade pr\'s for finalized versions.'
+        ),
+        type=bool,
+    ),
+    AttributeSpec.optional(
         name='vars',
         default={},
         doc='env vars to pass to after_merge_callback (similar to step\'s vars)',
@@ -170,6 +179,9 @@ class UpdateComponentDependenciesTrait(Trait):
 
     def after_merge_callback(self):
         return self.raw.get('after_merge_callback')
+
+    def ignore_dev_versions(self):
+        return self.raw.get('ignore_dev_versions')
 
     def vars(self):
         return self.raw['vars']

--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -16,6 +16,7 @@ update_component_deps_trait = job_variant.trait('update_component_deps')
 set_dependency_version_script_path = update_component_deps_trait.set_dependency_version_script_path()
 after_merge_callback = update_component_deps_trait.after_merge_callback()
 upstream_update_policy = update_component_deps_trait.upstream_update_policy()
+ignore_dev_versions=update_component_deps_trait.ignore_dev_versions()
 component_descriptor_trait = job_variant.trait('component_descriptor')
 ctx_repo_base_url = component_descriptor_trait.ctx_repository_base_url()
 %>
@@ -112,6 +113,7 @@ for from_ref, to_version in determine_upgrade_prs(
     upstream_update_policy=upstream_update_policy,
     upgrade_pull_requests=upgrade_pull_requests,
     ctx_repo_base_url='${ctx_repo_base_url}',
+    ignore_dev_versions=${ignore_dev_versions},
 ):
     applicable_merge_policy = [
         policy for policy, filter_func in merge_policy_and_filters.items() if filter_func(from_ref)

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -104,10 +104,12 @@ def latest_component_version_from_upstream(
     component_name: str,
     upstream_component_name: str,
     base_url: str,
+    ignore_dev_versions: bool=False,
 ):
     upstream_component_version = product.v2.latest_component_version(
         component_name=upstream_component_name,
         ctx_repo_base_url=base_url,
+        ignore_dev_versions=ignore_dev_versions,
     )
 
     if not upstream_component_version:
@@ -133,12 +135,14 @@ def determine_reference_versions(
     repository_ctx_base_url: str,
     upstream_component_name: str=None,
     upstream_update_policy: UpstreamUpdatePolicy=UpstreamUpdatePolicy.STRICTLY_FOLLOW,
+    ignore_dev_versions: bool=False,
 ) -> typing.Sequence[str]:
     if upstream_component_name is None:
         # no upstream component defined - look for greatest released version
         latest_component_version = product.v2.latest_component_version(
                 component_name=component_name,
                 ctx_repo_base_url=repository_ctx_base_url,
+                ignore_dev_versions=ignore_dev_versions,
         )
         if not latest_component_version:
             raise RuntimeError(
@@ -153,6 +157,7 @@ def determine_reference_versions(
         component_name=component_name,
         upstream_component_name=upstream_component_name,
         base_url=repository_ctx_base_url,
+        ignore_dev_versions=ignore_dev_versions,
     )
 
     if upstream_update_policy is UpstreamUpdatePolicy.STRICTLY_FOLLOW:
@@ -175,6 +180,7 @@ def determine_upgrade_prs(
     upstream_update_policy: UpstreamUpdatePolicy,
     upgrade_pull_requests,
     ctx_repo_base_url: str,
+    ignore_dev_versions=False,
 ) -> typing.Iterable[typing.Tuple[
     gci.componentmodel.ComponentReference, gci.componentmodel.ComponentReference, str
 ]]:
@@ -187,6 +193,7 @@ def determine_upgrade_prs(
             upstream_component_name=upstream_component_name,
             upstream_update_policy=upstream_update_policy,
             repository_ctx_base_url=ctx_repo_base_url,
+            ignore_dev_versions=ignore_dev_versions,
         ):
             if not greatest_version:
                 # if None is returned, no versions at all were found

--- a/product/v2.py
+++ b/product/v2.py
@@ -572,12 +572,14 @@ def greatest_references(
             yield matching_refs[-1]
 
 
-def greatest_component_version(component_name: str, ctx_repo_base_url: str) -> str:
+def greatest_component_version(
+    component_name: str, ctx_repo_base_url: str, ignore_dev_versions: bool=False,
+) -> str:
     image_tags = component_versions(
         component_name=component_name,
         ctx_repo_base_url=ctx_repo_base_url,
     )
-    return version.find_latest_version(image_tags)
+    return version.find_latest_version(image_tags, ignore_dev_versions)
 
 
 def greatest_version_before(

--- a/test/concourse/steps/update_component_deps_test.py
+++ b/test/concourse/steps/update_component_deps_test.py
@@ -89,6 +89,7 @@ def test_determine_reference_versions():
         product_mock.latest_component_version.assert_called_with(
             component_name=component_name,
             ctx_repo_base_url=base_url,
+            ignore_dev_versions=False,
         )
 
         product_mock.latest_component_version.reset_mock()
@@ -102,6 +103,7 @@ def test_determine_reference_versions():
         product_mock.latest_component_version.assert_called_with(
             component_name=component_name,
             ctx_repo_base_url=base_url,
+            ignore_dev_versions=False,
         )
 
     # Case 2: Upstream component defined
@@ -130,6 +132,7 @@ def test_determine_reference_versions():
             component_name=component_name,
             upstream_component_name='example.org/foo/bar',
             base_url=base_url,
+            ignore_dev_versions=False,
         )
 
         upstream_version_mock.reset_mock()
@@ -145,6 +148,7 @@ def test_determine_reference_versions():
             component_name=component_name,
             upstream_component_name='example.org/foo/bar',
             base_url=base_url,
+            ignore_dev_versions=False,
         )
 
         upstream_version_mock.reset_mock()
@@ -166,6 +170,7 @@ def test_determine_reference_versions():
                 component_name=component_name,
                 upstream_component_name='example.org/foo/bar',
                 base_url=base_url,
+                ignore_dev_versions=False,
             )
             product_mock.greatest_component_version_with_matching_minor.assert_called_once_with(
                 component_name=component_name,

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -31,6 +31,17 @@ class Version_find_latest_version(unittest.TestCase):
         result = examinee.find_latest_version(versions)
         self.assertEqual(str(result), '3.0.1')
 
+    def test_ignore_dev_versions(self):
+        versions = (semver.VersionInfo.parse(v) for v in (
+                '0.0.10',
+                '3.0.1',
+                '1.0.0',
+                '3.1.0-dev-abc',
+        )
+        )
+        result = examinee.find_latest_version(versions, ignore_dev_versions=True)
+        self.assertEqual(str(result), '3.0.1')
+
 
 class Version_process_version_Test(unittest.TestCase):
     # def test_invalid_version_operation(self):

--- a/version.py
+++ b/version.py
@@ -211,7 +211,7 @@ def process_version(
     return processed_version
 
 
-def find_latest_version(versions) -> str:
+def find_latest_version(versions, ignore_dev_versions=False) -> str:
     latest_candidate = None
     latest_candidate_str = None
 
@@ -221,6 +221,8 @@ def find_latest_version(versions) -> str:
         else:
             candidate_semver = candidate
 
+        if ignore_dev_versions and candidate_semver.prerelease != None:
+            continue
         if not latest_candidate:
             latest_candidate = candidate_semver
             latest_candidate_str = candidate


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Ignores dev versions for update pull requests.
Release versions are identified by the string `-dev-`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
