### PR TITLE
add support for ctf in draft release notes

### DIFF
--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -71,6 +71,8 @@ release_and_prepare_next_dev_cycle(
   % endif
   rebase_before_release=${release_trait.rebase_before_release()},
   githubrepobranch=githubrepobranch,
+  repo_hostname='${repo.repo_hostname()}',
+  repo_path='${repo.repo_path()}',
   repo_dir=repo_dir,
   repository_version_file_path='${version_trait.versionfile_relpath()}',
   release_version=version_str,

--- a/test/concourse/steps/release_test.py
+++ b/test/concourse/steps/release_test.py
@@ -177,7 +177,7 @@ class TestPublishReleaseNotesStep(object):
         ctf_path = os.path.join(tmp_path, product.v2.CTF_OUT_DIR_NAME)
         cd_v2 = cm.ComponentDescriptor(
             component=cm.Component(
-                name='a_name',
+                name='example.com/a_name',
                 version='1.2.3',
                 repositoryContexts=[],
                 provider=cm.Provider.INTERNAL,
@@ -202,12 +202,16 @@ class TestPublishReleaseNotesStep(object):
                 repo_name='test_name',
                 branch='master',
             ),
+            repository_hostname="example.com",
+            repository_path="a_name",
             repo_dir=str(tmp_path),
             release_version='1.0.0',
         ):
             return concourse.steps.release.PublishReleaseNotesStep(
                 github_helper=github_helper,
                 githubrepobranch=githubrepobranch,
+                repository_hostname=repository_hostname,
+                repository_path=repository_path,
                 repo_dir=repo_dir,
                 release_version=release_version,
                 component_descriptor_v2_path=component_descriptor_v2,


### PR DESCRIPTION
**What this PR does / why we need it**:

added support for ctf component descriptors in the draft release notes as it is already supported in the release notes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
