### PR TITLE
change the add_dependency_command oci image default from local to external

### DIFF
--- a/cli/gardener_ci/productutil_v2.py
+++ b/cli/gardener_ci/productutil_v2.py
@@ -34,7 +34,7 @@ def _raw_image_dep_to_v2(raw: dict):
   name = raw['name']
   version = raw['version']
   img_ref = raw['image_reference']
-  img_rel = cm.ResourceRelation(raw.get('relation', cm.ResourceRelation.LOCAL))
+  img_rel = cm.ResourceRelation(raw.get('relation', cm.ResourceRelation.EXTERNAL))
 
   return cm.Resource(
     name=name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the default relation for `add_dependecny_cmd` added oc images to `external`.
In the cdv2 local resources *MUST* have the same version as the component which collides with the current defaulting as the command is mostly used for external images. (local images are added by the ci in the publish step)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
