### PR TITLE
use detailed component descriptor filename as github asset name

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -657,7 +657,7 @@ class GitHubReleaseStep(TransactionalStep):
                 content_type='application/x-yaml',
                 name=asset_name,
                 asset=descriptor_str.encode('utf-8'),
-                label='component_descriptor.cnudie.yaml',
+                label=asset_name,
             )
 
         return {


### PR DESCRIPTION
**What this PR does / why we need it**:

The full filename is now displayed in the github release assets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
