### PR TITLE
Fix breaking websockets 9.X change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,6 @@ termcolor<2.0.0
 toposort
 urllib3<2.0.0
 uvicorn # todo: rm once whd is factored-out to separate package
-websockets==8.1.0
+websockets
 whitesource_common
 yamllint<2

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -3,6 +3,13 @@ import json
 import logging
 import typing
 import websockets
+from websockets.legacy import client
+"""
+The client, server, protocol, and auth modules were moved from the websockets package
+to websockets.legacy sub-package, as part of an upcoming refactoring.
+Despite the name, they’re still fully supported.
+See: https://websockets.readthedocs.io/en/stable/changelog.html#id5
+"""
 
 import dacite
 import requests
@@ -211,9 +218,9 @@ class WhitesourceRoutes:
 
 
 async def _upload_to_project(
-        websocket: websockets.client,
-        file: typing.IO,
-        contract: protocol.WhiteSourceApiExtensionWebsocketContract,
+    websocket: websockets.legacy.client,
+    file: typing.IO,
+    contract: protocol.WhiteSourceApiExtensionWebsocketContract,
 ):
     try:
         await websocket.send(json.dumps(dataclasses.asdict(contract.metadata)))

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -3,7 +3,7 @@ import json
 import logging
 import typing
 import websockets
-from websockets.legacy import client
+from websockets.legacy import client # noqa:F401
 """
 The client, server, protocol, and auth modules were moved from the websockets package
 to websockets.legacy sub-package, as part of an upcoming refactoring.


### PR DESCRIPTION
**What this PR does / why we need it**:
websockets 9.X moved some modules to `legacy` sub-module even though they keep supporting them.
This PR adjusts the corresponding imports.
See: https://websockets.readthedocs.io/en/stable/changelog.html#id5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
