### PR TITLE
Add oci-image support for WhiteSource

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -236,11 +236,10 @@ def image_layers_as_tarfile_generator(
     '''
     manifest = oci_client.manifest(image_reference=image_reference)
     offset = 0
-    for blob in manifest.blobs():
+    for blob in manifest.blobs() if include_config_blob else manifest.layers:
         logger.debug(f'getting blob {blob.digest}')
         if not include_config_blob:
-            if blob == manifest.config:
-                continue
+            logger.debug(f'skipping config blob')
         tarinfo = tarfile.TarInfo(name=blob.digest + '.tar') # note: may be gzipped
         tarinfo.size = blob.size
         tarinfo.offset = offset

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -239,7 +239,7 @@ def image_layers_as_tarfile_generator(
     for blob in manifest.blobs() if include_config_blob else manifest.layers:
         logger.debug(f'getting blob {blob.digest}')
         if not include_config_blob:
-            logger.debug(f'skipping config blob')
+            logger.debug('skipping config blob')
         tarinfo = tarfile.TarInfo(name=blob.digest + '.tar') # note: may be gzipped
         tarinfo.size = blob.size
         tarinfo.offset = offset

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -113,9 +113,9 @@ class WhitesourceClient:
 
         try:
             async with websockets.connect(
-                    uri=self.routes.upload_to_project(),
-                    ping_interval=ping_interval,
-                    ping_timeout=ping_timeout,
+                uri=self.routes.upload_to_project(),
+                ping_interval=ping_interval,
+                ping_timeout=ping_timeout,
             ) as websocket:
                 return await _upload_to_project(
                     websocket=websocket,
@@ -211,9 +211,9 @@ class WhitesourceRoutes:
 
 
 async def _upload_to_project(
-        websocket: 'websockets.legacy.client.WebSocketClientProtocol',
-        file: typing.IO,
-        contract: protocol.WhiteSourceApiExtensionWebsocketContract,
+    websocket: websockets.WebSocketClientProtocol,
+    file: typing.IO,
+    contract: protocol.WhiteSourceApiExtensionWebsocketContract,
 ):
     try:
         await websocket.send(json.dumps(dataclasses.asdict(contract.metadata)))

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -33,7 +33,9 @@ def get_scan_artifacts_from_components(
                     yield dso.model.ScanArtifact(
                         access=source.access,
                         label=ws_hint,
-                        name=f'{component.name}:{component.version}/{"source" if source in component.sources else "resources"}/{source.name}:{source.version}',
+                        name=f'{component.name}:{component.version}/'
+                             f'{"source" if source in component.sources else "resources"}/'
+                             f'{source.name}:{source.version}',
                     )
                 elif ws_hint.policy is dso.labels.ScanPolicy.SKIP:
                     continue

--- a/whitesource/util.py
+++ b/whitesource/util.py
@@ -2,9 +2,9 @@ import asyncio
 import concurrent.futures
 import functools
 import logging
+import os.path
 import tempfile
 import typing
-import os.path
 
 import tabulate
 
@@ -209,7 +209,7 @@ def scan_artifact_with_white_src(
 
     logger.debug('init scan')
     with tempfile.NamedTemporaryFile() as tmp_file:
-        if scan_artifact.access.type == cm.AccessType.GITHUB:
+        if scan_artifact.access.type is cm.AccessType.GITHUB:
             logger.debug('pulling from github')
             github_api = ccc.github.github_api_from_gh_access(access=scan_artifact.access)
             github_repo = github_api.repository(
@@ -223,8 +223,8 @@ def scan_artifact_with_white_src(
                 ref=scan_artifact.access.ref,
                 github_repo=github_repo,
             )
-            exclude_regexes = ''
-            include_regexes = ''
+            exclude_regexes = ()
+            include_regexes = ()
 
             if scan_artifact.label is not None:
                 if scan_artifact.label.path_config is not None:
@@ -242,7 +242,7 @@ def scan_artifact_with_white_src(
                 ref=commit_hash,
                 target=tmp_file,
             )
-        elif scan_artifact.access.type == cm.AccessType.OCI_REGISTRY:
+        elif scan_artifact.access.type is cm.AccessType.OCI_REGISTRY:
             logger.debug('pulling from oci registry')
             oci_client = ccc.oci.oci_client()
             tar_gen = oci.image_layers_as_tarfile_generator(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for WhiteSource oci-image scans.
Each oci-layer is pulled into a seperate tar file, and a top level tar is sent to the WhiteSource API.
The config blob is ignored.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
