### PR TITLE
Add CTF support for ScanSources

### DIFF
--- a/cli/gardener_ci/whitesource_cli.py
+++ b/cli/gardener_ci/whitesource_cli.py
@@ -1,9 +1,14 @@
+import logging
 import typing
 
+import concourse.steps.component_descriptor_util as util
 import concourse.steps.scan_sources
 
 
-def upload_and_scan_component(
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def scan_component_from_component_descriptor(
     whitesource_cfg_name: str,
     component_descriptor_path: str,
     notification_recipients: [str],
@@ -11,10 +16,51 @@ def upload_and_scan_component(
     extra_whitesource_config: typing.Dict={},
     max_workers=4,
 ):
-
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
-        component_descriptor_path=component_descriptor_path,
+        component_descriptor=util.component_descriptor_from_component_descriptor_path(
+            cd_path=component_descriptor_path,
+        ),
+        extra_whitesource_config=extra_whitesource_config,
+        cve_threshold=cve_threshold,
+        notification_recipients=notification_recipients,
+        max_workers=max_workers,
+    )
+
+
+def scan_component_from_ctf(
+    whitesource_cfg_name: str,
+    ctf_path: str,
+    notification_recipients: [str],
+    cve_threshold: float = 5.0,
+    extra_whitesource_config: typing.Dict={},
+    max_workers=4,
+):
+    concourse.steps.scan_sources.scan_component_with_whitesource(
+        whitesource_cfg_name=whitesource_cfg_name,
+        component_descriptor=util.component_descriptor_from_ctf_path(
+            ctf_path=ctf_path,
+        ),
+        extra_whitesource_config=extra_whitesource_config,
+        cve_threshold=cve_threshold,
+        notification_recipients=notification_recipients,
+        max_workers=max_workers,
+    )
+
+
+def scan_component_from_dir(
+    whitesource_cfg_name: str,
+    dir_path: str,
+    notification_recipients: [str],
+    cve_threshold: float = 5.0,
+    extra_whitesource_config: typing.Dict={},
+    max_workers=4,
+):
+    concourse.steps.scan_sources.scan_component_with_whitesource(
+        whitesource_cfg_name=whitesource_cfg_name,
+        component_descriptor=util.component_descriptor_from_dir(
+            dir_path=dir_path,
+        ),
         extra_whitesource_config=extra_whitesource_config,
         cve_threshold=cve_threshold,
         notification_recipients=notification_recipients,

--- a/concourse/steps/component_descriptor_util.py
+++ b/concourse/steps/component_descriptor_util.py
@@ -1,7 +1,14 @@
 import ci.util
+import logging
 import os
 
+import cnudie.util
+# do not use cm alias here, it does not work with templating
 import gci.componentmodel
+import product.v2
+
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def component_descriptor_fname(
@@ -37,3 +44,81 @@ def parse_component_descriptor(
       return component_descriptor
     else:
         raise NotImplementedError(schema_version)
+
+
+def component_descriptor_from_component_descriptor_path(
+    cd_path: str,
+) -> gci.componentmodel.ComponentDescriptor:
+
+    if not os.path.isfile(cd_path):
+        raise FileNotFoundError(
+            f'{os.path.abspath(cd_path)=} not found'
+        )
+
+    descriptor_v2 = gci.componentmodel.ComponentDescriptor.from_dict(
+        ci.util.parse_yaml_file(cd_path)
+    )
+    logger.info(f'found component-descriptor (v2) at {cd_path=}')
+    return descriptor_v2
+
+
+def component_descriptor_from_ctf_path(ctf_path: str) -> gci.componentmodel.ComponentDescriptor:
+
+    if not os.path.exists(ctf_path):
+        raise FileNotFoundError(
+            f'{os.path.abspath(ctf_path)=} not found'
+        )
+
+    if not os.path.isfile(ctf_path):
+        raise ValueError(
+            f'{os.path.abspath(ctf_path)=} is not a file'
+        )
+
+    component_descriptors = [
+        cd
+        for cd in cnudie.util.component_descriptors_from_ctf_archive(ctf_path)
+    ]
+
+    if len(component_descriptors) == 0:
+        raise RuntimeError(
+            f'No component descriptor found in ctf archive at {os.path.abspath(ctf_path)}'
+        )
+    if len(component_descriptors) > 1:
+        raise NotImplementedError(
+            f'More than one component_descriptor found at {os.path.abspath(ctf_path)}'
+        )
+    logger.info(f'found component-descriptor (v2) in {ctf_path=}')
+    return component_descriptors[0]
+
+
+def component_descriptor_from_dir(dir_path: str) -> gci.componentmodel.ComponentDescriptor:
+
+    if not os.path.isdir(dir_path):
+        raise NotADirectoryError(
+            f'{os.path.abspath(dir_path)=} is no directory'
+        )
+
+    v2_outfile = os.path.join(
+        dir_path,
+        component_descriptor_fname(
+            schema_version=gci.componentmodel.SchemaVersion.V2,
+        ),
+    )
+    ctf_out_path = os.path.abspath(
+        os.path.join(
+            dir_path,
+            product.v2.CTF_OUT_DIR_NAME,
+        )
+    )
+
+    have_ctf = os.path.exists(ctf_out_path)
+    have_cd = os.path.exists(v2_outfile)
+
+    if not have_ctf ^ have_cd:
+        logger.error(f'exactly one of {ctf_out_path=}, {v2_outfile=} must exist')
+
+    elif have_cd:
+        return component_descriptor_from_component_descriptor_path(cd_path=v2_outfile)
+
+    elif have_ctf:
+        return component_descriptor_from_ctf_path(ctf_path=ctf_out_path)

--- a/concourse/steps/scan_sources.mako
+++ b/concourse/steps/scan_sources.mako
@@ -13,17 +13,17 @@ checkmarx_cfg = source_scan_trait.checkmarx()
 whitesource_cfg = source_scan_trait.whitesource()
 email_recipients = source_scan_trait.email_recipients()
 component_trait = job_variant.trait('component_descriptor')
-
+component_descriptor_dir = job_step.input('component_descriptor_dir')
 %>
 ${step_lib('component_descriptor_util')}
 ${step_lib('scan_sources')}
 
-import gci.componentmodel as cm
+component_descriptor = component_descriptor_from_dir(dir_path='${component_descriptor_dir}')
 
 % if checkmarx_cfg:
 scan_sources_and_notify(
     checkmarx_cfg_name='${checkmarx_cfg.checkmarx_cfg_name()}',
-    component_descriptor_path=component_descriptor_path(schema_version=cm.SchemaVersion.V2),
+    component_descriptor=component_descriptor,
     email_recipients=${email_recipients},
     team_id='${checkmarx_cfg.team_id()}',
     threshold=${checkmarx_cfg.severity_threshold()},
@@ -35,7 +35,7 @@ scan_sources_and_notify(
 % if whitesource_cfg:
 component_name = '${component_trait.component_name()}'
 scan_component_with_whitesource(
-    component_descriptor_path=component_descriptor_path(schema_version=cm.SchemaVersion.V2),
+    component_descriptor=component_descriptor,
     cve_threshold=${whitesource_cfg.cve_threshold()},
     extra_whitesource_config={},
     notification_recipients=${email_recipients},

--- a/concourse/steps/scan_sources.py
+++ b/concourse/steps/scan_sources.py
@@ -1,11 +1,7 @@
 import logging
-import os
-import tarfile
 import typing
 
 import checkmarx.util
-import ci.util
-import cnudie.util
 import gci.componentmodel as cm
 import whitesource.client
 import whitesource.component
@@ -17,7 +13,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def scan_sources_and_notify(
     checkmarx_cfg_name: str,
-    component_descriptor_path: str,
+    component_descriptor: cm.ComponentDescriptor,
     email_recipients,
     team_id: str,
     threshold: int = 40,
@@ -26,14 +22,8 @@ def scan_sources_and_notify(
 ):
     checkmarx_client = checkmarx.util.create_checkmarx_client(checkmarx_cfg_name)
 
-    cds = _path_to_component_descriptors(path=component_descriptor_path)
-    if len(cds) > 1:
-        raise RuntimeError(
-            f'More than one component_descriptor found in {component_descriptor_path}'
-        )
-
     scans = checkmarx.util.scan_sources(
-        component_descriptor=cds[0],
+        component_descriptor=component_descriptor,
         cx_client=checkmarx_client,
         team_id=team_id,
         threshold=threshold,
@@ -57,7 +47,7 @@ def scan_sources_and_notify(
 
 def scan_component_with_whitesource(
     whitesource_cfg_name: str,
-    component_descriptor_path: str,
+    component_descriptor: cm.ComponentDescriptor,
     extra_whitesource_config: dict,
     cve_threshold: float,
     notification_recipients: list,
@@ -67,15 +57,9 @@ def scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
     )
 
-    cds = _path_to_component_descriptors(path=component_descriptor_path)
-    if len(cds) > 1:
-        raise RuntimeError(
-            f'More than one component_descriptor found in {component_descriptor_path}'
-        )
-
     product_name, projects = whitesource.util.scan_sources(
         whitesource_client=whitesource_client,
-        component_descriptor=cds[0],
+        component_descriptor=component_descriptor,
         extra_whitesource_config=extra_whitesource_config,
         max_workers=max_workers,
     )
@@ -92,32 +76,3 @@ def scan_component_with_whitesource(
         product_name=product_name,
         projects=projects,
     )
-
-
-def _path_to_component_descriptors(path: str) -> typing.List[cm.ComponentDescriptor]:
-
-    if not os.path.isfile(path):
-        raise RuntimeError(
-            f'Neither component descriptor nor CTX archive found at {path}'
-        )
-
-    # path is ctf archive
-    if tarfile.is_tarfile(path):
-        component_descriptors: typing.List[cm.ComponentDescriptor] = [
-            cd
-            for cd in cnudie.util.component_descriptors_from_ctf_archive(path)
-        ]
-        if len(component_descriptors) == 0:
-            raise RuntimeError(
-                f'No component descriptor found in ctf archive at {path}'
-            )
-
-        return component_descriptors
-
-    # path is cd
-    else:
-        return [
-            cm.ComponentDescriptor.from_dict(
-                ci.util.parse_yaml_file(path)
-            )
-        ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for ctf based component descriptors for ScanSources, thus CheckMarx and WhiteSource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
