### PR TITLE
Add scan sources filter

### DIFF
--- a/cli/gardener_ci/whitesource_cli.py
+++ b/cli/gardener_ci/whitesource_cli.py
@@ -1,5 +1,5 @@
+import ast
 import logging
-import typing
 
 import concourse.steps.component_descriptor_util as util
 import concourse.steps.scan_sources
@@ -11,11 +11,19 @@ logger: logging.Logger = logging.getLogger(__name__)
 def scan_component_from_component_descriptor(
     whitesource_cfg_name: str,
     component_descriptor_path: str,
-    notification_recipients: [str],
+    notification_recipients: str = None,
+    filters: str = None,
+    extra_whitesource_config: str = None,
     cve_threshold: float = 5.0,
-    extra_whitesource_config: typing.Dict={},
     max_workers=4,
 ):
+    if filters:
+        filters = ast.literal_eval(filters)
+    if extra_whitesource_config:
+        extra_whitesource_config = ast.literal_eval(extra_whitesource_config)
+    if notification_recipients:
+        notification_recipients = ast.literal_eval(notification_recipients)
+
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
         component_descriptor=util.component_descriptor_from_component_descriptor_path(
@@ -25,17 +33,26 @@ def scan_component_from_component_descriptor(
         cve_threshold=cve_threshold,
         notification_recipients=notification_recipients,
         max_workers=max_workers,
+        filters=filters,
     )
 
 
 def scan_component_from_ctf(
     whitesource_cfg_name: str,
     ctf_path: str,
-    notification_recipients: [str],
+    notification_recipients: str = None,
+    filters: str = None,
+    extra_whitesource_config: str = None,
     cve_threshold: float = 5.0,
-    extra_whitesource_config: typing.Dict={},
     max_workers=4,
 ):
+    if filters:
+        filters = ast.literal_eval(filters)
+    if extra_whitesource_config:
+        extra_whitesource_config = ast.literal_eval(extra_whitesource_config)
+    if notification_recipients:
+        notification_recipients = ast.literal_eval(notification_recipients)
+
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
         component_descriptor=util.component_descriptor_from_ctf_path(
@@ -45,17 +62,26 @@ def scan_component_from_ctf(
         cve_threshold=cve_threshold,
         notification_recipients=notification_recipients,
         max_workers=max_workers,
+        filters=filters,
     )
 
 
 def scan_component_from_dir(
     whitesource_cfg_name: str,
     dir_path: str,
-    notification_recipients: [str],
+    notification_recipients: str = None,
+    filters: str = None,
+    extra_whitesource_config: str = None,
     cve_threshold: float = 5.0,
-    extra_whitesource_config: typing.Dict={},
     max_workers=4,
 ):
+    if filters:
+        filters = ast.literal_eval(filters)
+    if extra_whitesource_config:
+        extra_whitesource_config = ast.literal_eval(extra_whitesource_config)
+    if notification_recipients:
+        notification_recipients = ast.literal_eval(notification_recipients)
+
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
         component_descriptor=util.component_descriptor_from_dir(
@@ -65,4 +91,5 @@ def scan_component_from_dir(
         cve_threshold=cve_threshold,
         notification_recipients=notification_recipients,
         max_workers=max_workers,
+        filters=filters,
     )

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -73,6 +73,31 @@ WHITESOURCE_ATTRIBUTES = (
 )
 
 
+FILTER_ATTRIBUTES = (
+    AttributeSpec.required(
+        name='type',
+        doc='defines type to apply filter on, (component|source|resource)',
+        type=str,
+    ),
+    AttributeSpec.required(
+        name='match',
+        doc='matches artifacts (list of regex|true|false)',
+        type=typing.Union[dict, bool],
+    ),
+    AttributeSpec.required(
+        name='action',
+        doc='defines action to matched artifacts (include|exclude)',
+        type=str,
+    ),
+)
+
+
+class FilterCfg(ModelBase):
+    @classmethod
+    def _attribute_specs(cls):
+        return FILTER_ATTRIBUTES
+
+
 class WhitesourceCfg(ModelBase):
     @classmethod
     def _attribute_specs(cls):
@@ -122,6 +147,12 @@ ATTRIBUTES = (
         doc='optional list of email recipients to be notified about critical scan results',
         type=typing.List[str],
     ),
+    AttributeSpec.required(
+        name='filters',
+        default=(),
+        doc='config to include and exclude sources, resources or whole components',
+        type=FilterCfg,
+    ),
     AttributeSpec.optional(
         name='checkmarx',
         type=CheckmarxCfg,
@@ -159,6 +190,10 @@ class SourceScanTrait(Trait):
     def whitesource(self):
         if whitesource := self.raw.get('whitesource'):
             return WhitesourceCfg(whitesource)
+
+    def filters(self):
+        if filters := self.raw.get('filters'):
+            return FilterCfg(filters)
 
     def transformer(self):
         return SourceScanTraitTransformer(trait=self)

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -158,7 +158,7 @@ ATTRIBUTES = (
     ),
     AttributeSpec.required(
         name='filters',
-        default=(),
+        default={},
         doc='config to include and exclude sources, resources or whole components',
         type=FilterCfg,
     ),

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -97,6 +97,15 @@ class FilterCfg(ModelBase):
     def _attribute_specs(cls):
         return FILTER_ATTRIBUTES
 
+    def type(self):
+        return self.raw['type']
+
+    def match(self):
+        return self.raw['match']
+
+    def action(self):
+        return self.raw['action']
+
 
 class WhitesourceCfg(ModelBase):
     @classmethod

--- a/concourse/steps/scan_sources.mako
+++ b/concourse/steps/scan_sources.mako
@@ -14,6 +14,7 @@ whitesource_cfg = source_scan_trait.whitesource()
 email_recipients = source_scan_trait.email_recipients()
 component_trait = job_variant.trait('component_descriptor')
 component_descriptor_dir = job_step.input('component_descriptor_dir')
+scan_sources_filter = source_scan_trait.filters().raw
 %>
 ${step_lib('component_descriptor_util')}
 ${step_lib('scan_sources')}
@@ -40,6 +41,7 @@ scan_component_with_whitesource(
     extra_whitesource_config={},
     notification_recipients=${email_recipients},
     whitesource_cfg_name='${whitesource_cfg.cfg_name()}',
+    filters=${scan_sources_filter},
 )
 % endif
 

--- a/concourse/steps/scan_sources.py
+++ b/concourse/steps/scan_sources.py
@@ -48,11 +48,15 @@ def scan_sources_and_notify(
 def scan_component_with_whitesource(
     whitesource_cfg_name: str,
     component_descriptor: cm.ComponentDescriptor,
-    extra_whitesource_config: dict,
+    extra_whitesource_config: typing.Union[None, dict],
     cve_threshold: float,
-    notification_recipients: list,
+    notification_recipients: typing.Union[None, list],
+    filters: typing.Union[None, list],
     max_workers=4,
 ):
+
+    filters = whitesource.util.parse_filters(filters=filters)
+
     whitesource_client = whitesource.util.create_whitesource_client(
         whitesource_cfg_name=whitesource_cfg_name,
     )
@@ -62,6 +66,7 @@ def scan_component_with_whitesource(
         component_descriptor=component_descriptor,
         extra_whitesource_config=extra_whitesource_config,
         max_workers=max_workers,
+        filters=filters,
     )
 
     whitesource.util.print_scans(

--- a/concourse/steps/scan_sources.py
+++ b/concourse/steps/scan_sources.py
@@ -48,10 +48,10 @@ def scan_sources_and_notify(
 def scan_component_with_whitesource(
     whitesource_cfg_name: str,
     component_descriptor: cm.ComponentDescriptor,
-    extra_whitesource_config: typing.Union[None, dict],
     cve_threshold: float,
-    notification_recipients: typing.Union[None, list],
-    filters: typing.Union[None, list],
+    extra_whitesource_config: dict = None,
+    notification_recipients: list = None,
+    filters: list = None,
     max_workers=4,
 ):
 

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -79,7 +79,7 @@ class WhitesourceClient:
 
     async def upload_to_project(
         self,
-        extra_whitesource_config: typing.Dict,
+        extra_whitesource_config: typing.Union[None, dict],
         file: typing.IO,
         project_name: str,
         length: int,
@@ -98,7 +98,7 @@ class WhitesourceClient:
             data_class=protocol.WhiteSourceApiExtensionWebsocketWSConfig,
             data={
                 'apiKey': self.api_key,
-                'extraWsConfig': extra_whitesource_config,
+                'extraWsConfig': extra_whitesource_config if extra_whitesource_config else {},
                 'productToken': self.product_token,
                 'projectName': project_name,
                 'requesterEmail': self.requester_mail,

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -25,7 +25,7 @@ def _get_ws_label_from_artifact(source: cm.ComponentSource) -> dso.labels.Source
 
 
 def get_scan_artifacts_from_components(
-    components: typing.Generator[typing.Union[tuple, typing.Any], None, None],
+    components: typing.Generator[dso.model.ScanArtifact, None, None],
     filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
 ) -> typing.Generator:
 

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tarfile
 import typing
 
@@ -7,8 +8,8 @@ import dacite
 
 import dso.labels
 import dso.model
-
 import gci.componentmodel as cm
+import whitesource.model
 
 
 logger = logging.getLogger(__name__)
@@ -24,8 +25,12 @@ def _get_ws_label_from_artifact(source: cm.ComponentSource) -> dso.labels.Source
 
 
 def get_scan_artifacts_from_components(
-    components: typing.Sequence[cm.Component],
+    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
+    filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
 ) -> typing.Generator:
+
+    components = apply_filters(components=components, filters=filters)
+
     for component in components:
         for artifact in component.sources + component.resources:
 
@@ -84,3 +89,136 @@ def download_component(
                 filtered_out_files += 1
 
     logger.info(f'{files_to_scan=}, {filtered_out_files=}')
+
+
+def apply_filters(
+    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
+    filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
+) -> typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any]:
+
+    component_filter = None
+    source_filter = None
+    resource_filter = None
+
+    for f in filters:
+        if f.type == 'component':
+            component_filter = f
+        elif f.type == 'source':
+            source_filter = f
+        elif f.type == 'resource':
+            resource_filter = f
+        else:
+            raise NotImplementedError
+
+    if component_filter:
+        components = _apply_component_filter(filter=component_filter, components=components)
+
+    if source_filter:
+        components = _apply_artifact_filter(filter=source_filter, components=components)
+
+    if resource_filter:
+        components = _apply_artifact_filter(filter=resource_filter, components=components)
+
+    return components
+
+
+def _apply_artifact_filter(
+    filter: whitesource.model.WhiteSourceFilterCfg,
+    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
+):
+    logger.debug(f'{filter=}')
+    for c in components:
+        # "source" or "resource", validated earlier
+        artifacts = c.sources if filter.type == 'source' else c.resources
+
+        logger.debug(f'pre filter ({filter.type=}): {len(artifacts)} artifacts')
+
+        if isinstance(m := filter.match, bool):
+            artifacts = list(_apply_artifact_action(
+                action=filter.action,
+                artifacts=artifacts, match=m,
+            ))
+            if filter.type == 'source':
+                c.sources = artifacts
+            elif filter.type == 'resource':
+                c.resources = artifacts
+            logger.debug(f'past filter ({filter.type=}): {len(artifacts)} artifacts')
+            yield c
+
+        elif isinstance(m := filter.match, dict):
+            tmp = []
+            for a in artifacts:
+                if isinstance(a.type, cm.ResourceType):
+                    resource_type_name = a.type.value
+                elif isinstance(a.type, str):
+                    resource_type_name = str(a.type)
+                else:
+                    raise NotImplementedError
+
+                logger.debug(f'parsed {a.type} to {resource_type_name=}')
+
+                if filter.action == 'include':
+                    if re.search(
+                            pattern=m.get('type') if filter.type == 'resource' else m.get('name'),
+                            string=resource_type_name if filter.type == 'resource' else a.name,
+                    ):
+                        tmp.append(a)
+                elif filter.action == 'exclude':
+                    if not re.search(
+                            pattern=m.get('type') if filter.type == 'resource' else m.get('name'),
+                            string=resource_type_name if filter.type == 'resource' else a.name,
+                    ):
+                        tmp.append(a)
+            if filter.type == 'source':
+                c.sources = tmp
+            elif filter.type == 'resource':
+                c.resources = tmp
+            logger.debug(f'past filter ({filter.type=}): {len(artifacts)} artifacts')
+            yield c
+        else:
+            raise NotImplementedError
+
+
+def _apply_artifact_action(
+    action: str,
+    artifacts,
+    match: bool,
+):
+    if action == 'include':
+        return artifacts if match else ()
+    elif action == 'exclude':
+        return artifacts if not match else ()
+    else:
+        raise RuntimeError
+
+
+def _apply_component_filter(
+    filter: whitesource.model.WhiteSourceFilterCfg,
+    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
+):
+    if isinstance(m := filter.match, bool):
+        yield from _apply_components_action(action=filter.action, components=components, match=m)
+
+    elif isinstance(m := filter.match, dict):
+        for c in components:
+            if filter.action == 'include':
+                if re.search(pattern=m.get('name'), string=c.name):
+                    yield c
+            elif filter.action == 'exclude':
+                if not re.search(pattern=m.get('name'), string=c.name):
+                    yield c
+    else:
+        raise NotImplementedError
+
+
+def _apply_components_action(
+    action: str,
+    components,
+    match: bool,
+):
+    if action == 'include':
+        return components if match else ()
+    elif action == 'exclude':
+        return components if not match else ()
+    else:
+        raise RuntimeError

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import tarfile
 import typing
 
@@ -9,6 +8,7 @@ import dacite
 import dso.labels
 import dso.model
 import gci.componentmodel as cm
+import whitesource.filters
 import whitesource.model
 
 
@@ -25,11 +25,11 @@ def _get_ws_label_from_artifact(source: cm.ComponentSource) -> dso.labels.Source
 
 
 def get_scan_artifacts_from_components(
-    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
+    components: typing.Generator[typing.Union[tuple, typing.Any], None, None],
     filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
 ) -> typing.Generator:
 
-    components = apply_filters(components=components, filters=filters)
+    components = whitesource.filters.apply_filters(components=list(components), filters=filters)
 
     for component in components:
         for artifact in component.sources + component.resources:
@@ -53,7 +53,7 @@ def get_scan_artifacts_from_components(
             elif ws_hint.policy is dso.labels.ScanPolicy.SKIP:
                 continue
             else:
-                raise NotImplementedError
+                raise NotImplementedError(ws_hint)
 
 
 def download_component(
@@ -89,136 +89,3 @@ def download_component(
                 filtered_out_files += 1
 
     logger.info(f'{files_to_scan=}, {filtered_out_files=}')
-
-
-def apply_filters(
-    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
-    filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
-) -> typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any]:
-
-    component_filter = None
-    source_filter = None
-    resource_filter = None
-
-    for f in filters:
-        if f.type == 'component':
-            component_filter = f
-        elif f.type == 'source':
-            source_filter = f
-        elif f.type == 'resource':
-            resource_filter = f
-        else:
-            raise NotImplementedError
-
-    if component_filter:
-        components = _apply_component_filter(filter=component_filter, components=components)
-
-    if source_filter:
-        components = _apply_artifact_filter(filter=source_filter, components=components)
-
-    if resource_filter:
-        components = _apply_artifact_filter(filter=resource_filter, components=components)
-
-    return components
-
-
-def _apply_artifact_filter(
-    filter: whitesource.model.WhiteSourceFilterCfg,
-    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
-):
-    logger.debug(f'{filter=}')
-    for c in components:
-        # "source" or "resource", validated earlier
-        artifacts = c.sources if filter.type == 'source' else c.resources
-
-        logger.debug(f'pre filter ({filter.type=}): {len(artifacts)} artifacts')
-
-        if isinstance(m := filter.match, bool):
-            artifacts = list(_apply_artifact_action(
-                action=filter.action,
-                artifacts=artifacts, match=m,
-            ))
-            if filter.type == 'source':
-                c.sources = artifacts
-            elif filter.type == 'resource':
-                c.resources = artifacts
-            logger.debug(f'past filter ({filter.type=}): {len(artifacts)} artifacts')
-            yield c
-
-        elif isinstance(m := filter.match, dict):
-            tmp = []
-            for a in artifacts:
-                if isinstance(a.type, cm.ResourceType):
-                    resource_type_name = a.type.value
-                elif isinstance(a.type, str):
-                    resource_type_name = str(a.type)
-                else:
-                    raise NotImplementedError
-
-                logger.debug(f'parsed {a.type} to {resource_type_name=}')
-
-                if filter.action == 'include':
-                    if re.search(
-                            pattern=m.get('type') if filter.type == 'resource' else m.get('name'),
-                            string=resource_type_name if filter.type == 'resource' else a.name,
-                    ):
-                        tmp.append(a)
-                elif filter.action == 'exclude':
-                    if not re.search(
-                            pattern=m.get('type') if filter.type == 'resource' else m.get('name'),
-                            string=resource_type_name if filter.type == 'resource' else a.name,
-                    ):
-                        tmp.append(a)
-            if filter.type == 'source':
-                c.sources = tmp
-            elif filter.type == 'resource':
-                c.resources = tmp
-            logger.debug(f'past filter ({filter.type=}): {len(artifacts)} artifacts')
-            yield c
-        else:
-            raise NotImplementedError
-
-
-def _apply_artifact_action(
-    action: str,
-    artifacts,
-    match: bool,
-):
-    if action == 'include':
-        return artifacts if match else ()
-    elif action == 'exclude':
-        return artifacts if not match else ()
-    else:
-        raise RuntimeError
-
-
-def _apply_component_filter(
-    filter: whitesource.model.WhiteSourceFilterCfg,
-    components: typing.Generator[typing.Union[tuple, typing.Any], typing.Any, typing.Any],
-):
-    if isinstance(m := filter.match, bool):
-        yield from _apply_components_action(action=filter.action, components=components, match=m)
-
-    elif isinstance(m := filter.match, dict):
-        for c in components:
-            if filter.action == 'include':
-                if re.search(pattern=m.get('name'), string=c.name):
-                    yield c
-            elif filter.action == 'exclude':
-                if not re.search(pattern=m.get('name'), string=c.name):
-                    yield c
-    else:
-        raise NotImplementedError
-
-
-def _apply_components_action(
-    action: str,
-    components,
-    match: bool,
-):
-    if action == 'include':
-        return components if match else ()
-    elif action == 'exclude':
-        return components if not match else ()
-    else:
-        raise RuntimeError

--- a/whitesource/filters.py
+++ b/whitesource/filters.py
@@ -1,0 +1,160 @@
+import logging
+import re
+import typing
+
+import gci.componentmodel as cm
+import whitesource.model
+
+
+logger = logging.getLogger(__name__)
+
+
+def _print_filter_stats(
+    components: typing.List[cm.Component],
+    filtered: bool
+):
+    sources = len([r for c in components for r in c.sources])
+    resources = len([r for c in components for r in c.resources])
+    logger.info(
+        f'{"past" if filtered else "pre"} filter: '
+        f'{len(components)} component with {sources} sources and {resources} resources'
+    )
+
+
+def apply_filters(
+    components: typing.List[cm.Component],
+    filters: typing.List[whitesource.model.WhiteSourceFilterCfg],
+) -> typing.Generator:
+
+    _print_filter_stats(components=components, filtered=False)
+    for f in filters:
+        if f.type is whitesource.model.FilterType.COMPONENT:
+            components = list(filter(lambda c: _component_filter(
+                filter_cfg=f,
+                component=c,
+            ), components))
+        elif f.type is whitesource.model.FilterType.SOURCE \
+            or f.type is whitesource.model.FilterType.RESOURCE:
+            if not components:
+                logger.warning('all components excluded, skipping artifact filter')
+            else:
+                components = list(_apply_artifact_filter(filter_cfg=f, components=components))
+
+        else:
+            raise NotImplementedError(f.type)
+
+    _print_filter_stats(components=components, filtered=False)
+    yield from components
+
+
+def _apply_artifact_filter(
+    filter_cfg: whitesource.model.WhiteSourceFilterCfg,
+    components: typing.Generator[typing.Union[tuple, typing.Any], None, None],
+):
+    logger.debug('applying artifact filter')
+    for c in components:
+        artifacts_pre = c.sources if filter_cfg.type is whitesource.model.FilterType.SOURCE \
+            else c.resources
+        artifacts_past = list(filter(lambda a: _artifact_filter(
+            filter_cfg=filter_cfg,
+            artifact=a,
+        ), artifacts_pre))
+        if filter_cfg.type is whitesource.model.FilterType.SOURCE:
+            c.sources = artifacts_past
+        elif filter_cfg.type is whitesource.model.FilterType.RESOURCE:
+            c.resources = artifacts_past
+        else:
+            raise NotImplementedError(filter_cfg.type)
+
+        yield c
+
+
+def _artifact_filter(
+    filter_cfg: whitesource.model.WhiteSourceFilterCfg,
+    artifact: typing.Union[cm.ComponentSource, cm.Resource],
+):
+    if isinstance(filter_cfg.match, bool):
+        return _match_bool_filter(filter_cfg=filter_cfg, artifact=artifact)
+
+    elif isinstance(filter_cfg.match, dict):
+        # enum to string
+        if isinstance(artifact.type, cm.ResourceType):
+            resource_type_name = artifact.type.value
+        elif isinstance(artifact.type, str):
+            resource_type_name = str(artifact.type)
+        else:
+            raise NotImplementedError
+
+        re_str = resource_type_name if filter_cfg.type is whitesource.model.FilterType.RESOURCE \
+            else artifact.name
+        re_pat = filter_cfg.match.get('type') if filter_cfg.type is \
+            whitesource.model.FilterType.RESOURCE else filter_cfg.match.get('name')
+
+        if filter_cfg.action is whitesource.model.ActionType.INCLUDE:
+            if re.search(pattern=re_pat, string=re_str):
+                logger.debug(
+                    f'included {artifact.name=}, '
+                    f'reason: {re_str=} matches {re_pat=} and {filter_cfg.action=}'
+                )
+                return True
+        elif filter_cfg.action is whitesource.model.ActionType.EXCLUDE:
+            if not re.search(pattern=re_pat, string=re_str):
+                logger.debug(
+                    f'included {artifact.name=}, reason: '
+                    f'{re_str=} does not match {re_pat=} and {filter_cfg.action=}'
+                )
+                return True
+        else:
+            raise NotImplementedError(filter_cfg.action)
+    else:
+        raise NotImplementedError(filter_cfg.match)
+
+    logger.debug(f'excluded {artifact.name=}')
+    return False
+
+
+def _match_bool_filter(
+    filter_cfg: whitesource.model.WhiteSourceFilterCfg,
+    artifact: typing.Union[cm.Resource, cm.ComponentSource] = None,
+    component: cm.Component = None,
+) -> bool:
+
+    if not artifact and not component:
+        raise NotImplementedError
+
+    if filter_cfg.action is whitesource.model.ActionType.INCLUDE:
+        if filter_cfg.match:
+            logger.debug(f'included {artifact.name if artifact else component.name},'
+                         f' reason: {filter_cfg.match=} and {filter_cfg.action=}')
+            return True
+    elif filter_cfg.action is whitesource.model.ActionType.EXCLUDE:
+        if not filter_cfg.match:
+            logger.debug(f'included {artifact.name if artifact else component.name},'
+                         f' reason: {filter_cfg.match=} and {filter_cfg.action=}')
+            return True
+    else:
+        raise NotImplementedError(filter_cfg.action)
+
+    logger.debug(f'excluded {artifact.name if artifact else component.name}')
+    return False
+
+
+def _component_filter(
+    filter_cfg: whitesource.model.WhiteSourceFilterCfg,
+    component: cm.Component,
+) -> bool:
+    logger.debug('applying component filter')
+    if isinstance(filter_cfg.match, bool):
+        return _match_bool_filter(filter_cfg=filter_cfg, component=component)
+
+    elif isinstance(filter_cfg.match, dict):
+        if filter_cfg.action is whitesource.model.ActionType.INCLUDE:
+            if re.search(pattern=filter_cfg.match.get('name'), string=component.name):
+                return True
+        elif filter_cfg.action is whitesource.model.ActionType.EXCLUDE:
+            if not re.search(pattern=filter_cfg.match.get('name'), string=component.name):
+                return True
+    else:
+        raise NotImplementedError
+
+    return False

--- a/whitesource/model.py
+++ b/whitesource/model.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import typing
 from dataclasses import dataclass
 
@@ -35,8 +36,19 @@ class WhiteSrcDisplayProject:
     highest_cve_score: float
 
 
+class FilterType(Enum):
+    COMPONENT = 'component'
+    SOURCE = 'source'
+    RESOURCE = 'resource'
+
+
+class ActionType(Enum):
+    INCLUDE = 'include'
+    EXCLUDE = 'exclude'
+
+
 @dataclass(frozen=True)
 class WhiteSourceFilterCfg:
-    type: str
+    type: FilterType
     match: typing.Union[bool, dict]
-    action: str
+    action: ActionType

--- a/whitesource/model.py
+++ b/whitesource/model.py
@@ -1,12 +1,11 @@
 import typing
-
-import dataclasses
+from dataclasses import dataclass
 
 cve_name = str
 cvss_score = float
 
 
-@dataclasses.dataclass
+@dataclass
 class WhiteSrcProject:
     name: str
     token: str
@@ -29,8 +28,15 @@ class WhiteSrcProject:
         return (cve_name, float(max_score))
 
 
-@dataclasses.dataclass
+@dataclass
 class WhiteSrcDisplayProject:
     name: str
     highest_cve_name: str
     highest_cve_score: float
+
+
+@dataclass(frozen=True)
+class WhiteSourceFilterCfg:
+    type: str
+    match: typing.Union[bool, dict]
+    action: str

--- a/whitesource/util.py
+++ b/whitesource/util.py
@@ -400,7 +400,7 @@ def send_mail(
 
 
 def parse_filters(
-    filters: typing.Optional[list[dict]],
+    filters: typing.Optional[typing.List[dict]],
 ) -> typing.List[whitesource.model.WhiteSourceFilterCfg]:
     l: typing.List[whitesource.model.WhiteSourceFilterCfg] = []
     if not filters:

--- a/whitesource/util.py
+++ b/whitesource/util.py
@@ -364,6 +364,7 @@ def send_mail(
 ):
     if not notification_recipients:
         logger.warning('No recipients defined. No emails will be sent...')
+        return
 
     if len(notification_recipients) > 0:
 
@@ -399,16 +400,20 @@ def send_mail(
 
 
 def parse_filters(
-    filters: typing.Union[None, list],
+    filters: typing.Optional[list[dict]],
 ) -> typing.List[whitesource.model.WhiteSourceFilterCfg]:
     l: typing.List[whitesource.model.WhiteSourceFilterCfg] = []
-    if filters:
-        for e in filters:
-            l.append(whitesource.model.WhiteSourceFilterCfg(
-                type=e.get('type'),
-                action=e.get('action'),
-                match=e.get('match'),
-            ))
-    if not l == []:
-        logger.info(f'found filter! {filters=}')
-    return l
+    if not filters:
+        return []
+
+    logger.info(f'found filter! {filters=}')
+    for f in filters:
+        l.append(whitesource.model.WhiteSourceFilterCfg(
+            type=whitesource.model.FilterType(f.get('type')),
+            action=whitesource.model.ActionType(f.get('action')),
+            match=f.get('match'),
+        ))
+
+    # sorting filters, component filters have to be first elements
+    # if component is excluded, its artifacts are excluded as well
+    return sorted(l, key=lambda k: str(k.type))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces filtering options for the `scan_sources` trait. `components`, `sources` and `resources` can be included / excluded, either with regex or the artifact type as a whole. Additionally `resources` can be matched which respect to their `resourceType`.
Sample trait:
```
scan_sources:
  filters:
  - type: component
    match:
      name: 'github.com/gardener/.*' # only include components from opensource-gardener-project
    action: 'include'
  - type: source
    match: false # reject all
    action: 'exclude'
  - type: resource
    match:
      type: ociImage # take all oci-images
    action: 'include'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
