### PR TITLE
move uploading of component descriptor to its own step

### DIFF
--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -95,6 +95,16 @@ ATTRIBUTES = (
         '''
     ),
     AttributeSpec.optional(
+        name='snapshot_ctx_repository',
+        type=str,
+        default=None,
+        doc='''
+            the component descriptor context repository cfg name for snapshot-component-descriptors,
+            i.e. component descriptors that are not for release-versions.
+            If not configured, no snapshot-component-descriptor will be published.
+        '''
+    ),
+    AttributeSpec.optional(
         name='component_labels',
         default=[],
         type=typing.List[Label],
@@ -138,6 +148,14 @@ class ComponentDescriptorTrait(Trait):
 
     def validation_policies(self):
         return ()
+
+    def snapshot_ctx_repository(self):
+        if snapshot_ctx_repo_name := self.raw['snapshot_ctx_repository']:
+            return self.cfg_set.ctx_repository(snapshot_ctx_repo_name)
+
+    def snapshot_ctx_repository_base_url(self):
+        if snapshot_repo_cfg := self.snapshot_ctx_repository():
+            return snapshot_repo_cfg.base_url()
 
     def ctx_repository(self) -> model.ctx_repository.CtxRepositoryCfg:
         ctx_repo_name = self.raw.get('ctx_repository')

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -645,6 +645,14 @@ class GitHubReleaseStep(TransactionalStep):
             product.v2.upload_component_descriptor_v2_to_oci_registry(
                 component_descriptor_v2=component_descriptor_v2,
             )
+        elif os.path.exists(self.ctf_path):
+            logger.info('processing CTF-archive')
+            subprocess.run(
+                [
+                    'component-cli', 'ctf', 'push', self.ctf_path,
+                ],
+                check=True,
+            )
 
         for component_descriptor_v2 in self.components:
             descriptor_str = yaml.dump(


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the upload of component descriptors to a separate step. This prevents issues with CDs being published before the corresponding release has been properly created.

This upload-step is always included for release-jobs, but it can also be configured for jobs containing the component-descriptor trait (to preserve existing functionality, if desired)

