### PR TITLE
Improve cfg-factory convenience a little bit

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -404,16 +404,21 @@ class ConfigFactory:
             if (factory_method := cfg_type.factory_method()):
                 yield factory_method
 
+            # also include methods for NamedModelElement-derived types
+            elif cfg_type.cfg_type() == NamedModelElement.__name__:
+                yield cfg_type.cfg_type_name()
+
         yield from super().__dir__()
 
     def __getattr__(self, cfg_type_name):
         for cfg_type in self._cfg_types().values():
             if cfg_type.factory_method() == cfg_type_name:
-                break
-        else:
-            raise AttributeError(cfg_type_name)
+                return functools.partial(self._cfg_element, cfg_type_name)
 
-        return functools.partial(self._cfg_element, cfg_type_name)
+            if cfg_type.cfg_type() == NamedModelElement.__name__:
+                return functools.partial(self._cfg_element, cfg_type_name)
+
+        raise AttributeError(cfg_type_name)
 
     def _serialise(self):
         cfg_types = self._cfg_types()


### PR DESCRIPTION
Provide default getters (`ConfigFactory.<type name>()`) for cfg-types that are based on `NamedModelElement`.
Should make interacting with these simple types from within Python3 a little bit more convenient, as before it required going through the `_cfg_element` method

