### PR TITLE
pass ctx_repo-objects, instead of just base-urls

### DIFF
--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -105,11 +105,12 @@ def component_diff_since_last_release(
     component = ci.util.not_none(
         component_descriptor.component,
     )
+    component: cm.Component
 
     greatest_release_version = product.v2.greatest_version_before(
         component_name=component.name,
         component_version=component.version,
-        ctx_repo_base_url=ctx_repo_url,
+        ctx_repo=component.current_repository_ctx(),
     )
 
     if not greatest_release_version:


### PR DESCRIPTION
Prepare for future introductions of other ctx-repository-flavours.
Introduce changes in a mostly backwards-compatible manner (print
warnings to help migration).
