### PR TITLE
Write scan results to compliance-db

### DIFF
--- a/cli/gardener_ci/checkmarx_cli.py
+++ b/cli/gardener_ci/checkmarx_cli.py
@@ -1,14 +1,19 @@
+import concourse.steps.component_descriptor_util as util
 import concourse.steps.scan_sources
 
 
 def upload_and_scan_from_component_descriptor(
         checkmarx_cfg_name: str,
         team_id: str,
-        component_descriptor_path: str
+        component_descriptor_path: str,
+        compliancedb_cfg_name: str = None,
 ):
     concourse.steps.scan_sources.scan_sources_and_notify(
         checkmarx_cfg_name=checkmarx_cfg_name,
         team_id=team_id,
-        component_descriptor_path=component_descriptor_path,
+        compliancedb_cfg_name=compliancedb_cfg_name,
+        component_descriptor=util.component_descriptor_from_component_descriptor_path(
+            cd_path=component_descriptor_path,
+        ),
         email_recipients=['johannes.krayl@sap.com']
     )

--- a/cli/gardener_ci/protecode_cli.py
+++ b/cli/gardener_ci/protecode_cli.py
@@ -1,0 +1,54 @@
+import logging
+
+import ci.util
+import concourse.steps.images
+import concourse.steps.component_descriptor_util as util
+from protecode.model import CVSSVersion
+import protecode.scanning_util
+import protecode.util
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def scan_component_from_component_descriptor(
+    protecode_cfg_name: str,
+    component_descriptor_path: str,
+    parallel_jobs: int = 1,
+    compliancedb_cfg_name: str = None,
+    processing_mode: str = 'rescan',
+    protecode_group_id: str = '5',
+    cvss_version: str = 'CVSSv3',
+    cve_threshold: float = 5.0,
+):
+
+    cfg_factory = ci.util.ctx().cfg_factory()
+    protecode_cfg = cfg_factory.protecode(protecode_cfg_name)
+
+    filter_function = concourse.steps.images.create_composite_filter_function(
+        include_image_references=('eu.gcr.*',),
+        exclude_image_references=(),
+        include_image_names=(),
+        exclude_image_names=(),
+        include_component_names=(),
+        exclude_component_names=(),
+    )
+
+    protecode_report = protecode.util.upload_grouped_images(
+        protecode_cfg=protecode_cfg,
+        protecode_group_id=protecode_group_id,
+        component_descriptor=util.component_descriptor_from_component_descriptor_path(
+            cd_path=component_descriptor_path,
+        ),
+        reference_group_ids=(),
+        processing_mode=protecode.scanning_util.ProcessingMode(processing_mode),
+        parallel_jobs=parallel_jobs,
+        cve_threshold=cve_threshold,
+        image_reference_filter=filter_function,
+        cvss_version=CVSSVersion(cvss_version),
+    )
+
+    protecode.scanning_util.insert_results(
+        protecode_results=protecode_report.rawResults,
+        compliancedb_cfg_name=compliancedb_cfg_name,
+    )

--- a/cli/gardener_ci/whitesource_cli.py
+++ b/cli/gardener_ci/whitesource_cli.py
@@ -12,6 +12,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def scan_component_from_component_descriptor(
     whitesource_cfg_name: str,
     component_descriptor_path: str,
+    compliancedb_cfg_name: str = None,
     notification_recipients: str = None,
     filters: str = None,
     extra_whitesource_config: str = None,
@@ -27,6 +28,7 @@ def scan_component_from_component_descriptor(
 
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
+        compliancedb_cfg_name=compliancedb_cfg_name,
         component_descriptor=util.component_descriptor_from_component_descriptor_path(
             cd_path=component_descriptor_path,
         ),
@@ -41,6 +43,7 @@ def scan_component_from_component_descriptor(
 def scan_component_from_ctf(
     whitesource_cfg_name: str,
     ctf_path: str,
+    compliancedb_cfg_name: str = None,
     notification_recipients: str = None,
     filters: str = None,
     extra_whitesource_config: str = None,
@@ -56,6 +59,7 @@ def scan_component_from_ctf(
 
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
+        compliancedb_cfg_name=compliancedb_cfg_name,
         component_descriptor=util.component_descriptor_from_ctf_path(
             ctf_path=ctf_path,
         ),
@@ -70,6 +74,7 @@ def scan_component_from_ctf(
 def scan_component_from_dir(
     whitesource_cfg_name: str,
     dir_path: str,
+    compliancedb_cfg_name: str = None,
     notification_recipients: str = None,
     filters: str = None,
     extra_whitesource_config: str = None,
@@ -85,6 +90,7 @@ def scan_component_from_dir(
 
     concourse.steps.scan_sources.scan_component_with_whitesource(
         whitesource_cfg_name=whitesource_cfg_name,
+        compliancedb_cfg_name=compliancedb_cfg_name,
         component_descriptor=util.component_descriptor_from_dir(
             dir_path=dir_path,
         ),

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -107,6 +107,27 @@ PROTECODE_ATTRS = (
 )
 
 
+COMPLIANCE_DB_ATTRIBUTES = (
+    AttributeSpec.required(
+        name='cfg_name',
+        doc='compliance db cfg_name',
+        type=str,
+    ),
+)
+
+
+class ComplianceDBCfg(ModelBase):
+    @classmethod
+    def _attribute_specs(cls):
+        return COMPLIANCE_DB_ATTRIBUTES
+
+    def cfg_name(self):
+        return self.raw['cfg_name']
+
+    def validate(self):
+        super().validate()
+
+
 class ProtecodeScanCfg(ModelBase):
     @classmethod
     def _attribute_specs(cls):
@@ -201,7 +222,14 @@ ATTRIBUTES = (
         default=(),
         type=typing.Set[str],
         doc='if present, generated build steps depend on those generated from specified traits',
-    )
+    ),
+    # TODO required
+    AttributeSpec.optional(
+        name='compliance_db',
+        type=ComplianceDBCfg,
+        default=(),
+        doc='config to write scan results to compliance db',
+    ),
 )
 
 
@@ -229,6 +257,10 @@ class ImageScanTrait(Trait, ImageFilterMixin):
     def clam_av(self):
         if self.raw['clam_av']:
             return ClamAVScanCfg(raw_dict=self.raw['clam_av'])
+
+    def compliance_db(self):
+        if self.raw['compliance_db']:
+            return ComplianceDBCfg(raw_dict=self.raw['compliance_db'])
 
     def transformer(self):
         return ImageScanTraitTransformer(trait=self)

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -73,6 +73,15 @@ WHITESOURCE_ATTRIBUTES = (
 )
 
 
+COMPLIANCE_DB_ATTRIBUTES = (
+    AttributeSpec.required(
+        name='cfg_name',
+        doc='compliance db cfg_name',
+        type=str,
+    ),
+)
+
+
 FILTER_ATTRIBUTES = (
     AttributeSpec.required(
         name='type',
@@ -90,6 +99,15 @@ FILTER_ATTRIBUTES = (
         type=str,
     ),
 )
+
+
+class ComplianceDBCfg(ModelBase):
+    @classmethod
+    def _attribute_specs(cls):
+        return COMPLIANCE_DB_ATTRIBUTES
+
+    def cfg_name(self):
+        return self.raw['cfg_name']
 
 
 class FilterCfg(ModelBase):
@@ -174,6 +192,13 @@ ATTRIBUTES = (
         default=(),
         doc='if present, perform whitesource scanning',
     ),
+    # TODO required
+    AttributeSpec.optional(
+        name='compliance_db',
+        type=ComplianceDBCfg,
+        default=(),
+        doc='config to write scan results to compliance db',
+    ),
 )
 
 
@@ -199,6 +224,10 @@ class SourceScanTrait(Trait):
     def whitesource(self):
         if whitesource := self.raw.get('whitesource'):
             return WhitesourceCfg(whitesource)
+
+    def compliance_db(self):
+        if compliance_db := self.raw.get('compliance_db'):
+            return ComplianceDBCfg(compliance_db)
 
     def filters(self):
         if filters := self.raw.get('filters'):

--- a/concourse/steps/scan_sources.mako
+++ b/concourse/steps/scan_sources.mako
@@ -10,11 +10,17 @@ repo_name = main_repo.logical_name().upper()
 
 source_scan_trait = job_variant.trait('scan_sources')
 checkmarx_cfg = source_scan_trait.checkmarx()
+compliance_db = source_scan_trait.compliance_db()
 whitesource_cfg = source_scan_trait.whitesource()
 email_recipients = source_scan_trait.email_recipients()
 component_trait = job_variant.trait('component_descriptor')
 component_descriptor_dir = job_step.input('component_descriptor_dir')
 scan_sources_filter = source_scan_trait.filters_raw()
+
+if not compliance_db:
+    compliancedb_cfg_name = None
+else:
+    compliancedb_cfg_name = compliance_db.cfg_name()
 %>
 ${step_lib('component_descriptor_util')}
 ${step_lib('scan_sources')}
@@ -24,6 +30,7 @@ component_descriptor = component_descriptor_from_dir(dir_path='${component_descr
 % if checkmarx_cfg:
 scan_sources_and_notify(
     checkmarx_cfg_name='${checkmarx_cfg.checkmarx_cfg_name()}',
+    compliancedb_cfg_name=compliancedb_cfg_name,
     component_descriptor=component_descriptor,
     email_recipients=${email_recipients},
     team_id='${checkmarx_cfg.team_id()}',
@@ -36,11 +43,12 @@ scan_sources_and_notify(
 % if whitesource_cfg:
 component_name = '${component_trait.component_name()}'
 scan_component_with_whitesource(
+    whitesource_cfg_name='${whitesource_cfg.cfg_name()}',
+    compliancedb_cfg_name=compliancedb_cfg_name,
     component_descriptor=component_descriptor,
     cve_threshold=${whitesource_cfg.cve_threshold()},
     extra_whitesource_config={},
     notification_recipients=${email_recipients},
-    whitesource_cfg_name='${whitesource_cfg.cfg_name()}',
     filters=${scan_sources_filter},
 )
 % endif

--- a/delivery/client.py
+++ b/delivery/client.py
@@ -1,5 +1,7 @@
 import requests
 
+from dso.compliancedb.model import ScanTool
+from dso.model import ArtifactType
 import gci.componentmodel as cm
 
 import ci.util
@@ -14,6 +16,13 @@ class DeliveryServiceRoutes:
             self._base_url,
             'cnudie',
             'component',
+        )
+
+    def compliance_scan(self):
+        return 'http://' + ci.util.urljoin(
+            self._base_url,
+            'compliance',
+            'scan',
         )
 
 
@@ -43,3 +52,31 @@ class DeliveryServiceClient:
             res.json(),
             validation_mode=validation_mode,
         )
+
+    def post_compliance_scan(
+        self,
+        scan_data: dict,
+        compliancedb_cfg_name: str,
+        tool: ScanTool,
+        component_name: str,
+        component_version: str,
+        artifact_name: str,
+        artifact_version: str,
+        artifact_type: ArtifactType,
+    ):
+        body = {
+            'scanData': scan_data,
+            'complianceDbCfg': compliancedb_cfg_name,
+            'tool': tool.value,
+            'componentName': component_name,
+            'componentVersion': component_version,
+            'artifactName': artifact_name,
+            'artifactVersion': artifact_version,
+            'artifactType': artifact_type.value,
+        }
+        res = requests.post(
+            url=self._routes.compliance_scan(),
+            json=body,
+        )
+
+        res.raise_for_status()

--- a/dso/compliancedb/db.py
+++ b/dso/compliancedb/db.py
@@ -1,0 +1,47 @@
+import logging
+
+import sqlalchemy
+
+import ci.util
+from dso.compliancedb.model import Base
+
+
+class ComplianceDB:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        hostname: str,
+        port: int,
+        dialect: str = 'postgresql',
+    ):
+        self._engine = sqlalchemy.create_engine(
+            f'{dialect}://{username}:{password}@{hostname}:{port}',
+            echo=True,
+            future=True,
+        )
+        self.Base = Base
+        # we configured our own root logger and use log propagation
+        # therefore pop streamhandler to not have duplicate output
+        logging.getLogger('sqlalchemy.engine.Engine').handlers.pop()
+        self.Base.metadata.create_all(self._engine)
+        self.Session = sqlalchemy.orm.Session(self._engine)
+
+
+class ComplianceDBFactory:
+    def __init__(
+        self,
+        cfg_name: str
+    ) -> None:
+        self.cfg_name = cfg_name
+
+    def make(self):
+        cfg_fac = ci.util.ctx().cfg_factory()
+        cfg = cfg_fac.compliancedb(self.cfg_name)
+        cdb = ComplianceDB(
+            username=cfg.credentials().username(),
+            password=cfg.credentials().password(),
+            hostname=cfg.hostname(),
+            port=cfg.port(),
+        )
+        return cdb

--- a/dso/compliancedb/model.py
+++ b/dso/compliancedb/model.py
@@ -1,0 +1,61 @@
+import datetime
+from enum import Enum
+
+import sqlalchemy
+from sqlalchemy import Column, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+import dso.model
+
+
+Base = declarative_base()
+
+
+class ScanTool(Enum):
+    WHITESOURCE = 'whitesource'
+    PROTECODE = 'protecode'
+    CHECKMARX = 'checkmarx'
+    CLAMAV = 'clamav'
+
+
+class Artifact(Base):
+    __tablename__ = 'artifact'
+
+    id = Column(sqlalchemy.String, primary_key=True)
+    component_name = Column(sqlalchemy.String)
+    component_version = Column(sqlalchemy.String)
+    name = Column(sqlalchemy.String)
+    type = Column(sqlalchemy.types.Enum(
+        dso.model.ArtifactType,
+        values_callable=lambda v: [e.value for e in v],
+    ))
+    version = Column(sqlalchemy.String)
+
+    scan_result = relationship('ScanResult')
+
+    def __repr__(self):
+        return f'Scan(id={self.id!r} '\
+            f'Component(name={self.component_name!r}, version={self.component_version!r}), '\
+            f'Artifact(name={self.name!r}, type={self.type!r}, version={self.version!r}))'
+
+
+class ScanResult(Base):
+    __tablename__ = 'scan_result'
+
+    id = Column(sqlalchemy.String, primary_key=True)
+    artifact_id = Column(sqlalchemy.String, ForeignKey('artifact.id'))
+    timestamp = Column(
+        sqlalchemy.TIMESTAMP(timezone=True),
+        default=datetime.datetime.utcnow(),
+    )
+    source = Column(sqlalchemy.types.Enum(
+        ScanTool,
+    ))
+    scan_data = Column(sqlalchemy.JSON)
+
+    def __repr__(self):
+        return f'ScanResult(id={self.id!r}, '\
+            f'Artifact(id={self.artifact_id!r}), '\
+            f'timestamp={self.timestamp!r}, source={self.source!r}, ' \
+            f'scan_data={self.scan_data!r})'

--- a/dso/model.py
+++ b/dso/model.py
@@ -1,13 +1,18 @@
-import dataclasses
+from dataclasses import dataclass
+from enum import Enum
 import typing
 
+import dso.labels
 import gci.componentmodel as cm
 
-import dso.labels
+
+class ArtifactType(Enum):
+    RESOURCE = 'resource'
+    SOURCE = 'source'
 
 
 # abstraction of component model v2 source and resource
-@dataclasses.dataclass
+@dataclass
 class ScanArtifact:
     name: str
     access: typing.Union[
@@ -17,3 +22,8 @@ class ScanArtifact:
         cm.ResourceAccess,
     ]
     label: dso.labels.ScanningHint
+    componentName: str
+    componentVersion: str
+    artifactName: str
+    artifactVersion: str
+    artifactType: ArtifactType

--- a/dso/util.py
+++ b/dso/util.py
@@ -1,7 +1,55 @@
 import functools
 import logging
+import uuid
+
+import dso.model
+import dso.compliancedb.db
+import dso.compliancedb.model
+
+
+logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache
 def component_logger(name: str):
     return logging.getLogger(name)
+
+
+def scans_to_compliance_db(
+    scan_data,
+    tool: dso.compliancedb.model.ScanTool,
+    component_name: str,
+    component_version: str,
+    artifact_name: str,
+    artifact_version: str,
+    artifact_type: dso.model.ArtifactType,
+    compliancedb_cfg_name: str,
+):
+    if not compliancedb_cfg_name:
+        logger.warning('no compliance db cfg name found, skipping insertion')
+        return
+    logger.info('inserting results to database')
+
+    db_fac = dso.compliancedb.db.ComplianceDBFactory(cfg_name=compliancedb_cfg_name)
+    cdb = db_fac.make()
+
+    # TODO ensure uuids are actually unique
+    artifact_id = uuid.uuid4()
+    artifact = dso.compliancedb.model.Artifact(
+        id=artifact_id,
+        component_name=component_name,
+        component_version=component_version,
+        name=artifact_name,
+        version=artifact_version,
+        type=artifact_type
+    )
+
+    scan_result = dso.compliancedb.model.ScanResult(
+        id=uuid.uuid4(),
+        artifact_id=artifact_id,
+        source=tool,
+        scan_data=scan_data,
+    )
+    cdb.Session.add(artifact)
+    cdb.Session.add(scan_result)
+    cdb.Session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ requests_toolbelt<1
 semver<3.0.0
 slackclient<3.0.0
 sphinx_rtd_theme<1.0.0
+sqlalchemy>1.4.0
 sseclient-py<2.0.0
 tabulate<1.0.0
 termcolor<2.0.0

--- a/whitesource/client.py
+++ b/whitesource/client.py
@@ -142,6 +142,8 @@ class WhitesourceClient:
     def get_all_projects_of_product(
         self,
     ) -> typing.List[whitesource.model.WhiteSrcProject]:
+        logger.info('getting all projects')
+
         body = {
             'requestType': 'getAllProjects',
             'userKey': self.creds.user_key(),
@@ -162,7 +164,7 @@ class WhitesourceClient:
         for element in res['projects']:
             projects.append(whitesource.model.WhiteSrcProject(
                 name=element['projectName'],
-                token=element['projectName'],
+                token=element['projectToken'],
                 vulnerability_report=self.get_project_vulnerability_report(
                     project_token=element['projectToken'],
                 ),

--- a/whitesource/component.py
+++ b/whitesource/component.py
@@ -47,8 +47,15 @@ def get_scan_artifacts_from_components(
                     access=artifact.access,
                     label=ws_hint,
                     name=f'{component.name}:{component.version}/'
-                         f'{"source" if artifact in component.sources else "resources"}/'
+                         f'{"source" if artifact in component.sources else "resource"}/'
                          f'{artifact.name}:{artifact.version}',
+                    componentName=component.name,
+                    componentVersion=component.version,
+                    artifactName=artifact.name,
+                    artifactVersion=artifact.version,
+                    artifactType=dso.model.ArtifactType(
+                        'source' if artifact in component.sources else 'resource'
+                    ),
                 )
             elif ws_hint.policy is dso.labels.ScanPolicy.SKIP:
                 continue

--- a/whitesource/model.py
+++ b/whitesource/model.py
@@ -2,6 +2,7 @@ from enum import Enum
 import typing
 from dataclasses import dataclass
 
+
 cve_name = str
 cvss_score = float
 
@@ -27,6 +28,12 @@ class WhiteSrcProject:
                 cve_name = entry['name']
 
         return (cve_name, float(max_score))
+
+
+@dataclass
+class WhiteSrcProduct:
+    name: str
+    projects: typing.List[WhiteSrcProject]
 
 
 @dataclass


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on `compliance_db` trait, write compliance scan results to given DB cfg.

Steps:
- add compliance-db model (sqlalchemy orm)
- parse scan results to fit compliance-db model
- implement custom `insert_result()` for each scan tool
- trigger insertion with `delivery.client`

Misc:
- some logging updates

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
