### PR TITLE
Fix v1 v2 conversion when layers are gziped and not filtered

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -66,6 +66,7 @@ def replicate_artifact(
         manifest, _ = oconv.v1_manifest_to_v2(
             manifest=manifest,
             oci_client=client,
+            src_image_reference=src_image_reference,
             tgt_image_ref=tgt_image_reference,
         )
         raw_manifest = json.dumps(dataclasses.asdict(manifest))

--- a/oci/convert.py
+++ b/oci/convert.py
@@ -1,7 +1,10 @@
 import dataclasses
+import gzip
 import hashlib
 import json
+import tarfile
 
+import ccc.oci
 import dacite
 
 import oci.client as oc
@@ -11,16 +14,42 @@ import oci.model as om
 
 def v2_cfg_from_v1_manifest(
     manifest: om.OciImageManifestV1,
+    src_image_reference: str
 ) -> od.DockerCfg:
     # we only need the latest cfg
     history = manifest.history[0]
     docker_cfg = history['v1Compatibility']
     docker_cfg = json.loads(docker_cfg)
 
+    # calcuate hash of layer blobs. 
+    # Ungzip those images to generate the hash of the uncompressed image.
+    oci_client =  ccc.oci.oci_client()
+    uncompressed_layers_digests = []
+    for layer in manifest.layers:
+        cfg_hash = hashlib.sha256() # we need to write "non-gzipped" hash to cfg-blob
+
+        is_gziped = None
+        src_tar_stream = oci_client.blob(
+            image_reference=src_image_reference,
+            digest=layer.digest,
+            stream=True,
+        ).iter_content(chunk_size=tarfile.BLOCKSIZE * 100000)
+        for chunk in src_tar_stream:
+            #detect header magic bytes for gzip on first chunk
+            if is_gziped is None:
+                if bytes(chunk).startswith(b'\x1f\x8b'):
+                    is_gziped = True
+                else:
+                    is_gziped = False
+
+            if is_gziped:
+                chunk = gzip.decompress(chunk)
+            cfg_hash.update(chunk) # need uncompressed before hashing for cfg-blob
+        uncompressed_layers_digests.append(f'sha256:{cfg_hash.hexdigest()}')
+
+    # docker mandates the uncompressed-layer digests in the config
     root_fs = {
-        'diff_ids': [
-            layer.digest for layer in manifest.layers
-        ],
+        'diff_ids': uncompressed_layers_digests,
         'type': 'layers',
     }
     docker_cfg['rootfs'] = root_fs
@@ -37,9 +66,10 @@ def v2_cfg_from_v1_manifest(
 def v1_manifest_to_v2(
     manifest: om.OciImageManifestV1,
     oci_client: oc.Client,
+    src_image_reference: str,
     tgt_image_ref: str,
 ) -> om.OciImageManifest:
-    docker_cfg = v2_cfg_from_v1_manifest(manifest=manifest)
+    docker_cfg = v2_cfg_from_v1_manifest(manifest=manifest, src_image_reference=src_image_reference)
     docker_cfg = dataclasses.asdict(docker_cfg)
     docker_cfg = json.dumps(docker_cfg).encode('utf-8')
 

--- a/oci/convert.py
+++ b/oci/convert.py
@@ -2,7 +2,6 @@ import dataclasses
 import gzip
 import hashlib
 import json
-import tarfile
 
 import ccc.oci
 import dacite
@@ -21,30 +20,23 @@ def v2_cfg_from_v1_manifest(
     docker_cfg = history['v1Compatibility']
     docker_cfg = json.loads(docker_cfg)
 
-    # calcuate hash of layer blobs. 
+    # calcuate hash of layer blobs.
     # Ungzip those images to generate the hash of the uncompressed image.
     oci_client =  ccc.oci.oci_client()
     uncompressed_layers_digests = []
     for layer in manifest.layers:
         cfg_hash = hashlib.sha256() # we need to write "non-gzipped" hash to cfg-blob
 
-        is_gziped = None
-        src_tar_stream = oci_client.blob(
+        src_content = oci_client.blob(
             image_reference=src_image_reference,
             digest=layer.digest,
-            stream=True,
-        ).iter_content(chunk_size=tarfile.BLOCKSIZE * 100000)
-        for chunk in src_tar_stream:
-            #detect header magic bytes for gzip on first chunk
-            if is_gziped is None:
-                if bytes(chunk).startswith(b'\x1f\x8b'):
-                    is_gziped = True
-                else:
-                    is_gziped = False
+            stream=False,
+        ).content
 
-            if is_gziped:
-                chunk = gzip.decompress(chunk)
-            cfg_hash.update(chunk) # need uncompressed before hashing for cfg-blob
+        # detect header magic bytes for gzip on first chunk
+        if bytes(src_content).startswith(b'\x1f\x8b'):
+            src_content = gzip.decompress(src_content)
+        cfg_hash.update(src_content) # need uncompressed before hashing for cfg-blob
         uncompressed_layers_digests.append(f'sha256:{cfg_hash.hexdigest()}')
 
     # docker mandates the uncompressed-layer digests in the config

--- a/oci/convert.py
+++ b/oci/convert.py
@@ -35,8 +35,17 @@ def v2_cfg_from_v1_manifest(
             stream=False,
         ).iter_content(chunk_size=tarfile.BLOCKSIZE * 64)
 
+        is_first_chunk = True
+        is_gziped = False
         for chunk in src_content:
-            cfg_hash.update(decompressor.decompress(chunk))
+            if is_first_chunk:
+                is_first_chunk = False
+                if bytes(chunk).startswith(b'\x1f\x8b'):
+                    is_gziped = True
+            if is_gziped:
+                cfg_hash.update(decompressor.decompress(chunk))
+            else:
+                cfg_hash.update(chunk)
 
         uncompressed_layers_digests.append(f'sha256:{cfg_hash.hexdigest()}')
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes v1->v2 conversion now correctly updates the config digests (of non gzipped layers) even if layers are gzipped.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
