### PR TITLE
return response objects from oci methods

### DIFF
--- a/container/util.py
+++ b/container/util.py
@@ -23,6 +23,7 @@ import tempfile
 import typing
 
 import deprecated
+import requests
 
 import ccc.oci
 import ci.util
@@ -45,7 +46,7 @@ def filter_image(
     target_ref:str,
     remove_files: typing.Sequence[str]=(),
     oci_client: oc.Client=None,
-):
+) -> requests.Response:
     if not oci_client:
         oci_client = ccc.oci.oci_client()
 
@@ -165,7 +166,7 @@ def filter_image(
 
     manifest_raw = json.dumps(dataclasses.asdict(manifest)).encode('utf-8')
 
-    oci_client.put_manifest(image_reference=target_ref, manifest=manifest_raw)
+    return oci_client.put_manifest(image_reference=target_ref, manifest=manifest_raw)
 
 
 @deprecated.deprecated

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -7,6 +7,7 @@ import typing
 import zlib
 
 import dacite
+import requests
 
 import oci.auth as oa
 import oci.client as oc
@@ -27,7 +28,7 @@ def replicate_artifact(
     credentials_lookup: oa.credentials_lookup=None,
     routes: oc.OciRoutes=oc.OciRoutes(),
     oci_client: oc.Client=None,
-):
+) -> requests.Response:
     '''
     verbatimly replicate the OCI Artifact from src -> tgt without taking any assumptions
     about the transported contents. This in particular allows contents to be replicated
@@ -173,7 +174,7 @@ def replicate_artifact(
         manifest_dict['config']['size'] = len(fake_cfg_raw)
         raw_manifest = json.dumps(manifest_dict)
 
-    client.put_manifest(
+    return client.put_manifest(
         image_reference=tgt_image_reference,
         manifest=raw_manifest,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:
return the response objects from 2 oci methods. this change is needed in https://github.com/gardener/cnudie-transport-tool/pull/8, for reading the content digests which is returned after uploading/replicating oci artifacts to a registry

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
