### PR TITLE
Support large release-notes

### DIFF
--- a/concourse/steps/draft_release.mako
+++ b/concourse/steps/draft_release.mako
@@ -97,6 +97,8 @@ if not draft_release:
     github_helper.create_draft_release(
         name=draft_name,
         body=release_notes_md,
+        component_version=processed_version,
+        component_name=component_descriptor_v2.component.name,
     )
 else:
     if not draft_release.body == release_notes_md:

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -40,6 +40,7 @@ release_callback_path = release_trait.release_callback_path()
 next_version_callback_path = release_trait.next_version_callback_path()
 %>
 import ccc.github
+import concourse.steps.component_descriptor_util as cdu
 
 ${step_lib('release')}
 
@@ -63,7 +64,13 @@ githubrepobranch = GitHubRepoBranch(
     branch=repository_branch,
 )
 
+component_descriptor = cdu.component_descriptor_from_dir(
+  '${job_step.input('component_descriptor_dir')}'
+)
+component_name = component_descriptor.component.name
+
 release_and_prepare_next_dev_cycle(
+  component_name=component_name,
   component_descriptor_v2_path='${component_descriptor_v2_path}',
   ctf_path='${ctf_path}',
   % if has_slack_trait:

--- a/test/concourse/steps/release_test.py
+++ b/test/concourse/steps/release_test.py
@@ -146,6 +146,7 @@ class TestGitHubReleaseStep:
             ),
             repo_dir=str(tmp_path),
             release_version='1.0.0',
+            component_name='github.test/test/component',
             tag_helper_return_value=False,
         ):
             # Create a github_helper mock that always reports a tag as existing/not existing,
@@ -156,6 +157,7 @@ class TestGitHubReleaseStep:
                 githubrepobranch=githubrepobranch,
                 repo_dir=repo_dir,
                 release_version=release_version,
+                component_name=component_name,
             )
         return _examinee
 


### PR DESCRIPTION
Github has a limit of 25.000 characters for release-bodies. Work around that by attaching release-notes as release-asset if they are too long.

n.b.: since release-notes are computed from scratch every time they are needed, any component that is downstream will also have release-notes that are too long (and thus are abbreviated here).

Does not affect release-notes posted to Slack.
