### PR TITLE
Rework cc client factory

### DIFF
--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -22,25 +22,6 @@ import model.concourse
 import ensure
 
 
-@functools.lru_cache()
-@ensure.ensure_annotations
-def client_from_cfg_name(
-    concourse_cfg_name: str,
-    team_name: str
-):
-    cfg_factory = ci.util.ctx().cfg_factory()
-
-    cc_cfg = cfg_factory.concourse(concourse_cfg_name)
-    uam_cfg = cfg_factory.concourse_uam(cc_cfg.concourse_uam_config())
-
-    return concourse.client.from_cfg(
-        concourse_cfg=cc_cfg,
-        concourse_uam_cfg=uam_cfg,
-        team_name=team_name,
-        verify_ssl=True,
-    )
-
-
 def lookup_cc_team_cfg(cfg_set, team_name) -> model.concourse.ConcourseTeamConfig:
     for cc_uam in cfg_set._cfg_elements('concourse_uam'):
         if cc_uam.team_name() == team_name:

--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -80,6 +80,7 @@ def client_from_cfg(
     )
 
 
+@functools.cache
 def client_from_env(
     team_name: str=None,
 ) -> concourse.client.api.ConcourseApiBase:

--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -17,12 +17,13 @@ import functools
 import ci.util
 import concourse.client
 import ctx
+import model.concourse
 
-from ensure import ensure_annotations
+import ensure
 
 
 @functools.lru_cache()
-@ensure_annotations
+@ensure.ensure_annotations
 def client_from_cfg_name(
     concourse_cfg_name: str,
     team_name: str
@@ -40,10 +41,68 @@ def client_from_cfg_name(
     )
 
 
+def lookup_cc_team_cfg(cfg_set, team_name) -> model.concourse.ConcourseTeamConfig:
+    for cc_uam in cfg_set._cfg_elements('concourse_uam'):
+        if cc_uam.team_name() == team_name:
+            return cc_uam
+
+    raise RuntimeError(f'No concourse uam for team name {team_name} found')
+
+
+@ensure.ensure_annotations
+def client_from_parameters(
+    base_url: str,
+    password: str,
+    team_name: str,
+    username: str,
+    verify_ssl: bool = True,
+    concourse_api_version=None,
+) -> concourse.client.api.ConcourseApiBase:
+    """
+    returns a concourse-client w/ the credentials valid for the current execution environment.
+    The returned client is authorised to perform operations in the same concourse-team as the
+    credentials provided calling this function.
+    """
+
+    concourse_api = concourse.client.api.ConcourseApiFactory.create_api(
+        base_url=base_url,
+        team_name=team_name,
+        verify_ssl=verify_ssl,
+        concourse_api_version=concourse_api_version,
+    )
+
+    concourse_api.login(
+        username=username,
+        passwd=password,
+    )
+    return concourse_api
+
+
+@functools.cache
+def client_from_cfg(
+    cfg_set,
+    team_name: str,
+) -> concourse.client.api.ConcourseApiBase:
+    """
+        returns a concourse-client w/ the credentials valid for the current execution environment.
+        The returned client is authorised to perform operations in the same concourse-team as the
+        service user of the team calling this function.
+    """
+    concourse_team_config = lookup_cc_team_cfg(cfg_set=cfg_set, team_name=team_name)
+    concourse_endpoint = cfg_set.concourse_endpoint(concourse_team_config.concourse_endpoint_name())
+
+    return client_from_parameters(
+        base_url=concourse_endpoint.base_url(),
+        password=concourse_team_config.password(),
+        team_name=team_name,
+        username=concourse_team_config.username(),
+    )
+
+
 def client_from_env(
     team_name: str=None,
-):
-    '''
+) -> concourse.client.api.ConcourseApiBase:
+    """
     returns a concourse-client w/ the credentials valid for the current execution environment.
     Note that this function must only be called if running in a "central" cicd-job.
     The returned client is authorised to perform operations in the same concourse-team as the
@@ -51,15 +110,18 @@ def client_from_env(
 
     if the (optional) team_name is specified, the returned client is not guaranteed to have the
     required authorisation.
-    '''
+    """
     cfg_set = ctx.cfg_set()
-    cc_cfg = cfg_set.concourse()
-    cc_uam = cfg_set.concourse_uam(cc_cfg.concourse_uam_config())
+
     if not team_name:
         team_name = ci.util.check_env('CONCOURSE_CURRENT_TEAM')
 
-    return concourse.client.from_cfg(
-        concourse_cfg=cc_cfg,
-        concourse_uam_cfg=cc_uam,
+    concourse_team_config = lookup_cc_team_cfg(cfg_set=cfg_set, team_name=team_name)
+    concourse_endpoint = cfg_set.concourse_endpoint(concourse_team_config.concourse_endpoint_name())
+
+    return client_from_parameters(
+        base_url=concourse_endpoint.base_url(),
+        password=concourse_team_config.password(),
         team_name=team_name,
+        username=concourse_team_config.username(),
     )

--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -16,6 +16,7 @@ import functools
 
 import ci.util
 import concourse.client
+import concourse.client.api
 import ctx
 import model.concourse
 

--- a/cli/gardener_ci/_concourse.py
+++ b/cli/gardener_ci/_concourse.py
@@ -15,12 +15,11 @@
 
 import os
 
-
+import ccc.concourse
 from ci.util import (
     ctx,
     CliHints,
 )
-from concourse import client
 from concourse.util import sync_org_webhooks
 from concourse.enumerator import (
     DefinitionDescriptorPreprocessor,
@@ -179,14 +178,12 @@ def trigger_resource_check(
     '''
     cfg_factory = ctx().cfg_factory()
     cfg_set = cfg_factory.cfg_set(cfg_name)
-    concourse_cfg = cfg_set.concourse()
-    concourse_uam = cfg_set.concourse_uam(concourse_cfg.concourse_uam_cfg())
 
-    api = client.from_cfg(
-        concourse_cfg=concourse_cfg,
-        concourse_uam_cfg=concourse_uam,
+    api = ccc.concourse.client_from_cfg(
+        cfg_set=cfg_set,
         team_name=team_name,
     )
+
     api.trigger_resource_check(
         pipeline_name=pipeline_name,
         resource_name=resource_name,

--- a/concourse/client/api.py
+++ b/concourse/client/api.py
@@ -64,7 +64,7 @@ class ConcourseApiFactory:
     def create_api(
         base_url: str,
         team_name: str,
-        verify_ssl: str,
+        verify_ssl: bool,
         concourse_api_version: latest_concourse_api_version,
     ) -> 'ConcourseApiBase':
         # disable logging output for now (breaks template in lss)

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -29,6 +29,7 @@ from concourse.enumerator import (
     GithubOrganisationDefinitionEnumerator,
 )
 
+import ccc.concourse
 import ccc.github
 import concourse.client
 import concourse.client.model
@@ -258,12 +259,8 @@ class ConcourseDeployer(DefinitionDeployer):
         pipeline_definition = definition_descriptor.pipeline
         pipeline_name = definition_descriptor.pipeline_name
         try:
-            concourse_cfg = definition_descriptor.concourse_target_cfg
-            concourse_uam_cfg = self.cfg_set.concourse_uam(concourse_cfg.concourse_uam_config())
-
-            api = concourse.client.from_cfg(
-                concourse_cfg=concourse_cfg,
-                concourse_uam_cfg=concourse_uam_cfg,
+            api = ccc.concourse.client_from_cfg(
+                cfg_set=self.cfg_set,
                 team_name=definition_descriptor.concourse_target_team,
             )
             response = api.set_pipeline(
@@ -347,16 +344,14 @@ class ReplicationResultProcessor:
 
         for concourse_target_key, concourse_results in concourse_target_results.items():
             # TODO: implement eq for concourse_cfg
-            concourse_cfg, concourse_team = next(iter(
+            _, concourse_team = next(iter(
                 concourse_results)).definition_descriptor.concourse_target()
-            concourse_uam_cfg = self._cfg_set.concourse_uam(concourse_cfg.concourse_uam_cfg())
 
-            concourse_results = concourse_target_results[concourse_target_key]
-            concourse_api = concourse.client.from_cfg(
-                concourse_cfg=concourse_cfg,
-                concourse_uam_cfg=concourse_uam_cfg,
+            concourse_api = ccc.concourse.client_from_cfg(
+                cfg_set=self._cfg_set,
                 team_name=concourse_team,
             )
+            concourse_results = concourse_target_results[concourse_target_key]
 
             # find pipelines to remove
             if self.remove_pipelines:

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -46,8 +46,8 @@ import os
 
 import gci.componentmodel as cm
 
+import ccc.concourse
 import ccc.github
-import concourse.client
 import cnudie.retrieve
 import ci.util
 import ci.log
@@ -79,13 +79,9 @@ if meta_build_job_name != env_build_job_name:
         f'Job name in META resource: {meta_build_job_name}'
     )
 
-cc_cfg = cfg_set.concourse()
-cc_uam = cfg_set.concourse_uam(cc_cfg.concourse_uam_cfg())
-
-concourse_api = concourse.client.from_cfg(
-  concourse_cfg=cc_cfg,
-  concourse_uam_cfg=cc_uam,
-  team_name=meta_vars_dict['build-team-name'],
+concourse_api = ccc.concourse.client_from_cfg(
+    cfg_set=cfg_set,
+    team_name=meta_vars_dict['build-team-name'],
 )
 ## TODO: Replace with MAIN_REPO_DIR once it is available in synthetic steps
 path_to_main_repository = "${job_variant.main_repository().resource_name()}"

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -7,6 +7,7 @@ import concourse.client
 import os
 import traceback
 
+import ccc.concourse
 import ci.util
 import mailutil
 
@@ -43,13 +44,9 @@ def job_url(v):
 
 
 def determine_previous_build_status(v, cfg_set):
-    cc_cfg = cfg_set.concourse()
-    cc_uam = cfg_set.concourse_uam(cc_cfg.concourse_uam_cfg())
-
-    concourse_client = concourse.client.from_cfg(
-        concourse_cfg=cc_cfg,
-        concourse_uam_cfg=cc_uam,
-        team_name=v['build-team-name']
+    concourse_client = ccc.concourse.client_from_cfg(
+        cfg_set=cfg_set,
+        team_name=v['build-team-name'],
     )
     try:
         build_number = int(float(v['build-name']))

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -22,6 +22,7 @@ import tabulate
 
 import gci.componentmodel as cm
 
+import ccc.concourse
 import concourse.util
 import ctx
 import mail.model
@@ -440,14 +441,9 @@ def print_protecode_info_table(
 
 
 def retrieve_buildlog(uuid: str):
-    concourse_cfg = concourse.util._current_concourse_config()
-    uam_cfg_name = concourse_cfg.concourse_uam_cfg()
-    concourse_uam_cfg = ctx.cfg_factory().concourse_uam(uam_cfg_name)
-
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    client = concourse.client.from_cfg(
-        concourse_cfg=concourse_cfg,
-        concourse_uam_cfg=concourse_uam_cfg,
+    client = ccc.concourse.client_from_cfg(
+        cfg_set=ctx.cfg_factory(),
         team_name=pipeline_metadata.team_name,
     )
     build = concourse.util.find_own_running_build()

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -24,6 +24,7 @@ import traceback
 
 import requests
 
+import ccc.concourse
 import ccc.elasticsearch
 import ccc.github
 import ccc.secrets_server
@@ -81,12 +82,10 @@ class GithubWebhookDispatcher:
     def concourse_clients(self):
         for concourse_config_name in self.whd_cfg.concourse_config_names():
             concourse_cfg = self.cfg_factory.concourse(concourse_config_name)
-            concourse_uam_cfg = self.cfg_factory.concourse_uam(concourse_cfg.concourse_uam_config())
             job_mapping_set = self.cfg_factory.job_mapping(concourse_cfg.job_mapping_cfg_name())
             for job_mapping in job_mapping_set.job_mappings().values():
-                yield concourse.client.from_cfg(
-                    concourse_cfg=concourse_cfg,
-                    concourse_uam_cfg=concourse_uam_cfg,
+                yield ccc.concourse.client_from_cfg(
+                    cfg_set=self.cfg_factory,
                     team_name=job_mapping.team_name(),
                 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
adds new client factory methods for concourse

- [x] ensure ConcourseTeamConfig and ConcourseEndpoint model is present in all secrets
- [ ] ensure to adapt all consumers
- [x] ensure that tm, ls-tools and cc-job image on alpine 3.14 and runc 1.0.0~rc93