### PR TITLE
Add new information to meta-step

### DIFF
--- a/cli/gardener_ci/_concourse.py
+++ b/cli/gardener_ci/_concourse.py
@@ -31,6 +31,7 @@ from concourse.enumerator import (
 from concourse.replicator import (
     FilesystemDeployer,
     PipelineReplicator,
+    RenderOrigin,
     Renderer,
 )
 import concourse.model as ccm
@@ -85,6 +86,7 @@ def render_pipeline(
         template_retriever=template_retriever,
         template_include_dir=template_include_dir,
         cfg_set=cfg_set,
+        render_origin=RenderOrigin.LOCAL,
     )
 
     deployer = FilesystemDeployer(base_dir=out_dir)
@@ -144,6 +146,7 @@ def render_pipelines(
         template_retriever=template_retriever,
         template_include_dir=template_include_dir,
         cfg_set=config_set,
+        render_origin=RenderOrigin.LOCAL,
     )
 
     deployer = FilesystemDeployer(base_dir=out_dir)

--- a/concourse/enumerator.py
+++ b/concourse/enumerator.py
@@ -88,6 +88,7 @@ class DefinitionEnumerator:
         override_definitions={},
         job_mapping: model.concourse.JobMapping = None,
         target_team: str=None,
+        pipeline_definition_committish: str = None,
     ) -> 'DefinitionDescriptor':
         if not target_team:
             target_team = self.job_mapping.team_name()
@@ -103,6 +104,7 @@ class DefinitionEnumerator:
                 override_definitions=[override_definitions.get(name,{}),],
                 secret_cfg=secret_cfg,
                 job_mapping=job_mapping,
+                pipeline_definition_committish=pipeline_definition_committish,
             )
 
 
@@ -285,6 +287,9 @@ class GithubDefinitionEnumeratorBase(DefinitionEnumerator):
                     path='.ci/pipeline_definitions',
                     ref=branch_name
                 )
+                pipeline_definition_committish = repository.ref(
+                    ref=f'heads/{branch_name}'
+                ).object.sha
             except NotFoundError:
                 continue # no pipeline definition for this branch
 
@@ -323,6 +328,7 @@ class GithubDefinitionEnumeratorBase(DefinitionEnumerator):
                 target_team=target_team,
                 secret_cfg=secret_cfg,
                 job_mapping=job_mapping,
+                pipeline_definition_committish=pipeline_definition_committish,
             )
 
 
@@ -459,6 +465,7 @@ class DefinitionDescriptor:
         job_mapping: model.concourse.JobMapping = None,
         override_definitions=[{},],
         exception=None,
+        pipeline_definition_committish: str = None,
     ):
         try:
             self.pipeline_name = not_empty(pipeline_name)
@@ -469,6 +476,7 @@ class DefinitionDescriptor:
             self.override_definitions = not_none(override_definitions)
             self.secret_cfg = secret_cfg
             self.job_mapping = job_mapping
+            self.pipeline_definition_committish = pipeline_definition_committish
         except Exception as e:
             raise ValueError(
                 f'{e=} missing value: {pipeline_name=} {pipeline_definition=} {main_repo=} '

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -182,6 +182,7 @@ class Renderer:
             'job_mapping': definition_descriptor.job_mapping,
             'render_origin': self.render_origin.value,
             'cc_utils_version': _cc_utils_version(),
+            'pipeline_definition_committish ': definition_descriptor.pipeline_definition_committish,
         }
 
         # also pass pipeline name if this was rendered by a replication job. Will be printed

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -100,6 +100,15 @@ def replicate_pipelines(
     return replicator.replicate()
 
 
+@functools.lru_cache
+def _cc_utils_version():
+    try:
+        with open(concourse.paths.last_released_tag_file) as f:
+            return f.read().strip()
+    except:
+        return None
+
+
 class Renderer:
     def __init__(
         self,
@@ -172,6 +181,7 @@ class Renderer:
             'secret_cfg': definition_descriptor.secret_cfg,
             'job_mapping': definition_descriptor.job_mapping,
             'render_origin': self.render_origin.value,
+            'cc_utils_version': _cc_utils_version(),
         }
 
         # also pass pipeline name if this was rendered by a replication job. Will be printed

--- a/concourse/steps/meta.mako
+++ b/concourse/steps/meta.mako
@@ -1,4 +1,4 @@
-<%def name="meta_step(job_step, job_variant, indent)", filter="indent_func(indent),trim">
+<%def name="meta_step(job_step, job_variant, indent, additional_meta_data={})", filter="indent_func(indent),trim">
 <%
 import datetime
 import os
@@ -8,6 +8,7 @@ from concourse.steps import step_lib
 import concourse.paths
 
 extra_attrs = {}
+extra_attrs |= additional_meta_data
 
 if os.path.isdir(os.path.join(concourse.paths.repo_root_dir, '.git')):
     import git

--- a/concourse/steps/meta.py
+++ b/concourse/steps/meta.py
@@ -38,4 +38,4 @@ def export_job_metadata(extra_attrs: dict={}):
     with open(jobmetadata_outfile, 'w') as f:
         json.dump(metadata, f)
 
-    print(json.dumps(metadata))
+    print(json.dumps(metadata, indent=2))

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -21,6 +21,12 @@ background_image = pipeline.get('background_image', 'https://i.imgur.com/raPlg21
 job_mapping = pipeline.get('job_mapping')
 secret_cfg = pipeline.get('secret_cfg')
 
+# fetch metadata and prepare it for the meta-step
+meta_data_dict = {
+  'render origin': pipeline.get('render_origin'),
+}
+if replication_pipeline_name := pipeline.get('replication_pipeline_name'):
+  meta_data_dict['replication pipeline name'] = replication_pipeline_name
 resource_registry = pipeline_definition._resource_registry
 
 github = config_set.github()
@@ -428,7 +434,7 @@ else:
 % elif job_step.name == 'release':
         ${release_step(job_step=job_step, job_variant=job_variant, github_cfg=github, indent=8)}
 % elif job_step.name == 'meta':
-        ${meta_step(job_step=job_step, job_variant=job_variant, indent=8)}
+        ${meta_step(job_step=job_step, job_variant=job_variant, indent=8, additional_meta_data=meta_data_dict)}
 % elif job_step.name == 'rm_pr_label':
         ${rm_pr_label_step(job_step=job_step, job_variant=job_variant, github_cfg=github, indent=8)}
 % elif job_step.name == DEFAULT_COMPONENT_DESCRIPTOR_STEP_NAME:

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -24,6 +24,7 @@ secret_cfg = pipeline.get('secret_cfg')
 # fetch metadata and prepare it for the meta-step
 meta_data_dict = {
   'render origin': pipeline.get('render_origin'),
+  'cc-utils version used for rendering': pipeline.get('cc_utils_version'),
 }
 if replication_pipeline_name := pipeline.get('replication_pipeline_name'):
   meta_data_dict['replication pipeline name'] = replication_pipeline_name

--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -28,6 +28,9 @@ meta_data_dict = {
 }
 if replication_pipeline_name := pipeline.get('replication_pipeline_name'):
   meta_data_dict['replication pipeline name'] = replication_pipeline_name
+if pipeline_definition_committish := pipeline.get('pipeline_definition_committish'):
+  meta_data_dict['pipeline definition committish'] = pipeline_definition_committish
+
 resource_registry = pipeline_definition._resource_registry
 
 github = config_set.github()

--- a/whd/pipelines.py
+++ b/whd/pipelines.py
@@ -40,6 +40,7 @@ def update_repository_pipelines(
         template_retriever=template_retriever,
         template_include_dir=whd_cfg.pipeline_include_path(),
         cfg_set=cfg_set,
+        render_origin=concourse.replicator.RenderOrigin.WEBHOOK_DISPATCHER,
     )
     deployer = concourse.replicator.ConcourseDeployer(
         cfg_set=cfg_set,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds additional information that should help debugging to the meta-step. Example :
```
{
  "uuid": "f0d9b165-d707-44a9-ad4c-6ab018f83142",
  "render origin": "local", # possible other values: webhook dispatcher, pipeline replication
  "cc-utils version used for rendering": "1.1425.0",
  "pipeline commit sha": "d854c83d5dd7f7ea0b54e925e65722b528d6111b",
  "cc-utils-version": "75342bd606da0714dce5ca2856afb3e2513831f3",
  "replication pipeline name": __foo__, # only shows up for centrally replicated pipelines
  "render-timestamp": "2021-08-31T13:39:03.959443"
}
```