### PR TITLE
Do not publish snapshot descriptors for release jobs

### DIFF
--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -229,6 +229,7 @@ elif have_cd:
 elif have_ctf:
   logger.info(f'found ctf-archive at {ctf_out_path=}')
 
+% if not job_variant.has_trait('release'):
 if snapshot_ctx_repository_base_url:
   if have_cd:
     snapshot_descriptor = cm.ComponentDescriptor.from_dict(
@@ -259,7 +260,7 @@ if snapshot_ctx_repository_base_url:
       check=True,
       env=subproc_env,
     )
-
+% endif
 if have_ctf:
   logger.info(f'processed ctf-archive at {ctf_out_path=} - exiting')
   # XXX TODO: also calculate bom-diff!

--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -225,9 +225,9 @@ elif have_cd:
   descriptor_v2 = cm.ComponentDescriptor.from_dict(
     ci.util.parse_yaml_file(v2_outfile)
   )
-  print(f'found component-descriptor (v2) at {v2_outfile=}')
+  logger.info(f'found component-descriptor (v2) at {v2_outfile=}')
 elif have_ctf:
-  print(f'found ctf-archive at {ctf_out_path=}')
+  logger.info(f'found ctf-archive at {ctf_out_path=}')
 
 if snapshot_ctx_repository_base_url:
   if have_cd:
@@ -261,7 +261,7 @@ if snapshot_ctx_repository_base_url:
     )
 
 if have_ctf:
-  print(f'processed ctf-archive at {ctf_out_path=} - exiting')
+  logger.info(f'processed ctf-archive at {ctf_out_path=} - exiting')
   # XXX TODO: also calculate bom-diff!
   exit(0)
 

--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -226,7 +226,11 @@ elif have_cd:
     ci.util.parse_yaml_file(v2_outfile)
   )
   print(f'found component-descriptor (v2) at {v2_outfile=}')
-  if snapshot_ctx_repository_base_url:
+elif have_ctf:
+  print(f'found ctf-archive at {ctf_out_path=}')
+
+if snapshot_ctx_repository_base_url:
+  if have_cd:
     snapshot_descriptor = cm.ComponentDescriptor.from_dict(
       ci.util.parse_yaml_file(v2_outfile)
     )
@@ -240,9 +244,7 @@ elif have_cd:
     product.v2.upload_component_descriptor_v2_to_oci_registry(
       component_descriptor_v2=snapshot_descriptor,
     )
-
-elif have_ctf:
-  if snapshot_ctx_repository_base_url:
+  elif have_ctf:
     subprocess_args = [
       'component-cli',
       'ctf',
@@ -257,9 +259,10 @@ elif have_ctf:
       check=True,
       env=subproc_env,
     )
-    print(f'processed ctf-archive at {ctf_out_path=} - exiting')
-    # XXX TODO: also calculate bom-diff!
 
+if have_ctf:
+  print(f'processed ctf-archive at {ctf_out_path=} - exiting')
+  # XXX TODO: also calculate bom-diff!
   exit(0)
 
 # determine "bom-diff" (changed component references)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents release jobs from publishing snapshot component descriptors. These snapshot descriptors could sometimes be published a long time ahead of the actual release, which causes problems with our release-note transport downstream.
Since we configured all our pipelines to publish snapshot descriptors into the same repository as their release descriptors there should be no noticeable change in behaviour for most (if not all) of our components. Components with custom snapshot-repos, however, will not have their release descriptors published to the snapshot-repo - this will be fixed at a future point in time.

**Special notes for your reviewer**:
Local testing was successful, will be merged on Monday
