### PR TITLE
Allow google-api-core, google-auth < 3

### DIFF
--- a/requirements.gardenlinux.txt
+++ b/requirements.gardenlinux.txt
@@ -6,7 +6,7 @@ azure-mgmt-storage~=18.0.0
 azure-storage-blob<13
 boto3
 google-api-python-client<3
-google-auth<2
+google-auth<3
 google-cloud-storage<2
 msal<2
 msrestazure~=0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ gardener-component-model==v0.0.56
 gardener-oci
 github3.py<3.0.0
 google-crc32c>1.1.4
-google-api-core<2
+google-api-core<3
 google-api-python-client<3
-google-auth<2
+google-auth<3
 google-cloud-storage<2
 html2text
 jira


### PR DESCRIPTION
**What this PR does / why we need it**:

`google-auth` and `google-api-core` recently published 2.0.0 releases which removed support for Python 2.7. Both packages now requires Python >=3.6. No other breaking changes were made. You can see the full list of changes for [google-auth](https://github.com/googleapis/google-auth-library-python/commit/560cf1ed02a900436c5d9e0a0fb3f94b5fd98c55) and [google-api-core](https://github.com/googleapis/python-api-core/commit/a30f004e74f709d46e905dd819c71f43354e9ac9).

I am opening PRs to expand google-auth version ranges for packages that meet either of the following criteria:
* Package has >10,000 monthly downloads as of June 2021
* Package is owned by a Google team

`google-auth` and `google-api-core` is a dependency of many different libraries that interact with Google APIs. Increasing the time and number of packages with compatible pins on `google-auth` lowers the chance end developers who use multiple libraries will see dependency conflicts. 

If possible, please do not require `google-auth>2.0.0` until this issue is resolved
https://github.com/googleapis/google-cloud-python/issues/10566, as that will further reduce the likelihood of diamond dependency conflicts.

Googlers, see [this doc](https://docs.google.com/document/d/1euAvUsia_4zf98lNvpwA3K0o2b4y5Xr9xAkyzCnIMzQ/edit) for more information.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Allow google-api-core, google-auth < 3
```
