### PR TITLE
Surpress trace if `find_own_running_build()` fails due to FileNotFound

### DIFF
--- a/ccc/oci.py
+++ b/ccc/oci.py
@@ -91,8 +91,9 @@ class _OciRequestHandler(logging.Handler):
                     'stacktrace': traceback.format_stack(),
                 }
             )
-        except:
-            logger.warning(traceback.format_exc())
+        except Exception as e:
+            if not isinstance(e, FileNotFoundError):
+                logger.warning(traceback.format_exc())
             logger.warning('could not send oci request log to elastic search')
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On a local machine, there is no `meta_info` file indicating the job's UUID.
Therefore, the `find_own_running_build()` function crashes and prints a trace everytime a document would be written to `Elasticsearch`.
This behaviour influences to log quality on a local machine drastically.

With this PR, the raised `Exception` is inspected and in case of `FileNotFound`, the trace is surpressed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
