### PR TITLE
Update compliance scan model

### DIFF
--- a/dso/deliverydb/model.py
+++ b/dso/deliverydb/model.py
@@ -14,6 +14,6 @@ class Scan(Base):
     # combination of hstore and mutabledict to allow in-place changes to the dict.
     # https://docs.sqlalchemy.org/en/14/dialects/
     # postgresql.html#sqlalchemy.dialects.postgresql.HSTORE
-    id = Column(MutableDict.as_mutable(JSONB), nullable=True, default=dict)
+    artifact = Column(MutableDict.as_mutable(JSONB), nullable=True, default=dict)
     meta = Column(MutableDict.as_mutable(JSONB), nullable=True, default=dict)
     data = Column(MutableDict.as_mutable(JSONB), nullable=True, default=dict)

--- a/dso/model.py
+++ b/dso/model.py
@@ -1,6 +1,5 @@
 import dataclasses
 import datetime
-from enum import Enum
 import typing
 
 import gci.componentmodel as cm
@@ -21,7 +20,7 @@ class ScanArtifact:
     label: dso.labels.ScanningHint
 
 
-class Datasource(Enum):
+class Datasource:
     WHITESOURCE = 'whitesource'
     PROTECODE = 'protecode'
     CHECKMARX = 'checkmarx'
@@ -29,21 +28,24 @@ class Datasource(Enum):
 
 
 @dataclasses.dataclass
-class ComplianceIssueId:
+class ArtifactReference:
     componentName: str
     componentVersion: str
-    artifact: cm.Artifact
+    artifact: typing.Union[
+        cm.Resource,
+        cm.ComponentSource,
+    ]
 
 
 @dataclasses.dataclass
-class ComplianceIssueMeta:
-    datasource: Datasource
-    creationDate: datetime.datetime
+class ComplianceIssueMetadata:
+    datasource: str
+    creationDate: typing.Union[datetime.datetime, str]
     uuid: str
 
 
 @dataclasses.dataclass
 class ComplianceIssue:
-    id: ComplianceIssueId
-    meta: ComplianceIssueMeta
+    artifact: ArtifactReference
+    meta: ComplianceIssueMetadata
     data: dict


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the compliance scan model in the following matter.

- `Datasources` does not inherit `enum.Enum` anymore
- `ComplianceIssueId` is now named `ArtifactReference`
- `ComplianceIssueMeta` is now named `ComplianceIssueMetadata`
- The `insert` function to write scans to the deliverydb is not based on a `ComplianceIssue` anymore, instead it takes the three raw dicts, `artifact`, `meta`, `data`.
- The `UploadResult` from the Protecode / BlackDuck scans are now parsed to `ComplianceIssue`'s utilising the custom dict factory introduced in https://github.com/gardener/cc-utils/commit/f3518ddbcbd17a4daeafdbd613297c23e031c241.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
