### PR TITLE
Add `active_db_cfg_name` to delivery model

### DIFF
--- a/model/delivery.py
+++ b/model/delivery.py
@@ -38,6 +38,9 @@ class DeliveryConfig(NamedModelElement):
     def deployment_name(self):
         return self.raw.get('deployment_name', 'delivery-dashboard')
 
+    def active_db_cfg_name(self):
+        return self.raw.get('active_db_cfg_name')
+
     def mongodb_config(self):
         if not self.raw.get('mongodb'):
             return None
@@ -48,6 +51,7 @@ class DeliveryConfig(NamedModelElement):
         yield from [
             'mongodb',
             'deployment_name',
+            'active_db_cfg_name',
         ]
 
     def _required_attributes(self):


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `active_db_cfg_name` to the delivery model class, as an optional attribute.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
