### PR TITLE
handle unresolvable component-references as an error

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -693,11 +693,10 @@ class UploadComponentDescriptorStep(TransactionalStep):
             try:
                 resolve_dependencies(component=component)
             except oci.model.OciImageNotFoundException as e:
-                # XXX: escalate to error ASAP
-                logger.warning(
-                    'Error when retrieving the Component Descriptor of a component referenced in '
-                    f"this component's Component Descriptor: {e}"
+                logger.error(
+                    f'{component.name=} {component.version=} has a dangling component-reference'
                 )
+                raise e
 
             component_descriptor = component_id_to_cd[component.identity()]
 


### PR DESCRIPTION
as of https://github.com/gardener/cc-utils/commit/80466eca3bfcca6b4152951b84a8d24b01294257 , multiple component-descriptors from CTF archives are published in topologically-sorted order. Thus, unresolvable component-references should (again) be handled as an error. 