### PR TITLE
switch default oci-image-builder to docker

### DIFF
--- a/concourse/model/traits/publish.py
+++ b/concourse/model/traits/publish.py
@@ -212,7 +212,7 @@ ATTRIBUTES = (
         name='oci-builder',
         doc='specifies the container image builder to use',
         type=OciBuilder,
-        default=OciBuilder.KANIKO,
+        default=OciBuilder.DOCKER,
     ),
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `docker` as OCI Image builder by default. This will affect all pipelines with an OCI-Image-Builder (`publish` trait) that do not explicitly configure the builder to use.

I believe this change to be beneficial for two reasons:

1. we saw several issues w/ kaniko in the past (also, we use it in an unsupported fashion)
2. this more closely reflects most (all?) developers' local dev setups