### PR TITLE
Fix erroneous webhook-urls being applied

### DIFF
--- a/concourse/util.py
+++ b/concourse/util.py
@@ -109,9 +109,11 @@ def _enumerate_required_org_webhooks(
         job_mapping_set = cfg_factory.job_mapping(concourse_cfg.job_mapping_cfg_name())
 
         for github_orgname, github_cfg_name in _enumerate_github_org_configs(job_mapping_set):
-            github_api = ccc.github.github_api(
-                github_cfg=cfg_factory.github(github_cfg_name),
-            )
+            github_cfg = cfg_factory.github(github_cfg_name)
+            github_api = ccc.github.github_api(github_cfg=github_cfg)
+
+            if not concourse_cfg.is_accessible_from(github_cfg.http_url()):
+                continue
 
             webhook_url = create_url_from_attributes(
                 netloc=whd_deployment_cfg.external_url(),

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -114,6 +114,19 @@ class ConcourseConfig(NamedModelElement):
     def oauth_config_name(self):
         return self.raw['oauth_config_name']
 
+    def is_accessible_from(self, url: str) -> bool:
+        if not (domain_rules := self.raw.get('domain_rules', [])):
+            return True
+
+        for dr in domain_rules:
+            if (
+                re.compile(dr['domain_regex']).fullmatch(url)
+                and not dr['accessible_from']
+            ):
+                return False
+
+        return True
+
     def _required_attributes(self):
         return [
             'externalUrl',
@@ -134,6 +147,7 @@ class ConcourseConfig(NamedModelElement):
             'clamav_config',
             'concourse_version', # TODO: Remove
             'deploy_storage_class',
+            'domain_rules',
             'github_enterprise_host',
             'ingress_host', # TODO: Remove
             'proxy',


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous logic did not take into account that we have job-mappings configured for our internal concourse that reference orgs in github.com. These job-mappings cause the previous logic to set an unreachable webhook-url on the orgs on github.com. Since the order in which we set webhooks is not deterministic, this may result in webhook-deliveries being lost if such a faulty update is performed after the correct one was set.

This change introduces a heuristic to determine undeliverable webhook- urls and avoids setting them at all.
