### PR TITLE
Add connection pool client for DeliveryDB

### DIFF
--- a/ccc/deliverydb.py
+++ b/ccc/deliverydb.py
@@ -5,7 +5,7 @@ import deliverydb.db
 import model.compliancedb
 
 
-def sqlalchemy_with_db_cfg(
+def sqlalchemy_from_db_cfg(
     db_cfg: model.compliancedb.ComplianceDbConfig,
     overwrite_hostname: str = None,
     overwrite_username: str = None,
@@ -26,7 +26,7 @@ def sqlalchemy_with_db_cfg(
     )
 
 
-def psycopg_connection_with_db_cfg(
+def psycopg_connection_from_db_cfg(
     db_cfg: model.compliancedb.ComplianceDbConfig,
     overwrite_hostname: str = None,
     overwrite_username: str = None,
@@ -47,7 +47,7 @@ def psycopg_connection_with_db_cfg(
     )
 
 
-def psycopg_connection_pool_with_db_cfg(
+def psycopg_connection_pool_from_db_cfg(
     db_cfg: model.compliancedb.ComplianceDbConfig,
     overwrite_hostname: str = None,
     overwrite_username: str = None,

--- a/ccc/deliverydb.py
+++ b/ccc/deliverydb.py
@@ -1,4 +1,5 @@
 import psycopg
+import psycopg_pool
 
 import deliverydb.db
 import model.compliancedb
@@ -25,7 +26,7 @@ def sqlalchemy_with_db_cfg(
     )
 
 
-def psycopg_with_db_cfg(
+def psycopg_connection_with_db_cfg(
     db_cfg: model.compliancedb.ComplianceDbConfig,
     overwrite_hostname: str = None,
     overwrite_username: str = None,
@@ -43,6 +44,39 @@ def psycopg_with_db_cfg(
 
     return psycopg.connect(
         conninfo=db_url,
+    )
+
+
+def psycopg_connection_pool_with_db_cfg(
+    db_cfg: model.compliancedb.ComplianceDbConfig,
+    overwrite_hostname: str = None,
+    overwrite_username: str = None,
+    overwrite_password: str = None,
+    overwrite_port: int = None,
+    min_size: int = 1,
+    max_size: int = 4,
+) -> psycopg_pool.ConnectionPool:
+    """
+    Please define pool size with cautious.
+    Rule of thumb for pool size is:
+    pool_size = ((core_count * 2) + effective_spindle_count)
+
+    Detailed analysis about pool sizing:
+    https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+    """
+
+    db_url = database_connection_url_from_cfg(
+        db_cfg=db_cfg,
+        overwrite_hostname=overwrite_hostname,
+        overwrite_username=overwrite_username,
+        overwrite_password=overwrite_password,
+        overwrite_port=overwrite_port,
+    )
+
+    return psycopg_pool.ConnectionPool(
+        conninfo=db_url,
+        min_size=min_size,
+        max_size=max_size,
     )
 
 

--- a/requirements.dso.txt
+++ b/requirements.dso.txt
@@ -1,6 +1,6 @@
-psycopg[binary]
-psycopg2-binary
+psycopg[binary, pool]
 # psycopg[binary] is version 3, used for direct db connection
+psycopg2-binary
 # psycopg2-binary is version 2, used by sqlalchemy
 sqlalchemy>1.4.0
 whitesource_common


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a function to retrieve not only a psycopg deliverydb connection, but a connection pool.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
