### PR TITLE
Drop basic_auth support for Protecode

### DIFF
--- a/model/protecode.py
+++ b/model/protecode.py
@@ -36,14 +36,7 @@ class ProtecodeConfig(NamedModelElement):
         return ProtecodeAuthScheme(self.raw['credentials'].get('auth_scheme', 'basic_auth'))
 
     def credentials(self) -> typing.Union[BasicCredentials, TokenCredentials]:
-        if (auth_scheme := self.auth_scheme()) is ProtecodeAuthScheme.BASIC_AUTH:
-            return BasicCredentials(
-                raw_dict={
-                    'password': self.raw['credentials']['password'],
-                    'username': self.raw['credentials']['username']
-                }
-            )
-        elif auth_scheme is ProtecodeAuthScheme.BEARER_TOKEN:
+        if (auth_scheme := self.auth_scheme()) is ProtecodeAuthScheme.BEARER_TOKEN:
             return TokenCredentials(
                 raw_dict={
                     'token': self.raw['credentials']['token'],


### PR DESCRIPTION
**What this PR does / why we need it**:
We do not support Protecode `basic_auth` anymore.
Therefore, this PR removes `basic_auth` specifics and raise `NotImplementedError` in case of `basic_auth`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
