### PR TITLE
Refine notification handling

### DIFF
--- a/concourse/factory.py
+++ b/concourse/factory.py
@@ -4,10 +4,8 @@ import graphlib
 
 from ci.util import merge_dicts, not_none
 from model.base import ModelValidationError
-from concourse.model.step import (
-    PipelineStep,
-    StepNotificationPolicy,
-)
+from concourse.model.step import PipelineStep
+
 from concourse.model.base import (
         normalise_to_dict,
         ScriptType,
@@ -219,7 +217,6 @@ class DefinitionFactory:
         return PipelineStep(
             name=name,
             is_synthetic=False,
-            notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
             raw_dict=step_dict,
             script_type=ScriptType.BOURNE_SHELL,
         )

--- a/concourse/model/step.py
+++ b/concourse/model/step.py
@@ -228,7 +228,12 @@ def attrs(pipeline_step):
 
 class StepNotificationPolicy(enum.Enum):
     NO_NOTIFICATION = enum.auto()
-    NOTIFY_PULL_REQUESTS = enum.auto()
+    ALWAYS = enum.auto()
+
+
+class PullRequestNotificationPolicy(enum.Enum):
+    NO_NOTIFICATION = enum.auto()
+    ALWAYS = enum.auto()
 
 
 class TaskHook(enum.Enum):
@@ -241,8 +246,11 @@ class PipelineStep(ModelBase):
         self,
         name: str,
         is_synthetic: bool,
-        notification_policy: StepNotificationPolicy,
-        script_type,
+        script_type: ScriptType,
+        notification_policy: StepNotificationPolicy = StepNotificationPolicy.ALWAYS,
+        pull_request_notification_policy: PullRequestNotificationPolicy = (
+            PullRequestNotificationPolicy.ALWAYS
+        ),
         extra_args=None,
         injecting_trait_name=None,
         *args,
@@ -255,6 +263,7 @@ class PipelineStep(ModelBase):
         self._inputs_dict = {}
         self._publish_to_dict = {}
         self._notification_policy = notification_policy
+        self._pull_request_notification_policy = pull_request_notification_policy
         self._notifications_cfg = None
         self._injecting_trait_name = injecting_trait_name
         self._extra_args = extra_args
@@ -445,6 +454,9 @@ class PipelineStep(ModelBase):
 
     def _on_abort(self):
         return self.raw.get('on_abort', None)
+
+    def pull_request_notification_policy(self):
+        return self._pull_request_notification_policy
 
     def validate(self):
         super().validate()

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -27,6 +27,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
+    PullRequestNotificationPolicy,
     StepNotificationPolicy,
 )
 from concourse.model.base import (
@@ -238,6 +239,7 @@ class ComponentDescriptorTraitTransformer(TraitTransformer):
             raw_dict={},
             is_synthetic=True,
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
         )

--- a/concourse/model/traits/draft_release.py
+++ b/concourse/model/traits/draft_release.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from concourse.model.step import (
     PipelineStep,
+    PullRequestNotificationPolicy,
     StepNotificationPolicy,
 )
 from concourse.model.base import (
@@ -68,6 +69,7 @@ class DraftReleaseTraitTransformer(TraitTransformer):
             raw_dict={},
             is_synthetic=True,
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
         )

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -25,7 +25,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
-    StepNotificationPolicy,
+    PullRequestNotificationPolicy,
 )
 from concourse.model.base import (
     AttributeSpec,
@@ -452,7 +452,7 @@ class ImageScanTraitTransformer(TraitTransformer):
                     name='scan_container_images',
                     raw_dict={},
                     is_synthetic=True,
-                    notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+                    pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
                     injecting_trait_name=self.name,
                     script_type=ScriptType.PYTHON3
             )
@@ -468,7 +468,7 @@ class ImageScanTraitTransformer(TraitTransformer):
                     name='malware-scan',
                     raw_dict={},
                     is_synthetic=True,
-                    notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+                    pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
                     injecting_trait_name=self.name,
                     script_type=ScriptType.PYTHON3
             )
@@ -484,7 +484,7 @@ class ImageScanTraitTransformer(TraitTransformer):
                     name='os-id-scan',
                     raw_dict={},
                     is_synthetic=True,
-                    notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+                    pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
                     injecting_trait_name=self.name,
                     script_type=ScriptType.PYTHON3
             )

--- a/concourse/model/traits/meta.py
+++ b/concourse/model/traits/meta.py
@@ -18,6 +18,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
+    PullRequestNotificationPolicy,
     StepNotificationPolicy,
 )
 from concourse.model.base import (
@@ -39,6 +40,7 @@ class MetaTraitTransformer(TraitTransformer):
             raw_dict={},
             is_synthetic=True,
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
         )

--- a/concourse/model/traits/publish.py
+++ b/concourse/model/traits/publish.py
@@ -30,7 +30,7 @@ from concourse.model.job import (
 from concourse.model.step import (
     PipelineStep,
     PrivilegeMode,
-    StepNotificationPolicy,
+    PullRequestNotificationPolicy,
 )
 from concourse.model.base import (
   AttributeSpec,
@@ -349,7 +349,6 @@ class PublishTraitTransformer(TraitTransformer):
             name='publish',
             raw_dict={},
             is_synthetic=True,
-            notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
             extra_args={
@@ -364,7 +363,7 @@ class PublishTraitTransformer(TraitTransformer):
             name='prepare',
             raw_dict={},
             is_synthetic=True,
-            notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.BOURNE_SHELL,
         )
@@ -396,7 +395,6 @@ class PublishTraitTransformer(TraitTransformer):
                             else PrivilegeMode.UNPRIVILEGED,
                     },
                     is_synthetic=True,
-                    notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
                     injecting_trait_name=self.name,
                     script_type=ScriptType.PYTHON3,
                     extra_args={

--- a/concourse/model/traits/pullrequest.py
+++ b/concourse/model/traits/pullrequest.py
@@ -20,6 +20,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
+    PullRequestNotificationPolicy,
     StepNotificationPolicy,
 )
 from concourse.model.base import (
@@ -105,6 +106,7 @@ class PullRequestTraitTransformer(TraitTransformer):
                 raw_dict={},
                 is_synthetic=True,
                 notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+                pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
                 injecting_trait_name=self.name,
                 script_type=ScriptType.PYTHON3
         )
@@ -129,4 +131,4 @@ class PullRequestTraitTransformer(TraitTransformer):
                     f"'{step_name}' was found in job '{pipeline_args.variant_name}'"
                 )
             step = pipeline_args.step(step_name)
-            step._notification_policy = StepNotificationPolicy.NO_NOTIFICATION
+            step._pull_request_notification_policy = PullRequestNotificationPolicy.NO_NOTIFICATION

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -23,7 +23,7 @@ from concourse.model.job import (
 from concourse.model.step import (
     PipelineStep,
     PrivilegeMode,
-    StepNotificationPolicy,
+    PullRequestNotificationPolicy,
 )
 from concourse.model.base import (
   AttributeSpec,
@@ -289,7 +289,7 @@ class ReleaseTraitTransformer(TraitTransformer):
                 'privilege_mode': privilege_mode,
             },
             is_synthetic=True,
-            notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
         )

--- a/concourse/model/traits/scan_sources.py
+++ b/concourse/model/traits/scan_sources.py
@@ -8,7 +8,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
-    StepNotificationPolicy,
+    PullRequestNotificationPolicy,
 )
 from concourse.model.base import (
     AttributeSpec,
@@ -231,7 +231,7 @@ class SourceScanTraitTransformer(TraitTransformer):
             name='scan_sources',
             raw_dict={},
             is_synthetic=True,
-            notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3
         )

--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -19,7 +19,7 @@ import typing
 from concourse.model.step import (
     PipelineStep,
     PrivilegeMode,
-    StepNotificationPolicy,
+    PullRequestNotificationPolicy,
 )
 from concourse.model.base import (
     AttributeSpec,
@@ -267,7 +267,7 @@ class UpdateComponentDependenciesTraitTransformer(TraitTransformer):
                     'privilege_mode': privilege_mode,
                 },
                 is_synthetic=True,
-                notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+                pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
                 injecting_trait_name=self.name,
                 script_type=ScriptType.PYTHON3
         )

--- a/concourse/model/traits/version.py
+++ b/concourse/model/traits/version.py
@@ -20,6 +20,7 @@ from concourse.model.job import (
 )
 from concourse.model.step import (
     PipelineStep,
+    PullRequestNotificationPolicy,
     StepNotificationPolicy,
 )
 from concourse.model.base import (
@@ -129,6 +130,7 @@ class VersionTraitTransformer(TraitTransformer):
             raw_dict={},
             is_synthetic=True,
             notification_policy=StepNotificationPolicy.NO_NOTIFICATION,
+            pull_request_notification_policy=PullRequestNotificationPolicy.NO_NOTIFICATION,
             injecting_trait_name=self.name,
             script_type=ScriptType.PYTHON3,
             )

--- a/test/concourse/model/job_test.py
+++ b/test/concourse/model/job_test.py
@@ -4,10 +4,7 @@ import unittest
 from concourse.model.base import ScriptType
 from concourse.model.job import JobVariant
 
-from concourse.model.step import (
-    PipelineStep,
-    StepNotificationPolicy,
-)
+from concourse.model.step import PipelineStep
 
 
 class JobVariantTest(unittest.TestCase):
@@ -23,7 +20,6 @@ class JobVariantTest(unittest.TestCase):
         return PipelineStep(
             name=name,
             is_synthetic=is_synthetic,
-            notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
             script_type=ScriptType.BOURNE_SHELL,
             raw_dict=kwargs,
         )

--- a/test/concourse/model/step_test.py
+++ b/test/concourse/model/step_test.py
@@ -18,10 +18,7 @@ import unittest
 import shlex
 
 from concourse.model.base import ScriptType
-from concourse.model.step import (
-    PipelineStep,
-    StepNotificationPolicy,
-)
+from concourse.model.step import PipelineStep
 
 
 class PipelineStepTest(unittest.TestCase):
@@ -29,7 +26,6 @@ class PipelineStepTest(unittest.TestCase):
         return PipelineStep(
             name=name,
             is_synthetic=False,
-            notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
             script_type=ScriptType.BOURNE_SHELL,
             raw_dict=kwargs,
         )

--- a/test/concourse/steps/notification_test.py
+++ b/test/concourse/steps/notification_test.py
@@ -17,10 +17,7 @@ from concourse.model.resources import (
     ResourceIdentifier,
     Resource,
 )
-from concourse.model.step import (
-    PipelineStep,
-    StepNotificationPolicy,
-)
+from concourse.model.step import PipelineStep
 from concourse.steps import notification
 from concourse.model.traits.notifications import (
     NotificationCfgSet,
@@ -40,7 +37,6 @@ class NotificationStepTest(unittest.TestCase):
         self.job_step = PipelineStep(
             name='step1',
             is_synthetic=False,
-            notification_policy=StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
             script_type=ScriptType.BOURNE_SHELL,
             raw_dict={},
         )

--- a/test/concourse/steps/test_utils.py
+++ b/test/concourse/steps/test_utils.py
@@ -27,7 +27,6 @@ def pipeline_step(name):
     return concourse.model.step.PipelineStep(
         name=name,
         is_synthetic=True,
-        notification_policy=concourse.model.step.StepNotificationPolicy.NOTIFY_PULL_REQUESTS,
         script_type=concourse.model.base.ScriptType.PYTHON3,
         raw_dict={}
     )


### PR DESCRIPTION
Split notification handling in two:
- Notifications on GH-PRs
- Our error notifications (i.e. e-mails)
