### PR TITLE
Upload clamav findings to delivery-db

### DIFF
--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -40,6 +40,7 @@ try:
 except:
   pass
 import ccc.clamav
+import ccc.delivery
 import ccc.oci
 import ci.util
 import clamav.cnudie
@@ -76,12 +77,25 @@ findings_count = 0
 have_errors = False
 err_count = 0
 
+if (delivery_client := ccc.delivery.default_client_if_available()):
+  logger.info('uploading results to deliverydb')
+else:
+  logger.warning('not uploading results to deliverydb, client not available')
+
 for result in clamav.cnudie.scan_resources(
   component=component_descriptor,
   oci_client=oci_client,
   clamav_client=clamav_client,
   max_workers=${clam_av.parallel_jobs()},
 ):
+
+  if delivery_client:
+    findings_data = clamav.cnudie.resource_scan_result_to_findings_data(
+        resource_scan_result=result,
+        datasource='clamav-findings',
+    )
+    delivery_client.upload_metadata(data=findings_data)
+
   results.append(result)
   scan_result = result.scan_result
   logger.info(f'{scan_result}')


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uploads clamav findings to delivery-db if a delivery-client is available during the malware_scan step.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
