### PR TITLE
Process config queue

### DIFF
--- a/cfg_mgmt/gcp.py
+++ b/cfg_mgmt/gcp.py
@@ -48,7 +48,6 @@ def delete_service_account_key(
     iam_client: googleapiclient.discovery.Resource,
     service_account_key_name: str,
 ):
-    # TODO: check whether key exists
     iam_client.projects().serviceAccounts().keys().delete(
         name=service_account_key_name,
     ).execute()

--- a/cfg_mgmt/gcp.py
+++ b/cfg_mgmt/gcp.py
@@ -48,6 +48,7 @@ def delete_service_account_key(
     iam_client: googleapiclient.discovery.Resource,
     service_account_key_name: str,
 ):
+    # TODO: check whether key exists
     iam_client.projects().serviceAccounts().keys().delete(
         name=service_account_key_name,
     ).execute()

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -1,6 +1,12 @@
+import dataclasses
 import logging
+import os
 import typing
+import yaml
 
+import traceback
+
+import ccc.gcp
 import cfg_mgmt.gcp as cmg
 import cfg_mgmt.github as cmgh
 import cfg_mgmt.model as cmm
@@ -11,6 +17,90 @@ import oci.model as om
 
 
 logger = logging.getLogger(__name__)
+
+
+def write_config_queue(
+    cfg_queue: typing.Iterable[cmm.CfgQueueEntry],
+    cfg_queue_file_path: str,
+):
+    with open(cfg_queue_file_path, 'w') as f:
+        yaml.dump(
+            {
+                'rotation_queue': [
+                    dataclasses.asdict(cfg_queue_entry)
+                    for cfg_queue_entry in cfg_queue
+                ]
+            },
+            f,
+        )
+
+
+def push_config_queue(
+    git_helper: gitutil.GitHelper,
+    target_ref: str,
+    type_name: str,
+    name: str,
+):
+    git_helper.add_and_commit(
+        message=f'process config queue for {type_name}/{name}',
+    )
+    try:
+        git_helper.push('@', target_ref)
+    except:
+        logger.warning('failed to push processed config queue - reverting')
+        git_helper.repo.git.reset('--hard', '@~')
+
+
+def delete_cfg_element(
+    cfg_dir: str,
+    cfg_queue_entry: cmm.CfgQueueEntry,
+    cfg_fac: model.ConfigFactory,
+    cfg_metadata: cmm.CfgMetadata,
+    git_helper: gitutil.GitHelper,
+    target_ref: str,
+) -> bool:
+    did_remove = False
+    if cfg_queue_entry.target.type == 'container_registry':
+        cfg_element = cfg_fac.container_registry(cfg_queue_entry.target.name)
+        if cfg_element.registry_type() == om.OciRegistryType.GCR:
+            logger.info('deleting old gcr secret')
+            iam_client = ccc.gcp.create_iam_client(
+                cfg_element=cfg_element,
+            )
+            try:
+                cmg.delete_service_account_key(
+                    iam_client=iam_client,
+                    service_account_key_name=cfg_queue_entry.secretId['gcp_secret_key'],
+                    absent_ok=True,
+                )
+                did_remove = True
+            except:
+                logger.warning(f'deleting {cfg_queue_entry.secretId["gcp_secret_key"]} failed')
+                traceback.print_exc()
+        else:
+            logger.warning(
+                f'{cfg_element.registry_type()} is not (yet) supported for automated deletion'
+            )
+    else:
+        logger.warning(f'{cfg_queue_entry.target.type} is not (yet) supported for automated delete')
+
+    if did_remove:
+        new_cfg_queue: typing.List[cmm.CfgQueueEntry] = [
+            entry for entry in cfg_metadata.queue
+            if not entry == cfg_queue_entry
+        ]
+        write_config_queue(
+            cfg_queue=new_cfg_queue,
+            cfg_queue_file_path=os.path.join(cfg_dir, cmm.cfg_queue_fname),
+        )
+        push_config_queue(
+            git_helper=git_helper,
+            target_ref=target_ref,
+            type_name=cfg_element._type_name,
+            name=cfg_element.name()
+        )
+
+    return did_remove
 
 
 def rotate_cfg_element(

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -71,7 +71,6 @@ def delete_cfg_element(
                 cmg.delete_service_account_key(
                     iam_client=iam_client,
                     service_account_key_name=cfg_queue_entry.secretId['gcp_secret_key'],
-                    absent_ok=True,
                 )
                 did_remove = True
             except:

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -35,22 +35,6 @@ def write_config_queue(
         )
 
 
-def push_config_queue(
-    git_helper: gitutil.GitHelper,
-    target_ref: str,
-    type_name: str,
-    name: str,
-):
-    git_helper.add_and_commit(
-        message=f'process config queue for {type_name}/{name}',
-    )
-    try:
-        git_helper.push('@', target_ref)
-    except:
-        logger.warning('failed to push processed config queue - reverting')
-        git_helper.repo.git.reset('--hard', '@~')
-
-
 def delete_cfg_element(
     cfg_dir: str,
     cfg_queue_entry: cmm.CfgQueueEntry,
@@ -92,12 +76,14 @@ def delete_cfg_element(
             cfg_queue=new_cfg_queue,
             cfg_queue_file_path=os.path.join(cfg_dir, cmm.cfg_queue_fname),
         )
-        push_config_queue(
-            git_helper=git_helper,
-            target_ref=target_ref,
-            type_name=cfg_element._type_name,
-            name=cfg_element.name()
+        git_helper.add_and_commit(
+            message=f'process config queue for {cfg_element._type_name}/{cfg_element.name()}',
         )
+        try:
+            git_helper.push('@', target_ref)
+        except:
+            logger.warning('failed to push processed config queue - reverting')
+            git_helper.repo.git.reset('--hard', '@~')
 
     return did_remove
 

--- a/cli/gardener_ci/_cfg_mgmt.py
+++ b/cli/gardener_ci/_cfg_mgmt.py
@@ -86,9 +86,6 @@ def process_config_queue(
         name=name,
     )
 
-    # cfg_queue_entries cannot be select with much comfort as cli argument.
-    # Therefore, as in pipeline case, they are iterated and the first candidate
-    # is processed.
     for cfg_queue_entry in cmu.iter_cfg_queue_entries_to_be_deleted(
         cfg_metadata=cfg_metadata,
         cfg_target=cfg_target,

--- a/cli/gardener_ci/_cfg_mgmt.py
+++ b/cli/gardener_ci/_cfg_mgmt.py
@@ -6,7 +6,9 @@ import cfg_mgmt.reporting as cmr
 import cfg_mgmt.rotate
 import cfg_mgmt.model
 import cfg_mgmt.util as cmu
+import gitutil
 import model
+
 
 __cmd_name__ = 'cfg_mgmt'
 logger = logging.getLogger(__name__)
@@ -45,6 +47,65 @@ def report(
 
     for _ in cmr.create_report(cfg_element_statuses=reports):
         pass
+
+
+def process_config_queue(
+    cfg_dir: str,
+    github_cfg: str, # e.g. github_wdf_sap_corp
+    cfg_repo_path: str, # e.g. kubernetes/cc-config
+    type_name: str=None,
+    name: str=None,
+    tgt_ref: str='refs/heads/master',
+):
+    '''
+    Iterates to be deleted cfg_queue_entries with optional cfg_target filter.
+    Processes very first supported entry and terminates.
+    '''
+
+    # ensure cfg_target filter is correct (None or name and type_name)
+    if not type_name and not name:
+        cfg_target = None
+    elif not type_name or not name:
+        logger.error('when specifying cfg_target filter, both name and type_name must be given')
+        return
+
+    cfg_metadata = cfg_mgmt.model.cfg_metadata_from_cfg_dir(cfg_dir=cfg_dir)
+    cfg_factory = model.ConfigFactory.from_cfg_dir(
+        cfg_dir=cfg_dir,
+        disable_cfg_element_lookup=True,
+    )
+    github_cfg = cfg_factory.github(github_cfg)
+    git_helper = gitutil.GitHelper(
+        repo=cfg_dir,
+        github_cfg=github_cfg,
+        github_repo_path=cfg_repo_path,
+    )
+
+    cfg_target = cfg_mgmt.model.CfgTarget(
+        type=type_name,
+        name=name,
+    )
+
+    # cfg_queue_entries cannot be select with much comfort as cli argument.
+    # Therefore, as in pipeline case, they are iterated and the first candidate
+    # is processed.
+    for cfg_queue_entry in cmu.iter_cfg_queue_entries_to_be_deleted(
+        cfg_metadata=cfg_metadata,
+        cfg_target=cfg_target,
+    ):
+        if not cfg_mgmt.rotate.delete_cfg_element(
+            cfg_dir=cfg_dir,
+            cfg_queue_entry=cfg_queue_entry,
+            cfg_fac=cfg_factory,
+            cfg_metadata=cfg_metadata,
+            git_helper=git_helper,
+            target_ref=tgt_ref,
+        ):
+            continue
+
+        # stop after first successful rotation (avoid causing too much trouble at one time
+        return
+    logger.info('no to be deleted config queue entry found')
 
 
 def rotate(

--- a/concourse/steps/replicate_secrets.mako
+++ b/concourse/steps/replicate_secrets.mako
@@ -120,17 +120,12 @@ else:
     logger.warning('not writing cfg status to elasticsearch, no client available')
 
 % if do_rotate_secrets:
-try:
-  process_config_queue(
-    cfg_dir=cfg_dir,
-    target_ref=f'refs/heads/{secrets_repo_default_branch}',
-    repo_url=secrets_repo_url,
-    github_repo_path=f'{secrets_repo_org}/{secrets_repo_repo}',
-  )
-except:
-  ## we are paranoid: let us not break replication upon rotation-error for now
-  import traceback
-  traceback.print_exc()
+process_config_queue(
+  cfg_dir=cfg_dir,
+  target_ref=f'refs/heads/{secrets_repo_default_branch}',
+  repo_url=secrets_repo_url,
+  github_repo_path=f'{secrets_repo_org}/{secrets_repo_repo}',
+)
 % endif
 
 </%def>

--- a/concourse/steps/replicate_secrets.mako
+++ b/concourse/steps/replicate_secrets.mako
@@ -119,4 +119,18 @@ if (es_client := ccc.elasticsearch.from_cfg(cfg_set.elasticsearch())):
 else:
     logger.warning('not writing cfg status to elasticsearch, no client available')
 
+% if do_rotate_secrets:
+try:
+  process_config_queue(
+    cfg_dir=cfg_dir,
+    target_ref=f'refs/heads/{secrets_repo_default_branch}',
+    repo_url=secrets_repo_url,
+    github_repo_path=f'{secrets_repo_org}/{secrets_repo_repo}',
+  )
+except:
+  ## we are paranoid: let us not break replication upon rotation-error for now
+  import traceback
+  traceback.print_exc()
+% endif
+
 </%def>

--- a/concourse/steps/replicate_secrets.py
+++ b/concourse/steps/replicate_secrets.py
@@ -56,7 +56,7 @@ def process_config_queue(
         ):
             continue
 
-        # stop after first successful rotation (avoid causing too much trouble at one time
+        # stop after first successful deletion (avoid causing too much trouble at one time
         return
     logger.info('no to be deleted config queue entry found')
 

--- a/concourse/steps/replicate_secrets.py
+++ b/concourse/steps/replicate_secrets.py
@@ -58,7 +58,7 @@ def process_config_queue(
 
         # stop after first successful deletion (avoid causing too much trouble at one time
         return
-    logger.info('no to be deleted config queue entry found')
+    logger.info('did not find a config queue entry to delete')
 
 
 def rotate_secrets(

--- a/concourse/steps/replicate_secrets.py
+++ b/concourse/steps/replicate_secrets.py
@@ -26,8 +26,7 @@ def process_config_queue(
     target_ref: str,
 ):
     '''
-    Iterates to be deleted cfg_queue_entries.
-    Processes very first supported entry and terminates.
+    Find first config queue entry that should be deleted and delete it.
     '''
     cfg_metadata = cmm.cfg_metadata_from_cfg_dir(cfg_dir=cfg_dir)
     cfg_factory = model.ConfigFactory.from_cfg_dir(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds config queue processing and support for GCR ServiceAccount Key deletion.
The config queue is iterated and `to_be_deleted` (`deleteAfter` exceeded) entries are yielded.
The very first one is processed and the corresponding delete logic is executed (atm. only GCR).
Changes to the `cfg-repo` (config queue update) are pushed and the logic terminates after.

This processing is added to both, `replicate_secrets` template and `cli.py`, but `cli.py` offers a `CfgTarget` filter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
