### PR TITLE
Factor out config analysis

### DIFF
--- a/cfg_mgmt/model.py
+++ b/cfg_mgmt/model.py
@@ -180,15 +180,15 @@ class CfgMetadata:
     queue: list[CfgQueueEntry]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CfgStatusAnalysis:
     fullyCompliant: bool
     hasResponsible: bool
     hasRule: bool
     assignedRuleRefersToUndefinedPolicy: bool
     hasStatus: bool
-    requiresStatus: bool = None
-    credentialsOutdated: bool = None
+    requiresStatus: typing.Optional[bool]
+    credentialsOutdated: typing.Optional[bool]
 
 
 @dataclasses.dataclass

--- a/cfg_mgmt/model.py
+++ b/cfg_mgmt/model.py
@@ -181,7 +181,7 @@ class CfgMetadata:
 
 
 @dataclasses.dataclass(frozen=True)
-class CfgStatusAnalysis:
+class CfgStatusEvaluationResult:
     fullyCompliant: bool
     hasResponsible: bool
     hasRule: bool

--- a/cfg_mgmt/model.py
+++ b/cfg_mgmt/model.py
@@ -181,6 +181,17 @@ class CfgMetadata:
 
 
 @dataclasses.dataclass
+class CfgStatusAnalysis:
+    fullyCompliant: bool
+    hasResponsible: bool
+    hasRule: bool
+    assignedRuleRefersToUndefinedPolicy: bool
+    hasStatus: bool
+    requiresStatus: bool = None
+    credentialsOutdated: bool = None
+
+
+@dataclasses.dataclass
 class CfgReportingSummary:
     url: str
     noRuleAssigned: list

--- a/cfg_mgmt/reporting.py
+++ b/cfg_mgmt/reporting.py
@@ -30,9 +30,9 @@ class CfgElementStatusReport:
     status: typing.Optional[cmm.CfgStatus]
 
 
-def analyse_cfg_element_status(
+def evaluate_cfg_element_status(
     cfg_element_status: CfgElementStatusReport,
-) -> cmm.CfgStatusAnalysis:
+) -> cmm.CfgStatusEvaluationResult:
 
     fully_compliant = True
     has_responsible = True
@@ -80,7 +80,7 @@ def analyse_cfg_element_status(
     else:
         raise NotImplementedError(cfg_element_status.policy.type)
 
-    return cmm.CfgStatusAnalysis(
+    return cmm.CfgStatusEvaluationResult(
         fullyCompliant=fully_compliant,
         hasResponsible=has_responsible,
         hasRule=has_rule,
@@ -123,28 +123,28 @@ def create_report(
 
     for cfg_element_status in cfg_element_statuses:
         cfg_summary = compliance_summary(element_storage=cfg_element_status.element_storage)
-        analysis = analyse_cfg_element_status(cfg_element_status)
+        evaluation_result = evaluate_cfg_element_status(cfg_element_status)
 
-        if not analysis.hasResponsible:
+        if not evaluation_result.hasResponsible:
             no_responsible_assigned.append(cfg_element_status)
             cfg_summary.noResponsibleAssigned.append(cfg_element_status)
 
-        if not analysis.hasRule:
+        if not evaluation_result.hasRule:
             no_rule_assigned.append(cfg_element_status)
             cfg_summary.noRuleAssigned.append(cfg_element_status)
 
-        elif analysis.assignedRuleRefersToUndefinedPolicy:
+        elif evaluation_result.assignedRuleRefersToUndefinedPolicy:
             assigned_rule_refers_to_undefined_policy.append(cfg_element_status)
             cfg_summary.assignedRuleRefersToUndefinedPolicy.append(cfg_element_status)
 
         else:
-            if analysis.requiresStatus:
-                if not analysis.hasStatus:
+            if evaluation_result.requiresStatus:
+                if not evaluation_result.hasStatus:
                     no_status.append(cfg_element_status)
                     cfg_summary.noStatus.append(cfg_element_status)
 
                 else:
-                    if analysis.credentialsOutdated:
+                    if evaluation_result.credentialsOutdated:
                         credentials_outdated.append(cfg_element_status)
                         cfg_summary.credentialsOutdated.append(cfg_element_status)
 
@@ -152,7 +152,7 @@ def create_report(
                         credentials_not_outdated.append(cfg_element_status)
                         cfg_summary.credentialsNotOutdated.append(cfg_element_status)
 
-        if analysis.fullyCompliant:
+        if evaluation_result.fullyCompliant:
             fully_compliant.append(cfg_element_status)
             cfg_summary.fullyCompliant.append(cfg_element_status)
             cfg_summary.compliantElementsCount += 1

--- a/cfg_mgmt/reporting.py
+++ b/cfg_mgmt/reporting.py
@@ -54,12 +54,8 @@ def analyse_cfg_element_status(
         analysis.fullyCompliant = False
         analysis.assignedRuleRefersToUndefinedPolicy = True
 
-    else:
-        # have rule w/ policy
-        # XXX hardcode there is only one rule-type (-> checking for credential-age)
+    elif cfg_element_status.policy.type is cmm.PolicyType.MAX_AGE:
         policy = cfg_element_status.policy
-        if not policy.type is cmm.PolicyType.MAX_AGE:
-            raise NotImplementedError(policy.type)
 
         # status is only required if policy requires rotation
         if policy.max_age is None:
@@ -80,6 +76,9 @@ def analyse_cfg_element_status(
                 else:
                     analysis.fullyCompliant = False
                     analysis.credentialsOutdated = True
+
+    else:
+        raise NotImplementedError(cfg_element_status.policy.type)
 
     return analysis
 


### PR DESCRIPTION
`create_report` used to analyse a config status and print a report.
With the introduction of multiple elasticsearch metrics, the analysis
was extended by several semantics to calculate those metrics.
This commit separates the analysis and reporting to have clear concerns.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
