### PR TITLE
Sanitise ES logs (reduce tracebacks to only one time print)

### DIFF
--- a/concourse/util.py
+++ b/concourse/util.py
@@ -189,6 +189,12 @@ def meta_info_file_from_env() -> str:
     )
 
 
+def has_metadata() -> bool:
+    return os.path.isfile(
+        meta_info_file_from_env()
+    )
+
+
 @functools.lru_cache()
 def find_own_running_build(cfg_factory=None):
     '''

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -179,6 +179,16 @@ def own_running_build_url(cfg_factory=None):
     )
 
 
+def meta_info_file_from_env() -> str:
+    return os.path.abspath(
+        os.path.join(
+            check_env('CC_ROOT_DIR'),
+            concourse.model.traits.meta.DIR_NAME,
+            concourse.steps.meta.jobmetadata_filename,
+        )
+    )
+
+
 @functools.lru_cache()
 def find_own_running_build(cfg_factory=None):
     '''
@@ -191,14 +201,7 @@ def find_own_running_build(cfg_factory=None):
     if not _running_on_ci():
         raise RuntimeError('Can only find own running build if running on CI infrastructure.')
 
-    meta_dir = os.path.join(
-        os.path.abspath(check_env('CC_ROOT_DIR')),
-        concourse.model.traits.meta.DIR_NAME
-    )
-    meta_info_file = os.path.join(
-        meta_dir,
-        concourse.steps.meta.jobmetadata_filename,
-    )
+    meta_info_file = meta_info_file_from_env()
 
     with open(meta_info_file, 'r') as f:
         metadata_json = json.load(f)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sanitises ES logging.
If no concourse metadata is present, each `emit` printed a traceback.

On `OciRequestHandler` initialisation, cc-metadata availability is checked and if absent a warning is printed.
The availability status is stored in state and an early-exit returns `emit`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
