### PR TITLE
Refactor Concourse-API creation

### DIFF
--- a/ccc/concourse.py
+++ b/ccc/concourse.py
@@ -68,6 +68,30 @@ def client_from_parameters(
 
 
 @functools.lru_cache()
+def client_for_concourse_cfg(
+    concourse_cfg_name: str,
+    cfg_factory=None,
+) -> typing.Union[concourse.client.api.ConcourseApiBase, None]:
+    '''Create a Concourse API client for the main team of the given concourse config and return it
+
+    Will return `None` if no main team is configured.
+    '''
+    if not cfg_factory:
+        cfg_factory = ci.util.ctx().cfg_factory()
+
+    concourse_cfg: model.concourse.ConcourseConfig = cfg_factory.concourse(concourse_cfg_name)
+
+    if not (main_team_cfg_name := concourse_cfg.main_team_config_name()):
+        return None
+
+    return client_for_concourse_team(
+        concourse_cfg_name=concourse_cfg_name,
+        team_name=main_team_cfg_name,
+        cfg_factory=cfg_factory,
+    )
+
+
+@functools.lru_cache()
 def client_for_concourse_team(
     concourse_cfg_name: str,
     team_name: str,

--- a/cli/gardener_ci/_concourse.py
+++ b/cli/gardener_ci/_concourse.py
@@ -186,10 +186,12 @@ def trigger_resource_check(
     cfg_set = cfg_factory.cfg_set(cfg_name)
     concourse_cfg = cfg_set.concourse()
 
-    api = ccc.concourse.client_from_cfg_name(
-        concourse_cfg_name=concourse_cfg.name(),
+    api = ccc.concourse.client_for_concourse_team(
         team_name=team_name,
+        concourse_cfg=concourse_cfg,
+        cfg_set=cfg_set,
     )
+
     api.trigger_resource_check(
         pipeline_name=pipeline_name,
         resource_name=resource_name,

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -299,7 +299,7 @@ class ConcourseDeployer(DefinitionDeployer):
         try:
             concourse_cfg = definition_descriptor.concourse_target_cfg
 
-            api = ccc.concourse.client_from_cfg_name(
+            api = ccc.concourse.client_for_concourse_team(
                 concourse_cfg_name=concourse_cfg.name(),
                 team_name=definition_descriptor.concourse_target_team,
             )
@@ -389,7 +389,7 @@ class ReplicationResultProcessor:
                 concourse_results)).definition_descriptor.concourse_target()
 
             concourse_results = concourse_target_results[concourse_target_key]
-            concourse_api = ccc.concourse.client_from_cfg_name(
+            concourse_api = ccc.concourse.client_for_concourse_team(
                 concourse_cfg_name=concourse_cfg.name(),
                 team_name=concourse_team,
             )

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -81,7 +81,7 @@ if meta_build_job_name != env_build_job_name:
 
 cc_cfg = cfg_set.concourse()
 
-concourse_api = ccc.concourse.client_from_cfg_name(
+concourse_api = ccc.concourse.client_for_concourse_team(
   concourse_cfg_name=cc_cfg.name(),
   team_name=meta_vars_dict['build-team-name'],
 )

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -45,7 +45,7 @@ def job_url(v):
 def determine_previous_build_status(v, cfg_set):
     cc_cfg = cfg_set.concourse()
 
-    concourse_client = ccc.concourse.client_from_cfg_name(
+    concourse_client = ccc.concourse.client_for_concourse_team(
         concourse_cfg_name=cc_cfg.name(),
         team_name=v['build-team-name']
     )

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -443,7 +443,7 @@ def retrieve_buildlog(uuid: str):
     concourse_cfg = concourse.util._current_concourse_config()
 
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    client = ccc.concourse.client_from_cfg_name(
+    client = ccc.concourse.client_for_concourse_team(
         concourse_cfg_name=concourse_cfg.name(),
         team_name=pipeline_metadata.team_name,
     )

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -108,6 +108,9 @@ class ConcourseConfig(NamedModelElement):
     def oauth_config_name(self):
         return self.raw['oauth_config_name']
 
+    def main_team_config_name(self):
+        return self.raw.get('main_team_config_name')
+
     def is_accessible_from(self, url: str) -> bool:
         if not (domain_rules := self.raw.get('domain_rules', [])):
             return True
@@ -125,14 +128,14 @@ class ConcourseConfig(NamedModelElement):
         return [
             'externalUrl',
             'helm_chart_default_values_config',
-            'kubernetes_cluster_config',
-            'job_mapping',
-            'imagePullSecret',
-            'tls_secret_name',
-            'ingress_config',
-            'helm_chart_version',
             'helm_chart_values',
+            'helm_chart_version',
+            'imagePullSecret',
+            'ingress_config',
+            'job_mapping',
+            'kubernetes_cluster_config',
             'oauth_config_name',
+            'tls_secret_name',
         ]
 
     def _optional_attributes(self):
@@ -143,6 +146,7 @@ class ConcourseConfig(NamedModelElement):
             'domain_rules',
             'github_enterprise_host',
             'ingress_host', # TODO: Remove
+            'main_team_config_name'
             'proxy',
         }
 

--- a/whd/dispatcher.py
+++ b/whd/dispatcher.py
@@ -89,7 +89,7 @@ class GithubWebhookDispatcher:
             concourse_cfg = self.cfg_factory.concourse(concourse_config_name)
             job_mapping_set = self.cfg_factory.job_mapping(concourse_cfg.job_mapping_cfg_name())
             for job_mapping in job_mapping_set.job_mappings().values():
-                yield ccc.concourse.client_from_cfg_name(
+                yield ccc.concourse.client_for_concourse_team(
                     concourse_cfg_name=concourse_cfg.name(),
                     team_name=job_mapping.team_name(),
                 )


### PR DESCRIPTION
This PR refactors our client-creation a bit.

- Change names of methods for more clarity
- Add docstrings
- rm ensure

Also, make main-team of a given Concourse-instance explicitly configurable and add convenience methods for retrieving the corresponding client.