### PR TITLE
Rm concourse externalUrl

### DIFF
--- a/ccc/elasticsearch.py
+++ b/ccc/elasticsearch.py
@@ -65,10 +65,16 @@ def _metadata_dict():
     if not ci.util._running_on_ci():
         return {}
 
+    cfg_fac = ci.util.ctx().cfg_factory()
+
     build = concourse.util.find_own_running_build()
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    config_set = ci.util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
+    config_set = cfg_fac.cfg_set(pipeline_metadata.current_config_set_name)
     concourse_cfg = config_set.concourse()
+
+    external_url = cfg_fac.concourse_endpoint(
+        concourse_cfg.concourse_endpoint_name()
+    ).base_url()
 
     meta_dict = {
       'build-id': build.id(),
@@ -76,7 +82,7 @@ def _metadata_dict():
       'build-job-name': pipeline_metadata.job_name,
       'build-team-name': pipeline_metadata.team_name,
       'build-pipeline-name': pipeline_metadata.pipeline_name,
-      'atc-external-url': concourse_cfg.external_url(),
+      'atc-external-url': external_url,
     }
 
     # XXX deduplicate; mv to concourse package

--- a/concourse/steps/notification.py
+++ b/concourse/steps/notification.py
@@ -12,17 +12,23 @@ import mailutil
 
 
 def meta_vars():
+    cfg_fac = ci.util.ctx().cfg_factory()
+
     build = concourse.util.find_own_running_build()
     pipeline_metadata = concourse.util.get_pipeline_metadata()
-    config_set = ci.util.ctx().cfg_factory().cfg_set(pipeline_metadata.current_config_set_name)
+    config_set = cfg_fac.cfg_set(pipeline_metadata.current_config_set_name)
     concourse_cfg = config_set.concourse()
+    external_url = cfg_fac.concourse_endpoint(
+        concourse_cfg.concourse_endpoint_name()
+    ).base_url()
+
     v = {
         'build-id': build.id(),
         'build-name': build.build_number(),
         'build-job-name': pipeline_metadata.job_name,
         'build-team-name': pipeline_metadata.team_name,
         'build-pipeline-name': pipeline_metadata.pipeline_name,
-        'atc-external-url': concourse_cfg.external_url(),
+        'atc-external-url': external_url,
     }
 
     return v

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -172,8 +172,15 @@ def own_running_build_url(cfg_factory=None):
     own_build = find_own_running_build(cfg_factory=cfg_factory)
     cc_cfg = _current_concourse_config()
 
+    if not cfg_factory:
+        cfg_factory = ctx().cfg_factory()
+
+    external_url = cfg_factory.concourse_endpoint(
+        cc_cfg.concourse_endpoint_name()
+    ).base_url()
+
     return ConcourseApiRoutesBase.running_build_url(
-        cc_cfg.external_url(),
+        external_url,
         pipeline_metadata,
         own_build.build_number(),
     )

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -49,9 +49,6 @@ class ConcourseConfig(NamedModelElement):
     Not intended to be instantiated by users of this module
     '''
 
-    def external_url(self):
-        return self.raw.get('externalUrl')
-
     def job_mapping_cfg_name(self):
         return self.raw.get('job_mapping')
 
@@ -126,7 +123,6 @@ class ConcourseConfig(NamedModelElement):
 
     def _required_attributes(self):
         return [
-            'externalUrl',
             'helm_chart_default_values_config',
             'kubernetes_cluster_config',
             'job_mapping',

--- a/test/model/concourse_test.py
+++ b/test/model/concourse_test.py
@@ -80,7 +80,6 @@ class ConcourseConfigTest:
     @pytest.fixture
     def required_dict(self):
         return {
-            'externalUrl': 'foo',
             'helm_chart_default_values_config': 'foo',
             'kubernetes_cluster_config': 'foo',
             'job_mapping': 'foo',


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/gardener/cc-utils/commit/fbec124ac26c5f432a3e20b356518e0f4b7c3cda introduced a `concourse endpoint` config attribute. We should rather use the referenced `concourse_endpoint cfg` to retrieve the `externalUrl`.

This PR removes the `externalUrl` attribute and replaces its usages with `concourse_endpoint cfg`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
