### PR TITLE
Introduce trait to omit github releases

### DIFF
--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -176,6 +176,14 @@ ATTRIBUTES = (
         The first tag will be used to create the GitHub-release.
         ''',
         type=list
+    ),
+    AttributeSpec.optional(
+        name='release_on_github',
+        default=True,
+        doc='''
+        if true, a github release is published.
+        ''',
+        type=bool
     )
 )
 
@@ -228,6 +236,9 @@ class ReleaseTrait(Trait):
         if tags := self.raw.get('git_tags'):
             return tags[0]
         return None
+
+    def release_on_github(self) -> bool:
+        return self.raw['release_on_github']
 
     def validate(self):
         super().validate()

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -98,6 +98,7 @@ release_and_prepare_next_dev_cycle(
   next_version_callback='${next_version_callback_path}',
   % endif
   rebase_before_release=${release_trait.rebase_before_release()},
+  release_on_github=${release_trait.release_on_github()},
   githubrepobranch=githubrepobranch,
   repo_hostname='${repo.repo_hostname()}',
   repo_path='${repo.repo_path()}',

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -720,7 +720,7 @@ class UploadComponentDescriptorStep(TransactionalStep):
         else:
             upload_ctf(ctf_path=self.ctf_path)
 
-        def attach_cd_to_release():
+        def upload_component_descriptor_as_release_asset():
             try:
                 release = self.github_helper.repository.release_from_tag(release_tag_name)
 
@@ -744,7 +744,7 @@ class UploadComponentDescriptorStep(TransactionalStep):
                 logger.warning('Unable to attach component-descriptors to release as release-asset.')
 
         if self.release_on_github:
-            attach_cd_to_release()
+            upload_component_descriptor_as_release_asset()
 
     def revert(self):
         pass

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -1140,6 +1140,8 @@ def release_and_prepare_next_dev_cycle(
             raise RuntimeError('An error occurred while publishing the release notes.')
 
     if slack_channel_configs:
+        if not release_on_github:
+            raise RuntimeError('Cannot post to slack without a github release')
         release_notes = transaction_ctx.step_output(
             publish_release_notes_step.name()
             ).get('release notes')

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -1065,14 +1065,15 @@ def release_and_prepare_next_dev_cycle(
         )
         step_list.append(next_cycle_commit_step)
 
-    github_release_step = GitHubReleaseStep(
-        github_helper=github_helper,
-        githubrepobranch=githubrepobranch,
-        repo_dir=repo_dir,
-        component_name=component_name,
-        release_version=release_version,
-    )
-    step_list.append(github_release_step)
+    if release_on_github:
+        github_release_step = GitHubReleaseStep(
+            github_helper=github_helper,
+            githubrepobranch=githubrepobranch,
+            repo_dir=repo_dir,
+            component_name=component_name,
+            release_version=release_version,
+        )
+        step_list.append(github_release_step)
 
     upload_component_descriptor_step = UploadComponentDescriptorStep(
         github_helper=github_helper,

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -1000,6 +1000,7 @@ def release_and_prepare_next_dev_cycle(
     next_version_callback: str=None,
     prerelease_suffix: str="dev",
     rebase_before_release: bool=False,
+    release_on_github: bool=True,
     release_commit_callback: str=None,
     release_commit_message_prefix: str=None,
     slack_channel_configs: list=[],


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `release_on_github` trait (default `True`) to controller whether a github release is published on release.
As some steps rely on `GitHubReleaseStep`, the `release_on_github` condition is used multiple times.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
