### PR TITLE
Eliminate codeowners class

### DIFF
--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -23,7 +23,8 @@ from ci.util import (
     urljoin,
 )
 from mailutil import _send_mail
-from github.codeowners import CodeownersEnumerator, CodeOwnerEntryResolver
+from github.codeowners import CodeOwnerEntryResolver
+import github.codeowners
 
 from concourse.factory import DefinitionFactory, RawPipelineDefinitionDescriptor
 from concourse.enumerator import (
@@ -524,10 +525,9 @@ class ReplicationResultProcessor:
             branch=main_repo['branch'],
         )
 
-        codeowners_enumerator = CodeownersEnumerator()
         codeowners_resolver = CodeOwnerEntryResolver(github_api=github_api)
         recipients = set(codeowners_resolver.resolve_email_addresses(
-            codeowners_enumerator.enumerate_remote_repo(github_repo_helper=repo_helper)
+            github.codeowners.enumerate_remote_repo(repo=repo_helper.repository)
         ))
 
         # in case no codeowners are available, resort to using the committer

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -23,7 +23,6 @@ from ci.util import (
     urljoin,
 )
 from mailutil import _send_mail
-from github.codeowners import CodeOwnerEntryResolver
 import github.codeowners
 
 from concourse.factory import DefinitionFactory, RawPipelineDefinitionDescriptor
@@ -525,9 +524,11 @@ class ReplicationResultProcessor:
             branch=main_repo['branch'],
         )
 
-        codeowners_resolver = CodeOwnerEntryResolver(github_api=github_api)
-        recipients = set(codeowners_resolver.resolve_email_addresses(
-            github.codeowners.enumerate_remote_repo(repo=repo_helper.repository)
+        recipients = set(github.codeowners.resolve_email_addresses(
+            codeowners_entries=github.codeowners.enumerate_remote_repo(
+                repo=repo_helper.repository
+            ),
+            github_api=github_api,
         ))
 
         # in case no codeowners are available, resort to using the committer

--- a/concourse/replicator.py
+++ b/concourse/replicator.py
@@ -525,7 +525,7 @@ class ReplicationResultProcessor:
         )
 
         recipients = set(github.codeowners.resolve_email_addresses(
-            codeowners_entries=github.codeowners.enumerate_remote_repo(
+            codeowners_entries=github.codeowners.enumerate_codeowners_from_remote_repo(
                 repo=repo_helper.repository
             ),
             github_api=github_api,

--- a/github/codeowners.py
+++ b/github/codeowners.py
@@ -29,7 +29,7 @@ ci.log.configure_default_logging()
 
 def enumerate_codeowners_from_remote_repo(
     repo: github3.repos.repo.Repository,
-    paths: typing.Sequence[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
+    paths: typing.Iterable[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
 ) -> typing.Generator[str, None, None]:
     for path in paths:
         try:
@@ -42,7 +42,7 @@ def enumerate_codeowners_from_remote_repo(
 
 def enumerate_codeowners_from_file(
     file_path: str,
-):
+) -> typing.Generator[str, None, None]:
     file_path = existing_file(file_path)
     with open(file_path) as f:
         yield from filter_codeowners_entries(f.readlines())
@@ -50,8 +50,8 @@ def enumerate_codeowners_from_file(
 
 def enumerate_codeowners_from_local_repo(
     repo_dir: str,
-    paths: typing.Sequence[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
-):
+    paths: typing.Iterable[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
+) -> typing.Generator[str, None, None]:
     repo_dir = existing_dir(Path(repo_dir))
     if not repo_dir.joinpath('.git').is_dir():
         raise ValueError(f'not a git root directory: {repo_dir}')
@@ -63,7 +63,9 @@ def enumerate_codeowners_from_local_repo(
                 yield from filter_codeowners_entries(f.readlines())
 
 
-def filter_codeowners_entries(lines):
+def filter_codeowners_entries(
+    lines: typing.Iterable[str],
+) -> typing.Generator[str, None, None]:
     '''
     returns a generator yielding parsed entries from */CODEOWNERS
     each entry may be one of
@@ -79,7 +81,9 @@ def filter_codeowners_entries(lines):
         yield from line.split()[1:]
 
 
-def _first(iterable):
+def _first(
+    iterable: typing.Iterable,
+):
     try:
         return next(iterable)
     except StopIteration:
@@ -89,7 +93,7 @@ def _first(iterable):
 def determine_email_address(
     github_user_name: str,
     github_api: GitHub,
-):
+) -> typing.Optional[str]:
     not_none(github_user_name)
     try:
         user = github_api.user(github_user_name)
@@ -103,7 +107,7 @@ def determine_email_address(
 def resolve_team_members(
     github_team_name: str,
     github_api: GitHub,
-):
+) -> typing.Union[typing.Generator[str, None, None], list]:
     not_none(github_team_name)
     org_name, team_name = github_team_name.split('/') # always of form 'org/name'
     organisation = github_api.organization(org_name)

--- a/github/codeowners.py
+++ b/github/codeowners.py
@@ -20,7 +20,7 @@ from github3 import GitHub
 from github3.exceptions import NotFoundError
 import github3.repos.repo
 
-from ci.util import existing_dir, existing_file, not_none, warning
+from ci.util import existing_dir, existing_file, not_none
 import ci.log
 
 logger = logging.getLogger(__name__)

--- a/github/codeowners.py
+++ b/github/codeowners.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 
 
-def enumerate_remote_repo(
+def enumerate_codeowners_from_remote_repo(
     repo: github3.repos.repo.Repository,
     paths: typing.Sequence[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
 ) -> typing.Generator[str, None, None]:
@@ -40,7 +40,7 @@ def enumerate_remote_repo(
             pass # ignore absent files
 
 
-def enumerate_single_file(
+def enumerate_codeowners_from_file(
     file_path: str,
 ):
     file_path = existing_file(file_path)
@@ -48,7 +48,7 @@ def enumerate_single_file(
         yield from filter_codeowners_entries(f.readlines())
 
 
-def enumerate_local_repo(
+def enumerate_codeowners_from_local_repo(
     repo_dir: str,
     paths: typing.Sequence[str] = ('CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'),
 ):

--- a/mailutil.py
+++ b/mailutil.py
@@ -162,7 +162,9 @@ def determine_local_repository_codeowners_recipients(
     '''
     def enumerate_entries_from_src_dirs(src_dirs):
         for src_dir in src_dirs:
-            yield from github.codeowners.enumerate_local_repo(repo_dir=src_dir)
+            yield from github.codeowners.enumerate_codeowners_from_local_repo(
+                repo_dir=src_dir,
+            )
 
     entries = enumerate_entries_from_src_dirs(src_dirs)
 
@@ -180,7 +182,7 @@ def determine_codeowner_file_recipients(
     '''
     def enumerate_entries_from_codeowners_files(codeowners_files):
         for codeowners_file in codeowners_files:
-            yield from github.codeowners.enumerate_single_file(codeowners_file)
+            yield from github.codeowners.enumerate_codeowners_from_file(codeowners_file)
 
     entries = enumerate_entries_from_codeowners_files(codeowners_files)
     yield from github.codeowners.resolve_email_addresses(
@@ -295,7 +297,7 @@ def _codeowners_parser_from_component(
         branch=branch_name,
     )
 
-    return github_api, github.codeowners.enumerate_remote_repo(
+    return github_api, github.codeowners.enumerate_codeowners_from_remote_repo(
         repo=repo_helper.repository,
     )
 

--- a/mailutil.py
+++ b/mailutil.py
@@ -35,7 +35,8 @@ from ci.util import (
 )
 from mail import template_mailer as mailer
 import ccc.github
-from github.codeowners import CodeownersEnumerator, CodeOwnerEntryResolver
+from github.codeowners import CodeOwnerEntryResolver
+import github.codeowners
 
 
 def send_mail(
@@ -160,12 +161,11 @@ def determine_local_repository_codeowners_recipients(
     '''returns a generator yielding e-mail adresses from all given repository work
     tree's CODEOWNERS files.
     '''
-    enumerator = CodeownersEnumerator()
     resolver = CodeOwnerEntryResolver(github_api=github_api)
 
     def enumerate_entries_from_src_dirs(src_dirs):
         for src_dir in src_dirs:
-            yield from enumerator.enumerate_local_repo(repo_dir=src_dir)
+            yield from github.codeowners.enumerate_local_repo(repo_dir=src_dir)
 
     entries = enumerate_entries_from_src_dirs(src_dirs)
 
@@ -178,12 +178,11 @@ def determine_codeowner_file_recipients(
 ):
     '''returns a generator yielding e-mail adresses from the given CODEOWNERS file(s).
     '''
-    enumerator = CodeownersEnumerator()
     resolver = CodeOwnerEntryResolver(github_api=github_api)
 
     def enumerate_entries_from_codeowners_files(codeowners_files):
         for codeowners_file in codeowners_files:
-            yield from enumerator.enumerate_single_file(codeowners_file)
+            yield from github.codeowners.enumerate_single_file(codeowners_file)
 
     entries = enumerate_entries_from_codeowners_files(codeowners_files)
     yield from resolver.resolve_email_addresses(entries)
@@ -293,9 +292,10 @@ def _codeowners_parser_from_component(
     )
 
     resolver = CodeOwnerEntryResolver(github_api=github_api)
-    enumerator = CodeownersEnumerator()
 
-    return resolver, enumerator.enumerate_remote_repo(github_repo_helper=repo_helper)
+    return resolver, github.codeowners.enumerate_remote_repo(
+        repo=repo_helper.repository,
+    )
 
 
 def notify(


### PR DESCRIPTION
**What this PR does / why we need it**:
Eliminate oop pattern by factoring out the actual methods.
One small change is also made, the remote enumaration was expecting a
`GithubRepoHelper` which in a nutshell holds two information, the repo
and its api. As only the repo is needed (read file contents, separate
api object not necessary), the function now only expects the repo.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
