### PR TITLE
Make Merge-Method Configurable

### DIFF
--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -44,6 +44,12 @@ class MergePolicy(enum.Enum):
     AUTO_MERGE = 'auto_merge'
 
 
+class MergeMethod(enum.Enum):
+    MERGE = 'merge'
+    REBASE = 'rebase'
+    SQUASH = 'squash'
+
+
 class UpstreamUpdatePolicy(enum.Enum):
     STRICTLY_FOLLOW = 'strictly_follow'
     ACCEPT_HOTFIXES = 'accept_hotfixes'
@@ -65,6 +71,15 @@ MERGE_POLICY_CONFIG_ATTRIBUTES = (
         type=MergePolicy,
         doc='whether or not created PRs should be automatically merged',
     ),
+    AttributeSpec.optional(
+        name='merge_method',
+        default='merge',
+        type=MergeMethod,
+        doc=(
+            'The method to use when merging PRs automatically. For more details, check '
+            '`the GitHub documentation for merge-methods <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github>`_.' # noqa:E501
+        )
+    ),
 )
 
 
@@ -84,6 +99,9 @@ class MergePolicyConfig(ModelBase):
 
     def merge_mode(self):
         return MergePolicy(self.raw['merge_mode'])
+
+    def merge_method(self):
+        return MergeMethod(self.raw['merge_method'])
 
 
 ATTRIBUTES = (
@@ -180,6 +198,7 @@ class UpdateComponentDependenciesTrait(Trait):
                     MergePolicyConfig({
                         'component_names': ['.*'],
                         'merge_mode': 'manual',
+                        'merge_method': 'merge',
                     })]
 
             # preserve legacy behaviour
@@ -189,6 +208,7 @@ class UpdateComponentDependenciesTrait(Trait):
                     MergePolicyConfig({
                         'component_names': ['.*'],
                         'merge_mode': self.raw['merge_policy'],
+                        'merge_method': 'merge',
                     })
                 ]
 

--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -181,7 +181,6 @@ for from_ref, to_version in determine_upgrade_prs(
         githubrepobranch=githubrepobranch,
         repo_dir=REPO_ROOT,
         github_cfg_name=github_cfg_name,
-        cfg_factory=cfg_factory,
         merge_policy=merge_policy,
 % if after_merge_callback:
         after_merge_callback='${after_merge_callback}',

--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -165,10 +165,13 @@ for from_ref, to_version in determine_upgrade_prs(
         ]):
             raise RuntimeError(f'Conflicting merge policies found to apply to {from_ref.name}')
         merge_policy = applicable_merge_policy[0].merge_mode()
+        merge_method = applicable_merge_policy[0].merge_method()
     elif len(applicable_merge_policy) == 0:
         merge_policy = MergePolicy.MANUAL
+        merge_method = MergeMethod.MERGE
     else:
         merge_policy = applicable_merge_policy[0].merge_mode()
+        merge_method = applicable_merge_policy[0].merge_method()
 
     create_upgrade_pr(
         component=own_component,
@@ -182,6 +185,7 @@ for from_ref, to_version in determine_upgrade_prs(
         repo_dir=REPO_ROOT,
         github_cfg_name=github_cfg_name,
         merge_policy=merge_policy,
+        merge_method=merge_method,
 % if after_merge_callback:
         after_merge_callback='${after_merge_callback}',
 % endif

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -23,6 +23,7 @@ import product.v2
 import version
 from concourse.model.traits.update_component_deps import (
     MergePolicy,
+    MergeMethod,
 )
 from github.util import (
     GitHubRepoBranch,
@@ -286,7 +287,8 @@ def create_upgrade_pr(
     githubrepobranch: GitHubRepoBranch,
     repo_dir,
     github_cfg_name,
-    merge_policy,
+    merge_policy: MergePolicy,
+    merge_method: MergeMethod,
     after_merge_callback=None,
     container_image:str=None,
 ):
@@ -397,8 +399,16 @@ def create_upgrade_pr(
 
     if merge_policy is MergePolicy.MANUAL:
         return
-    # auto-merge - todo: make configurable (e.g. merge method)
-    pull_request.merge()
+
+    if merge_method is MergeMethod.MERGE:
+        pull_request.merge(merge_method='merge')
+    elif merge_method is MergeMethod.REBASE:
+        pull_request.merge(merge_method='rebase')
+    elif merge_method is MergeMethod.SQUASH:
+        pull_request.merge(merge_method='squash')
+    else:
+        raise NotImplementedError(f'{merge_method=}')
+
     try:
         ls_repo.ref(f'heads/{upgrade_branch_name}').delete()
     except github3.exceptions.NotFoundError:

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -286,7 +286,6 @@ def create_upgrade_pr(
     githubrepobranch: GitHubRepoBranch,
     repo_dir,
     github_cfg_name,
-    cfg_factory,
     merge_policy,
     after_merge_callback=None,
     container_image:str=None,


### PR DESCRIPTION
This allows for the merge-method (`merge`, `rebase`, or `squash`) to be configured in our update-component-deps trait.

This can be necessary for repositories, where merge-commits are not allowed (such as this very repository).