### PR TITLE
oci ref annotations

### DIFF
--- a/cli/gardener_ci/_oci.py
+++ b/cli/gardener_ci/_oci.py
@@ -1,4 +1,3 @@
-import dataclasses
 import enum
 import hashlib
 import pprint
@@ -63,7 +62,7 @@ def manifest(
             accept=accept,
         )
 
-        pprint.pprint(dataclasses.asdict(manifest))
+        pprint.pprint(manifest.as_dict())
 
         if isinstance(manifest, om.OciImageManifest):
             total_size = sum(blob.size for blob in manifest.blobs())

--- a/container/util.py
+++ b/container/util.py
@@ -297,7 +297,7 @@ def filter_image(
 
     manifest.config = dataclasses.replace(manifest.config, digest=cfg_digest, size=cfg_leng)
 
-    manifest_raw = json.dumps(dataclasses.asdict(manifest)).encode('utf-8')
+    manifest_raw = json.dumps(manifest.as_dict()).encode('utf-8')
 
     if target_ref.has_tag:
         target_ref = str(target_ref)

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -451,7 +451,6 @@ def publish_container_image_from_kaniko_tarfile(
 
         # optionally patch manifest's mimetype (e.g. required for docker-hub)
         manifest_dict = image.oci_manifest().as_dict()
-
         manifest_dict['mediaType'] = manifest_mimetype
 
         manifest_bytes = json.dumps(

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -1,4 +1,3 @@
-import dataclasses
 import enum
 import hashlib
 import json
@@ -343,7 +342,7 @@ def replicate_artifact(
             data=fake_cfg_raw,
         )
 
-        manifest_dict = dataclasses.asdict(manifest)
+        manifest_dict = manifest.as_dict()
         # patch-on altered cfg-digest
         manifest_dict['config']['digest'] = cfg_digest
         manifest_dict['config']['size'] = len(fake_cfg_raw)
@@ -451,7 +450,8 @@ def publish_container_image_from_kaniko_tarfile(
             )
 
         # optionally patch manifest's mimetype (e.g. required for docker-hub)
-        manifest_dict = dataclasses.asdict(image.oci_manifest())
+        manifest_dict = image.oci_manifest().as_dict()
+
         manifest_dict['mediaType'] = manifest_mimetype
 
         manifest_bytes = json.dumps(

--- a/oci/model.py
+++ b/oci/model.py
@@ -192,6 +192,7 @@ class OciBlobRef:
     digest: str
     mediaType: str
     size: int
+    annotations: typing.Optional[typing.Dict] = None
 
 
 @dataclasses.dataclass
@@ -272,11 +273,15 @@ class OciPlatform:
 
 @dataclasses.dataclass(frozen=True)
 class OciImageManifestListEntry(OciBlobRef):
-    platform: OciPlatform
+    # platform is an optional attribute according to the oci image spec.
+    # it must also be optional to not have a non-default attribute after
+    # the default attribute "annotations" in parent class OciBlobRef.
+    platform: typing.Optional[OciPlatform] = None
 
     def as_dict(self) -> dict:
         raw = dataclasses.asdict(self)
-        raw['platform'] = self.platform.as_dict()
+        if self.platform:
+            raw['platform'] = self.platform.as_dict()
         return raw
 
 

--- a/oci/workarounds.py
+++ b/oci/workarounds.py
@@ -98,7 +98,7 @@ def sanitise_image(
         ),
     )
 
-    manifest_bytes = json.dumps(dataclasses.asdict(manifest)).encode('utf-8')
+    manifest_bytes = json.dumps(manifest.as_dict()).encode('utf-8')
 
     oci_client.put_manifest(image_reference=image_ref, manifest=manifest_bytes)
 

--- a/product/v2.py
+++ b/product/v2.py
@@ -342,7 +342,7 @@ def upload_component_descriptor_v2_to_oci_registry(
         ],
     )
 
-    manifest_dict = dataclasses.asdict(manifest)
+    manifest_dict = manifest.as_dict()
     manifest_bytes = json.dumps(manifest_dict).encode('utf-8')
 
     client.put_manifest(

--- a/test/oci/oci_model_test.py
+++ b/test/oci/oci_model_test.py
@@ -1,3 +1,4 @@
+import dataclasses
 import hashlib
 import pytest
 
@@ -128,3 +129,59 @@ def test_parsed_digest_tag():
 
     assert alg == 'sha256'
     assert dig == example_digest.split(':')[-1]
+
+
+def test_oci_image_manifest_serialisation():
+    annotations = {
+        'key': 'val',
+    }
+    manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest='',
+            mediaType='',
+            size=0,
+            annotations=annotations,
+        ),
+        layers=[
+            om.OciBlobRef(
+                digest='',
+                mediaType='',
+                size=0,
+                annotations=annotations,
+            ),
+        ],
+    )
+    manifest_dict = dataclasses.asdict(manifest)
+
+    assert 'annotations' in manifest_dict['config']
+    assert manifest_dict['config']['annotations'] == annotations
+    assert 'annotations' in manifest_dict['layers'][0]
+    assert manifest_dict['layers'][0]['annotations'] == annotations
+
+
+def test_oci_image_manifest_list_serialisation():
+    annotations = {
+        'key': 'val',
+    }
+    platform = om.OciPlatform(
+        architecture='amd64',
+        os='linux'
+    )
+    manifest_list = om.OciImageManifestList(
+        manifests=[
+            om.OciImageManifestListEntry(
+                digest='',
+                mediaType='',
+                size=0,
+                annotations=annotations,
+                platform=platform,
+            )
+        ]
+    )
+    manifest_list_dict = manifest_list.as_dict()
+
+    assert 'annotations' in manifest_list_dict['manifests'][0]
+    assert manifest_list_dict['manifests'][0]['annotations'] == annotations
+
+    assert 'platform' in manifest_list_dict['manifests'][0]
+    assert manifest_list_dict['manifests'][0]['platform'] == platform.as_dict()

--- a/test/oci/oci_model_test.py
+++ b/test/oci/oci_model_test.py
@@ -1,4 +1,3 @@
-import dataclasses
 import hashlib
 import pytest
 
@@ -132,6 +131,25 @@ def test_parsed_digest_tag():
 
 
 def test_oci_image_manifest_serialisation():
+    manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest='',
+            mediaType='',
+            size=0,
+        ),
+        layers=[
+            om.OciBlobRef(
+                digest='',
+                mediaType='',
+                size=0,
+            ),
+        ],
+    )
+    manifest_dict = manifest.as_dict()
+
+    assert 'annotations' not in manifest_dict['config']
+    assert 'annotations' not in manifest_dict['layers'][0]
+
     annotations = {
         'key': 'val',
     }
@@ -151,7 +169,7 @@ def test_oci_image_manifest_serialisation():
             ),
         ],
     )
-    manifest_dict = dataclasses.asdict(manifest)
+    manifest_dict = manifest.as_dict()
 
     assert 'annotations' in manifest_dict['config']
     assert manifest_dict['config']['annotations'] == annotations
@@ -160,6 +178,20 @@ def test_oci_image_manifest_serialisation():
 
 
 def test_oci_image_manifest_list_serialisation():
+    manifest_list = om.OciImageManifestList(
+        manifests=[
+            om.OciImageManifestListEntry(
+                digest='',
+                mediaType='',
+                size=0,
+            )
+        ]
+    )
+    manifest_list_dict = manifest_list.as_dict()
+
+    assert 'annotations' not in manifest_list_dict['manifests'][0]
+    assert 'platform' not in manifest_list_dict['manifests'][0]
+
     annotations = {
         'key': 'val',
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
adds the "annotations" attribute to the classes OciBlobRef and OciImageManifestListEntry.
this was previously introduced in #732 and later reverted because multi-arch manifests with "annotations" being null weren't accepted by GCR.
therefore, now a more "defensive" approach is used, where the "annotations" and "platform" attributes are omitted from being serialised if they are null.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- adds the "annotations" attribute to the classes OciBlobRef and OciImageManifestListEntry
```
