### PR TITLE
Don't call version trait write_callback if it is None. 

### DIFF
--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -104,7 +104,7 @@ if os.path.isdir(os.path.join(ci.paths.repo_root, '.git')):
   except:
     pass
 
-if version_interface is version_trait.VersionInterface.CALLBACK:
+if version_interface is version_trait.VersionInterface.CALLBACK and write_callback is not None:
   write_version(
     version_interface=version_interface,
     version_str=effective_version,


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**What this PR does / why we need it**:
If the `write_callback` on the `version` trait is `None`, the template should not call it. The callback may not be able to handle writes. 
