### PR TITLE
Rework Filter for Image Scan

### DIFF
--- a/concourse/model/traits/filter.py
+++ b/concourse/model/traits/filter.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2019-2020 SAP SE or an SAP affiliate company. All rights reserved. This file is
+# licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import enum
+import typing
+
+import dacite
+import pydash
+
+from concourse.model.base import (
+    AttributeSpec,
+    ModelBase,
+)
+import gci.componentmodel as cm
+import reutil
+
+
+class ImageFilterMixin(ModelBase):
+    def matching_config(self):
+        return self.raw['matching_config']
+
+
+FILTER_ATTRS = (
+    AttributeSpec.optional(
+        name='matching_config',
+        default=[],
+        doc='''
+        a list of configs to use for matching
+        ''',
+        type=list,
+    ),
+)
+
+
+class ComponentFilterSemantics(enum.Enum):
+    INCLUDE = 'include'
+    EXCLUDE = 'exclude'
+
+
+@dataclasses.dataclass
+class ConfigRule:
+    target: str
+    expression: str
+    matching_semantics: ComponentFilterSemantics
+
+
+@dataclasses.dataclass
+class MatchingConfig:
+    name: str
+    rules: typing.List[ConfigRule]
+
+
+def filter_for_matching_configs(
+    configs: typing.Collection[MatchingConfig]
+) -> typing.Callable[[cm.Component, cm.Resource], bool]:
+    # A filter for several matching configs is the combination of its constituent filters joined
+    # with a boolean AND
+    filters_from_configs = [
+        filter_for_matching_config(
+            config=config,
+        ) for config in configs
+    ]
+    return lambda component, resource: all(
+        filter_func(component, resource) for filter_func in filters_from_configs
+    )
+
+
+def filter_for_matching_config(
+    config: MatchingConfig,
+) -> typing.Callable[[cm.Component, cm.Resource], bool]:
+    # A filter for a single matching configs is the combination of the filters for its rules joined
+    # with a boolean OR
+    rule_filters = [
+        filter_for_rule(
+            rule=rule,
+        ) for rule in config.rules
+    ]
+    return lambda component, resource: any(
+        filter_func(component, resource) for filter_func in rule_filters
+    )
+
+
+def filter_for_rule(
+    rule: ConfigRule,
+) -> typing.Callable[[cm.Component, cm.Resource], bool]:
+    match rule.matching_semantics:
+        case ComponentFilterSemantics.INCLUDE:
+            re_filter = reutil.re_filter(
+                include_regexes=[rule.expression],
+                value_transformation=str
+            )
+        case ComponentFilterSemantics.EXCLUDE:
+            re_filter = reutil.re_filter(
+                exclude_regexes=[rule.expression],
+                value_transformation=str
+            )
+        case _:
+            raise NotImplementedError(rule.matching_semantics)
+
+    def filter_func(component: cm.Component, resource:cm.Resource):
+        match rule.target.split('.'):
+            case ['component', *tail]:
+                return re_filter(pydash.get(component, tail))
+            case ['resource', *tail]:
+                return re_filter(pydash.get(resource, tail))
+            case _:
+                raise ValueError(f"Unable to parse matching rule '{rule.target}'")
+
+    return filter_func
+
+
+def matching_configs_from_dicts(
+    dicts: typing.Iterable[dict],
+) -> typing.List[MatchingConfig]:
+    return [
+        dacite.from_dict(
+            data_class=MatchingConfig,
+            data=d,
+            config=dacite.Config(
+                cast=[ComponentFilterSemantics]
+            )
+        ) for d in dicts
+    ]

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -41,8 +41,8 @@ from protecode.model import CVSSVersion
 
 import concourse.model.traits.component_descriptor
 import github.compliance.model
-from .images import (
-    IMAGE_ATTRS,
+from .filter import (
+    FILTER_ATTRS,
     ImageFilterMixin,
 )
 
@@ -276,7 +276,7 @@ class IssuePolicies:
 
 
 ATTRIBUTES = (
-    *IMAGE_ATTRS,
+    *FILTER_ATTRS,
     AttributeSpec.optional(
         name='notify',
         default=Notify.EMAIL_RECIPIENTS,

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -14,7 +14,6 @@ clam_av = image_scan_trait.clam_av()
 
 saf_cfg_name = clam_av.saf_config_name() or ''
 
-filter_cfg = image_scan_trait.filters()
 component_trait = job_variant.trait('component_descriptor')
 component_descriptor_dir = job_step.input('component_descriptor_dir')
 %>
@@ -47,8 +46,8 @@ import ccc.clamav
 import ccc.delivery
 import ccc.oci
 import ci.util
-import clamav.cnudie
 import clamav.client
+import clamav.cnudie
 import clamav.report
 import cnudie.retrieve
 import concourse.util
@@ -63,7 +62,6 @@ import saf.model as sm
 from concourse.model.traits.image_scan import Notify
 
 ${step_lib('scan_container_images')}
-${step_lib('images')}
 ${step_lib('component_descriptor_util')}
 
 cfg_factory = ci.util.ctx().cfg_factory()

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -97,12 +97,6 @@ def print_protecode_info_table(
     protecode_group_id: int,
     reference_protecode_group_ids: typing.List[int],
     cvss_version: pm.CVSSVersion,
-    include_image_references: typing.List[str],
-    exclude_image_references: typing.List[str],
-    include_image_names: typing.List[str],
-    exclude_image_names: typing.List[str],
-    include_component_names: typing.List[str],
-    exclude_component_names: typing.List[str],
 ):
     headers = ('Protecode Scan Configuration', '')
     entries = (
@@ -110,12 +104,6 @@ def print_protecode_info_table(
         ('Protecode group URL', protecode_group_url),
         ('Protecode reference group IDs', reference_protecode_group_ids),
         ('Used CVSS version', cvss_version.value),
-        ('Image reference filter (include)', include_image_references),
-        ('Image reference filter (exclude)', exclude_image_references),
-        ('Image name filter (include)', include_image_names),
-        ('Image name filter (exclude)', exclude_image_names),
-        ('Component name filter (include)', include_component_names),
-        ('Component name filter (exclude)', exclude_component_names),
     )
     print(tabulate.tabulate(entries, headers=headers))
 

--- a/test/concourse/model/traits/filter_test.py
+++ b/test/concourse/model/traits/filter_test.py
@@ -1,0 +1,201 @@
+import dataclasses
+
+import pytest
+
+import concourse.model.traits.filter as examinee
+
+
+# Dummy dataclass for testing.
+# We could also test using dicts, but since the actual objects the filter will be applied to
+# will usually be dataclasses, use this simple dataclass instead.
+# We could of course also test using the actual gci.componentmodel classes, but that would expose
+# the test to changes in the model.
+@dataclasses.dataclass
+class Dummy:
+    name: str
+
+
+class TestMatchingFilter:
+    def test_unspecific_target_fails(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='Name',
+                    expression='TestComponent',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+        component_dummy = Dummy(name='TestComponent')
+        with pytest.raises(ValueError):
+            test_filter(component_dummy, None)
+
+    def test_component_attr_included(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='component.name',
+                    expression='TestComponent',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        component_dummy = Dummy(name='TestComponent')
+        assert test_filter(component_dummy, None)
+
+        component_dummy = Dummy(name='AnotherName')
+        assert not test_filter(component_dummy, None)
+
+    def test_component_attr_excluded(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='component.name',
+                    expression='TestComponent',
+                    matching_semantics=examinee.ComponentFilterSemantics('exclude'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        component_dummy = Dummy(name='AnotherName')
+        assert test_filter(component_dummy, None)
+
+        component_dummy = Dummy(name='TestComponent')
+        assert not test_filter(component_dummy, None)
+
+    def test_resource_attr_included(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='resource.name',
+                    expression='TestResource',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        resource_dummy = Dummy(name='TestResource')
+        assert test_filter(None, resource_dummy)
+
+        resource_dummy = Dummy(name='AnotherName')
+        assert not test_filter(None, resource_dummy)
+
+    def test_resource_attr_excluded(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='resource.name',
+                    expression='TestResource',
+                    matching_semantics=examinee.ComponentFilterSemantics('exclude'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        resource_dummy = Dummy(name='AnotherName')
+        assert test_filter(None, resource_dummy)
+
+        resource_dummy = Dummy(name='TestResource')
+        assert not test_filter(None, resource_dummy)
+
+    def test_multiple_component_rules(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='component.name',
+                    expression='AName',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                ),
+                examinee.ConfigRule(
+                    target='component.name',
+                    expression='AnotherName',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        component_dummy = Dummy(name='AName')
+        assert test_filter(component_dummy, None)
+
+        component_dummy = Dummy(name='AnotherName')
+        assert test_filter(component_dummy, None)
+
+        component_dummy = Dummy(name='YetAnotherName')
+        assert not test_filter(component_dummy, None)
+
+    def test_multiple_resource_rules(self):
+        test_config = examinee.MatchingConfig(
+            name='Some Config Name',
+            rules=[
+                examinee.ConfigRule(
+                    target='resource.name',
+                    expression='AName',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                ),
+                examinee.ConfigRule(
+                    target='resource.name',
+                    expression='AnotherName',
+                    matching_semantics=examinee.ComponentFilterSemantics('include'),
+                )
+            ]
+        )
+        test_filter = examinee.filter_for_matching_config(test_config)
+
+        resource_dummy = Dummy(name='AName')
+        assert test_filter(None, resource_dummy)
+
+        resource_dummy = Dummy(name='AnotherName')
+        assert test_filter(None, resource_dummy)
+
+        resource_dummy = Dummy(name='YetAnotherName')
+        assert not test_filter(None, resource_dummy)
+
+    def test_multiple_configs(self):
+        test_configs = [
+            examinee.MatchingConfig(
+                name='Some Config Name',
+                rules=[
+                    examinee.ConfigRule(
+                        target='component.name',
+                        expression='ComponentName',
+                        matching_semantics=examinee.ComponentFilterSemantics('include'),
+                    ),
+                ]
+            ),
+            examinee.MatchingConfig(
+                name='Another Config Name',
+                rules=[
+                    examinee.ConfigRule(
+                        target='resource.name',
+                        expression='ResourceName',
+                        matching_semantics=examinee.ComponentFilterSemantics('include'),
+                    )
+                ]
+            ),
+        ]
+        test_filter = examinee.filter_for_matching_configs(test_configs)
+
+        matching_component_dummy = Dummy(name='ComponentName')
+        matching_resource_dummy = Dummy(name='ResourceName')
+
+        assert test_filter(matching_component_dummy, matching_resource_dummy)
+
+        resource_dummy = Dummy(name='AnotherResource')
+        assert not test_filter(matching_component_dummy, resource_dummy)
+
+        component_dummy = Dummy(name='AnotherComponent')
+        assert not test_filter(component_dummy, matching_resource_dummy)
+
+        assert not test_filter(component_dummy, resource_dummy)


### PR DESCRIPTION
This PR generalises filtering by adding support for paths in the component's (or resources') descriptor that can be filtered using a regular expression.

An example for a filter config would be:

```yaml
  name: component_name_starts_with_foo # arbitrary
  rules:
  - target: component.name
    expression: "^foo.*"
    matching_semantics: include # include|exclude
```

The first part of the `target` will be used to determine what to check against. If the target starts with `resource`, the expression will be checked against resources in the component descriptor, e.g.:

```yaml
  name: resource_name_starts_with_foo
  rules:
  - target: resource.name
    expression: "^foo.*"
    matching_semantics: include
```

A single config may contain multiple rules. In that case, the rules will be combined using a logical `or` when filtering. The following example would include components whose name starts with `foo` or `bar`:

```yaml
  name: foo_or_bar
  rules:
  - target: component.name
    expression: "^foo.*"
    matching_semantics: include
  - target: component.name
    expression: "^bar.*"
    matching_semantics: include
```

If multiple configs are given, they will be combined using the logical `and`, i.e. a component or resource matches iff it matches all configs.

```yaml
matching_config:
- name: component_version_does_not_start_with_1
  rules:
  - target: component.version
    expression: '^1\..*'
    matching_semantics: exclude
- name: resource_name_starts_with_bar
  rules:
  - target: resource.name
    expression: "^bar.*"
    matching_semantics: include
```

**Special notes for your reviewer**:
No backwards compatibility included - we will need to adjust the image-scanning jobs when we merge this.

