### PR TITLE
Factor out `find_branch_info`

### DIFF
--- a/concourse/steps/os_id.py
+++ b/concourse/steps/os_id.py
@@ -11,6 +11,7 @@ import gci.componentmodel as cm
 import ci.log
 import ci.util
 import delivery.client
+import delivery.model
 import dso.model as dm
 import github.compliance.model as gcm
 import github.compliance.issue as gciss
@@ -77,6 +78,40 @@ def base_image_os_id(
     )
 
 
+def find_branch_info(
+    os_id: um.OperatingSystemId,
+    os_infos: list[delivery.model.OsReleaseInfo],
+) -> delivery.model.OsReleaseInfo:
+    if not os_id.ID:
+        return None # os-id could not be determined
+
+    os_version = os_id.VERSION_ID
+
+    def version_candidates():
+        yield os_version
+        yield f'v{os_version}'
+
+        parts = os_version.split('.')
+
+        if len(parts) == 1:
+            return
+
+        yield parts[0]
+        yield 'v' + parts[0]
+
+        yield '.'.join(parts[:2]) # strip parts after minor
+        yield 'v' + '.'.join(parts[:2]) # strip parts after minor
+
+    candidates = tuple(version_candidates())
+
+    for os_info in os_infos:
+        for candidate in candidates:
+            if os_info.name == candidate:
+                return os_info
+
+    logger.warning(f'did not find branch-info for {os_id=}')
+
+
 def scan_result_group_collection_for_outdated_os_ids(
     results: tuple[gcm.OsIdScanResult],
     delivery_svc_client: delivery.client.DeliveryServiceClient,
@@ -88,45 +123,21 @@ def scan_result_group_collection_for_outdated_os_ids(
         if (info := delivery_svc_client.os_release_infos(os_id=os_name, absent_ok=True)) is not None
     }
 
-    def find_branch_info(os_id: um.OperatingSystemId) -> delivery.model.OsReleaseInfo:
-        if not os_id.ID:
-            return None # os-id could not be determined
-
-        os_version = os_id.VERSION_ID
-
-        def version_candidates():
-            yield os_version
-            yield f'v{os_version}'
-
-            parts = os_version.split('.')
-
-            if len(parts) == 1:
-                return
-
-            yield parts[0]
-            yield 'v' + parts[0]
-
-            yield '.'.join(parts[:2]) # strip parts after minor
-            yield 'v' + '.'.join(parts[:2]) # strip parts after minor
-
-        candidates = tuple(version_candidates())
-
-        for os_info in os_infos[os_id.ID]:
-            for candidate in candidates:
-                if os_info.name == candidate:
-                    return os_info
-
-        logger.warning(f'did not find branch-info for {os_id=}')
-
     def branch_reached_eol(os_id: um.OperatingSystemId):
-        branch_info = find_branch_info(os_id=os_id)
+        branch_info = find_branch_info(
+            os_id=os_id,
+            os_infos=os_infos[os_id.ID],
+        )
         if not branch_info:
             return False
 
         return branch_info.reached_eol()
 
     def update_available(os_id: um.OperatingSystemId):
-        branch_info = find_branch_info(os_id=os_id)
+        branch_info = find_branch_info(
+            os_id=os_id,
+            os_infos=os_infos[os_id.ID],
+        )
         if not branch_info:
             return False
 

--- a/delivery/util.py
+++ b/delivery/util.py
@@ -1,0 +1,41 @@
+import logging
+
+import delivery.model
+import unixutil.model as um
+
+
+logger = logging.getLogger(__name__)
+
+
+def find_branch_info(
+    os_id: um.OperatingSystemId,
+    os_infos: list[delivery.model.OsReleaseInfo],
+) -> delivery.model.OsReleaseInfo:
+    if not os_id.ID:
+        return None # os-id could not be determined
+
+    os_version = os_id.VERSION_ID
+
+    def version_candidates():
+        yield os_version
+        yield f'v{os_version}'
+
+        parts = os_version.split('.')
+
+        if len(parts) == 1:
+            return
+
+        yield parts[0]
+        yield 'v' + parts[0]
+
+        yield '.'.join(parts[:2]) # strip parts after minor
+        yield 'v' + '.'.join(parts[:2]) # strip parts after minor
+
+    candidates = tuple(version_candidates())
+
+    for os_info in os_infos:
+        for candidate in candidates:
+            if os_info.name == candidate:
+                return os_info
+
+    logger.warning(f'did not find branch-info for {os_id=}')


### PR DESCRIPTION
**What this PR does / why we need it**:
Mv `find_branch_info` from closure to top level.
Alter shadowing `os_infos: list[delivery.model.OsReleaseInfo]` to function parameter.

Small nit:
Added `import delivery.model` as required for typehint integrity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
