### PR TITLE
`write_callback` needs to be defined for #741 to work properly.

### DIFF
--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -18,7 +18,8 @@ legacy_version_file = os.path.join(job_step.output('version_path'), 'number')
 if (read_callback := version_trait.read_callback()):
   read_callback = os.path.join(main_repo.resource_name(), read_callback)
 
-if (write_callback := version_trait.write_callback()):
+# Assign empty string if None, as we'd template 'None' (the string) later otherwise
+if (write_callback := version_trait.write_callback() or ''):
   write_callback = os.path.join(main_repo.resource_name(), write_callback)
 
 version_operation = version_trait._preprocess()
@@ -104,11 +105,12 @@ if os.path.isdir(os.path.join(ci.paths.repo_root, '.git')):
   except:
     pass
 
-if version_interface is version_trait.VersionInterface.CALLBACK and write_callback is not None:
+write_callback = '${write_callback}' ## Either a path or an empty string
+if version_interface is version_trait.VersionInterface.CALLBACK and write_callback:
   write_version(
     version_interface=version_interface,
     version_str=effective_version,
-    path='${write_callback}',
+    path=write_callback,
   )
 elif version_interface is version_trait.VersionInterface.FILE:
   write_version(


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**What this PR does / why we need it**:
Fix change in #741. `write_callback` is not necessarily defined in some cases. Should fix https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-provider-vsphere-csi-driver-release-2.6-fork/jobs/release-2.6-fork-head-update-job/builds/7.

@AndreasBurger Could you give this a review to be sure I didn't miss anything else? I am not a Python coder... thanks!