### PR TITLE
Update SAF Model

### DIFF
--- a/clamav/scan.py
+++ b/clamav/scan.py
@@ -48,7 +48,7 @@ class ResourceScanResult:
 
 
 @dataclasses.dataclass
-class MalwarescanEvidenceRequestV1(saf.model.EvidenceRequestV1):
+class MalwarescanEvidenceRequest(saf.model.EvidenceRequest):
     EvidenceDataBinary: typing.List[ResourceScanResult]
 
 

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -59,9 +59,6 @@ import concourse.util
 import concourse.model.traits.filter
 import dso.model
 import mailutil
-import product.util
-import product.v2
-import protecode.util
 import saf.client
 import saf.model as sm
 
@@ -176,23 +173,24 @@ logger.info('findings and errors are printed on top of table\n')
 
 print(clamav.report.as_table(scan_results=results, tablefmt='fancy_grid'))
 
+evidence_request = prepare_evidence_request(
+  scan_results=results,
+  evidence_id='gardener-mm6',
+  pipeline_url=pipeline_url,
+)
+
+## fall back to default saf-cfg if no config was given explicitly
+if saf_cfg_name := '${saf_cfg_name}':
+  saf_cfg = cfg_factory.saf(saf_cfg_name)
+else:
+  saf_cfg = cfg_set.saf()
+
+saf_client = saf.client.SafClient(saf_cfg=saf_cfg)
+
 try:
   # publish evidence to SAF-API
-  ## fall back to default saf-cfg if no config was given explicitly
-  if saf_cfg_name := '${saf_cfg_name}':
-    saf_cfg = cfg_factory.saf(saf_cfg_name)
-  else:
-    saf_cfg = cfg_set.saf()
-
-  clamav_cfg = cfg_set.clamav('${clam_av.clamav_cfg_name()}')
-  saf_client = saf.client.SafClient(saf_cfg=saf_cfg)
-  evidence_request = prepare_evidence_request(
-    scan_results = results,
-    evidence_id = 'gardener-mm6',
-    pipeline_url = pipeline_url,
-  )
   res = saf_client.post_evidence(evidence=evidence_request)
-  print(f'uploaded evidence to saf-api: {res=}')
+  logger.info(f'uploaded evidence to saf-api: {res=}')
 except requests.exceptions.HTTPError as e:
   logger.warning(f'An exception occurred when uploading the evidence: {e}')
   logger.info(f'Response headers: {e.response.headers}')
@@ -205,11 +203,11 @@ notification_policy = Notify('${image_scan_trait.notify().value}')
 
 
 if notification_policy is Notify.NOBODY:
-  print("Notification policy set to 'nobody', exiting")
+  logger.info("Notification policy set to 'nobody', exiting")
   sys.exit(0)
 
 if notification_policy is not Notify.EMAIL_RECIPIENTS:
-  print('nobody to report to - early-exiting')
+  logger.info('nobody to report to - early-exiting')
   sys.exit(0)
 
 

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -121,6 +121,8 @@ oci_client = ccc.oci.oci_client()
 
 logger.info('running malware scan for all container images')
 
+pipeline_url = concourse.util.own_running_build_url()
+
 results = []
 have_findings = False
 findings_count = 0
@@ -184,19 +186,17 @@ try:
 
   clamav_cfg = cfg_set.clamav('${clam_av.clamav_cfg_name()}')
   saf_client = saf.client.SafClient(saf_cfg=saf_cfg)
-  evidence_rq = clamav.scan.MalwarescanEvidenceRequestV1(
-    meta=sm.EvidenceMetadata(
-      evidence_id='gardener-mm6',
-      collection_date=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
-    ),
-    EvidenceDataBinary=results,
+  evidence_request = prepare_evidence_request(
+    scan_results = results,
+    evidence_id = 'gardener-mm6',
+    pipeline_url = pipeline_url,
   )
-  res = saf_client.post_evidence(evidence=evidence_rq)
+  res = saf_client.post_evidence(evidence=evidence_request)
   print(f'uploaded evidence to saf-api: {res=}')
 except requests.exceptions.HTTPError as e:
   logger.warning(f'An exception occurred when uploading the evidence: {e}')
   logger.info(f'Response headers: {e.response.headers}')
-  dump_malware_scan_request(evidence_rq)
+  dump_malware_scan_request(evidence_request)
 except:
   import traceback
   traceback.print_exc()

--- a/concourse/util.py
+++ b/concourse/util.py
@@ -164,7 +164,7 @@ def _current_concourse_config():
     return ctx().cfg_set().concourse()
 
 
-def own_running_build_url(cfg_factory=None):
+def own_running_build_url(cfg_factory=None) -> str:
     if not _running_on_ci():
         raise RuntimeError('Can only determine own build url if running on CI infrastructure')
 

--- a/saf/client.py
+++ b/saf/client.py
@@ -29,7 +29,7 @@ class SafClient:
 
     def post_evidence(
         self,
-        evidence: typing.Union[saf.model.EvidenceRequestV1, dict],
+        evidence: typing.Union[saf.model.EvidenceRequest, dict],
     ):
         if dataclasses.is_dataclass(evidence):
             raw = dataclasses.asdict(evidence)

--- a/saf/model.py
+++ b/saf/model.py
@@ -1,17 +1,44 @@
 import dataclasses
+import enum
 import typing
 
 
-dc = dataclasses.dataclass
+# generic evidence-model
+class TargetType(enum.Enum):
+    OCM_COMPONENT = 'ocm/component'
+    OCM_RESOURCE = 'ocm/resource'
 
 
-@dc
+@dataclasses.dataclass
+class MetadataTarget:
+    id: int
+    type: TargetType
+
+
+@dataclasses.dataclass(kw_only=True)
+class ResourceTarget(MetadataTarget):
+    name: str
+    version: str
+    extra_id: dict | None
+    type: TargetType = TargetType.OCM_RESOURCE
+
+
+@dataclasses.dataclass(kw_only=True)
+class ComponentTarget(MetadataTarget):
+    name: str
+    version: str
+    type: TargetType = TargetType.OCM_COMPONENT
+
+
+@dataclasses.dataclass
 class EvidenceMetadata:
+    pipeline_url: str | None
+    targets: typing.List[MetadataTarget]
     evidence_id: str
     collection_date: str
 
 
-@dc
-class EvidenceRequestV1:
+@dataclasses.dataclass
+class EvidenceRequest:
     meta: EvidenceMetadata
     EvidenceDataBinary: typing.Dict


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces meta-information classes to our SAF Model. As of now, these classes are intended to provide information about the artifacts targeted by whomever uploaded the evidence. 
In accordance with that purpose this PR also updates our malware-scanning to provide meta-information about the scanned resources.

**Special notes for your reviewer**:
I've cleaned up the code a bit where possible. As far as I can tell, none of the attributes supported by the old `MalwarescanEvidenceData` (`pipeline_url`, `component_name`, `component_version`, `scanning_endpoint`, `scanning_cfg`, `scan_results` and `scan_log`) was provided - in fact, the class wasn't used at all. I've removed it and included `pipeline_url` in the new metadata, as that seems like information applicable to all our scans.

No testing done as of yet.
