### PR TITLE
add accept_header method to oci replication mode

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -50,6 +50,16 @@ class ReplicationMode(enum.Enum):
     PREFER_MULTIARCH = 'prefer_multiarch'
     NORMALISE_TO_MULTIARCH = 'normalise_to_multiarch'
 
+    def accept_header(self):
+        if self is ReplicationMode.REGISTRY_DEFAULTS:
+            return None
+        elif self is ReplicationMode.PREFER_MULTIARCH:
+            return om.MimeTypes.prefer_multiarch
+        elif self is ReplicationMode.NORMALISE_TO_MULTIARCH:
+            return om.MimeTypes.prefer_multiarch
+        else:
+            raise NotImplementedError(self)
+
 
 def replicate_artifact(
     src_image_reference: typing.Union[str, om.OciImageReference],
@@ -100,14 +110,7 @@ def replicate_artifact(
     else:
         client = oci_client
 
-    if mode is ReplicationMode.REGISTRY_DEFAULTS:
-        accept = None
-    elif mode is ReplicationMode.PREFER_MULTIARCH:
-        accept = om.MimeTypes.prefer_multiarch
-    elif mode is ReplicationMode.NORMALISE_TO_MULTIARCH:
-        accept = om.MimeTypes.prefer_multiarch
-    else:
-        raise NotImplementedError(mode)
+    accept = mode.accept_header()
 
     # we need the unaltered - manifest for verbatim replication
     raw_manifest = client.manifest_raw(


### PR DESCRIPTION
**What this PR does / why we need it**:
add dedicated method to the oci replication mode struct for getting the correct accept header. this logic is now also needed in the cnudie-transport-tool (see https://github.com/gardener/cnudie-transport-tool/pull/489).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
