### PR TITLE
`product.v2` refactoring

### DIFF
--- a/cli/gardener_ci/cd.py
+++ b/cli/gardener_ci/cd.py
@@ -1,10 +1,8 @@
 import sys
 
-import ccc.oci
+import cnudie.retrieve
 import ctx
 import gci.componentmodel as cm
-import product.v2
-import version
 
 
 def retrieve(
@@ -21,15 +19,12 @@ def retrieve(
             componentNameMapping=cm.OciComponentNameMapping.URL_PATH,
         )
 
-    target_ref = product.v2._target_oci_ref_from_ctx_base_url(
-        component_name=name,
-        component_version=version,
+    component_descriptor = cnudie.retrieve.oci_component_descriptor_lookup()(
+        component_id=cm.ComponentIdentity(
+            name=name,
+            version=version,
+        ),
         ctx_repo=ctx_repo,
-    )
-
-    component_descriptor = product.v2.retrieve_component_descriptor_from_oci_ref(
-        manifest_oci_image_ref=target_ref,
-        absent_ok=False,
     )
 
     if out:
@@ -50,15 +45,15 @@ def ls(
     if not ocm_repo_base_url:
         ocm_repo_base_url = ctx.cfg.ctx.ocm_repo_base_url
 
-    oci_name = product.v2._target_oci_repository_from_component_name(
-        component_name=name,
-        ctx_repo=cm.OciRepositoryContext(
-            baseUrl=ocm_repo_base_url,
-        ),
-    )
-    client = ccc.oci.oci_client()
-    tags = client.tags(image_reference=oci_name)
+    ctx_repo = cm.OciRepositoryContext(baseUrl=ocm_repo_base_url)
+
     if greatest:
-        print(version.greatest_version(tags))
+        print(cnudie.retrieve.greatest_component_version(
+            component_name=name,
+            ctx_repo=ctx_repo,
+        ))
     else:
-        print(tags)
+        print(cnudie.retrieve.component_versions(
+            component_name=name,
+            ctx_repo=ctx_repo,
+        ))

--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -525,6 +525,7 @@ def determine_main_component(
                 ' that matches the main repository')
 
 
+@deprecated.deprecated
 def greatest_component_versions(
     component_name: str,
     ctx_repo: cm.RepositoryContext,

--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -22,7 +22,6 @@ import yaml
 import ci.util
 import cnudie.util
 import cnudie.retrieve
-import product.v2
 
 import gci.componentmodel as cm
 
@@ -107,7 +106,7 @@ def component_diff_since_last_release(
     )
     component: cm.Component
 
-    greatest_release_version = product.v2.greatest_version_before(
+    greatest_release_version = cnudie.retrieve.greatest_version_before(
         component_name=component.name,
         component_version=component.version,
         ctx_repo=component.current_repository_ctx(),

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -72,7 +72,6 @@ import ci.util
 import ci.log
 import github
 import mailutil
-import product.v2
 
 from ci.util import ctx
 
@@ -213,7 +212,7 @@ ctx_repo = cm.OciRepositoryContext(
 
 ## Finally, determine recipients for all component names gathered
 def retr_component(component_name: str):
-  greatest_version = product.v2.greatest_component_version(
+  greatest_version = cnudie.retrieve.greatest_component_version(
     component_name=component_name,
     ctx_repo=ctx_repo,
   )

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -127,7 +127,7 @@ def latest_component_version_from_upstream(
     ctx_repo: gci.componentmodel.OciRepositoryContext,
     ignore_prerelease_versions: bool=False,
 ):
-    upstream_component_version = product.v2.latest_component_version(
+    upstream_component_version = cnudie.retrieve.greatest_component_version(
         component_name=upstream_component_name,
         ctx_repo=ctx_repo,
         ignore_prerelease_versions=ignore_prerelease_versions,
@@ -162,10 +162,10 @@ def determine_reference_versions(
 ) -> typing.Sequence[str]:
     if upstream_component_name is None:
         # no upstream component defined - look for greatest released version
-        latest_component_version = product.v2.greatest_component_version(
-                component_name=component_name,
-                ctx_repo=ctx_repo,
-                ignore_prerelease_versions=ignore_prerelease_versions,
+        latest_component_version = cnudie.retrieve.greatest_component_version(
+            component_name=component_name,
+            ctx_repo=ctx_repo,
+            ignore_prerelease_versions=ignore_prerelease_versions,
         )
         if not latest_component_version:
             raise RuntimeError(
@@ -187,7 +187,7 @@ def determine_reference_versions(
         return (version_candidate,)
 
     elif upstream_update_policy is UpstreamUpdatePolicy.ACCEPT_HOTFIXES:
-        hotfix_candidate = product.v2.greatest_component_version_with_matching_minor(
+        hotfix_candidate = cnudie.retrieve.greatest_component_version_with_matching_minor(
             component_name=component_name,
             ctx_repo=ctx_repo,
             reference_version=reference_version,

--- a/github/release_notes/util.py
+++ b/github/release_notes/util.py
@@ -26,7 +26,6 @@ import ci.log
 import cnudie.retrieve
 import cnudie.util
 import gci.componentmodel
-import product.v2
 import version
 
 from git.exc import GitError
@@ -488,7 +487,7 @@ def create_release_note_block(
             )
             source_component = component_descriptor_lookup(gci.componentmodel.ComponentIdentity(
                 name=source_repo,
-                version=product.v2.greatest_component_version(
+                version=cnudie.retrieve.greatest_component_version(
                     component_name=source_repo,
                     ctx_repo=ctx_repo,
                     ignore_prerelease_versions=True,

--- a/mailutil.py
+++ b/mailutil.py
@@ -19,8 +19,8 @@ import typing
 
 import gci.componentmodel as cm
 
+import cnudie.retrieve
 import cnudie.util
-import product.v2
 from model.email import EmailConfig
 from ci.util import (
     existing_dir,
@@ -261,9 +261,11 @@ def _codeowners_parser_from_component_name(
     ctx_repo_url: str,
     branch_name='master',
 ):
-    component = product.v2.greatest_component_version_by_name(
+    ctx_repo = cm.OciRepositoryContext(baseUrl=ctx_repo_url)
+
+    component = cnudie.retrieve.greatest_component_version_by_name(
         component_name=component_name,
-        ctx_repo_base_url=ctx_repo_url,
+        ctx_repo=ctx_repo,
     )
     return _codeowners_parser_from_component(
         component=component,

--- a/test/concourse/steps/update_component_deps_test.py
+++ b/test/concourse/steps/update_component_deps_test.py
@@ -84,8 +84,8 @@ def test_determine_reference_versions():
         component_name=component_name,
         ctx_repo=ctx_repo,
     )
-    with unittest.mock.patch('product.v2') as product_mock:
-        product_mock.greatest_component_version.return_value = greatest_version
+    with unittest.mock.patch('cnudie.retrieve') as cnudie_retrieve_mock:
+        cnudie_retrieve_mock.greatest_component_version.return_value = greatest_version
 
         # no upstream component -> expect latest version to be returned
         assert examinee(
@@ -93,20 +93,20 @@ def test_determine_reference_versions():
                 upstream_component_name=None,
             ) == (greatest_version,)
 
-        product_mock.greatest_component_version.assert_called_with(
+        cnudie_retrieve_mock.greatest_component_version.assert_called_with(
             component_name=component_name,
             ctx_repo=ctx_repo,
             ignore_prerelease_versions=False,
         )
 
-        product_mock.greatest_component_version.reset_mock()
+        cnudie_retrieve_mock.greatest_component_version.reset_mock()
 
         assert examinee(
                 reference_version='2.2.0', # same result, if our version is already greater
                 upstream_component_name=None,
             ) == (greatest_version,)
 
-        product_mock.greatest_component_version.assert_called_with(
+        cnudie_retrieve_mock.greatest_component_version.assert_called_with(
             component_name=component_name,
             ctx_repo=ctx_repo,
             ignore_prerelease_versions=False,
@@ -158,11 +158,11 @@ def test_determine_reference_versions():
 
         upstream_version_mock.reset_mock()
 
-        with unittest.mock.patch('product.v2') as product_mock:
+        with unittest.mock.patch('cnudie.retrieve') as cnudie_retrieve_mock:
             # if not strictly following, should consider hotfix
             reference_version = '1.2.3'
             upstream_hotfix_version = '2.2.3'
-            product_mock.greatest_component_version_with_matching_minor.return_value = \
+            cnudie_retrieve_mock.greatest_component_version_with_matching_minor.return_value = \
                 upstream_hotfix_version
 
             assert examinee(
@@ -176,7 +176,8 @@ def test_determine_reference_versions():
                 ctx_repo=ctx_repo,
                 ignore_prerelease_versions=False,
             )
-            product_mock.greatest_component_version_with_matching_minor.assert_called_once_with(
+            cnudie_retrieve_mock.greatest_component_version_with_matching_minor.\
+                assert_called_once_with(
                 component_name=component_name,
                 ctx_repo=ctx_repo,
                 reference_version=reference_version,


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves and adjusts component version retrievals from `product.v2` to `cnudie.retrieve`.
Also, replaces `product.v2` occurrences in CC-Utils with their respective counterpart from `cnudie.retrieve` where it is possible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
