### PR TITLE
Raise `OciImageNotFoundException` again instead of returning `None`

### DIFF
--- a/cnudie/retrieve.py
+++ b/cnudie/retrieve.py
@@ -20,6 +20,7 @@ import ci.util
 import cnudie.util
 import ctx
 import oci.client as oc
+import oci.model as om
 import version
 
 
@@ -196,6 +197,7 @@ def delivery_service_component_descriptor_lookup(
     def lookup(
         component_id: cm.ComponentIdentity,
         ctx_repo: cm.RepositoryContext=default_ctx_repo,
+        absent_ok=False,
     ):
         if not ctx_repo:
             raise ValueError(ctx_repo)
@@ -214,7 +216,9 @@ def delivery_service_component_descriptor_lookup(
             traceback.print_exc()
 
         # component descriptor not found in lookup
-        return None
+        if absent_ok:
+            return None
+        raise om.OciImageNotFoundException
 
     return lookup
 
@@ -238,6 +242,7 @@ def oci_component_descriptor_lookup(
     def lookup(
         component_id: cm.ComponentIdentity,
         ctx_repo: cm.RepositoryContext=default_ctx_repo,
+        absent_ok=False,
     ):
         if not ctx_repo:
             raise ValueError(ctx_repo)
@@ -258,9 +263,11 @@ def oci_component_descriptor_lookup(
             absent_ok=True,
         )
 
-        if not manifest:
-            # component descriptor not found in lookup
+        # check if component descriptor not found in lookup
+        if not manifest and absent_ok:
             return None
+        elif not manifest:
+            raise om.OciImageNotFoundException
 
         try:
             cfg_dict = json.loads(
@@ -323,19 +330,29 @@ def composite_component_descriptor_lookup(
     def lookup(
         component_id: cm.ComponentIdentity,
         ctx_repo: cm.RepositoryContext=default_ctx_repo,
+        absent_ok=False,
     ):
         writebacks = []
         for lookup in lookups:
-            if ctx_repo:
-                res = lookup(component_id, ctx_repo)
-            else:
-                res = lookup(component_id)
+            res = None
+            try:
+                if ctx_repo:
+                    res = lookup(component_id, ctx_repo)
+                else:
+                    res = lookup(component_id)
+            except om.OciImageNotFoundException:
+                pass
 
             if isinstance(res, cm.ComponentDescriptor):
                 for wb in writebacks: wb(component_id, res)
                 return res
             elif res is None: continue
             elif isinstance(res, WriteBack): writebacks.append(res)
+
+        # component descriptor not found in lookup
+        if absent_ok:
+            return None
+        raise om.OciImageNotFoundException
 
     return lookup
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The component descriptor lookup logic introduced in `a0d141cf62d3c42bf97e704c4a5e4330f4c40a5d` did not raise an `OciImageNotFoundException` but returned `None` in case no image was found.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
