### PR TITLE
UnboundLocalError: local variable 'issue' referenced before assignment

### DIFF
--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -457,15 +457,16 @@ def create_or_update_github_issues(
                             break
                     else:
                         issue.create_comment(comment_body)
+
+                logger.info(
+                    f'updated gh-issue for {component.name=} {artifact.name=} '
+                    f'{issue_type=}: {issue.html_url=}'
+                )
             except github3.exceptions.GitHubError as ghe:
                 err_count += 1
                 logger.warning('error whilst trying to create or update issue - will keep going')
                 logger.warning(f'error: {ghe} {ghe.code=} {ghe.message=}')
 
-            logger.info(
-                f'updated gh-issue for {component.name=} {artifact.name=} '
-                f'{issue_type=}: {issue.html_url=}'
-            )
         else:
             raise NotImplementedError(action)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
log entry was outside try block where issues variable was assigned

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see error in https://concourse.ci.gardener.cloud.sap/teams/landscaper-dev/pipelines/landscaper-dev-jobs-main/jobs/main-checkmarx_scan-job/builds/27

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
