### PR TITLE
Make WHD Auto-Labeling more configurable

### DIFF
--- a/github/util.py
+++ b/github/util.py
@@ -674,6 +674,23 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         organization = self.github.organization(organization_name)
         return organization.is_member(user_login)
 
+    def is_team_member(self, team_name, user_login) -> bool:
+        '''Returns a bool indicating team-membership to the given team for the given user-login
+
+        The team-name is expected in the format `<org-name>/<team-name>`.
+        Note: If the team cannot be seen by the user used for the lookup or does not exist `False`
+        will be returned.
+        '''
+        o, t = team_name.split('/')
+        org = self.github.organization(o)
+        try:
+            team = org.team_by_name(t)
+            team.membership_for(user_login)
+        except github3.exceptions.NotFoundError:
+            return False
+        else:
+            return True
+
     def delete_outdated_draft_releases(self) -> Iterable[Tuple[github3.repos.release.Release, bool]]:
         '''Find outdated draft releases and try to delete them
 

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -575,10 +575,10 @@ class JobMapping(NamedModelElement):
 
         return False
 
-    '''
-        when set the secrets replication pipline will be rendered into the defined team
-    '''
     def secrets_replication_pipeline_target_cc_team_cfg_name(self) -> typing.Optional[str]:
+        '''
+            when set the secrets replication pipline will be rendered into the defined team
+        '''
         return self.raw.get('secrets_replication_pipeline_target_cc_team_cfg_name')
 
     def unpause_new_pipelines(self) -> bool:

--- a/model/concourse.py
+++ b/model/concourse.py
@@ -599,6 +599,12 @@ class JobMapping(NamedModelElement):
         '''
         return self.raw.get('expose_pipelines', True)
 
+    def trusted_teams(self) -> typing.Iterable[str]:
+        '''Pull requests created/synchronized by members of this team will automatically have
+        the required label set by the webhook-dispatcher
+        '''
+        return self.raw.get('trusted_teams', [])
+
     def _required_attributes(self):
         return [
             'concourse_target_team',
@@ -612,6 +618,7 @@ class JobMapping(NamedModelElement):
             'secret_cfg',
             'secrets_replication_pipeline_target_cc_team_cfg_name',
             'secrets_repo',
+            'trusted_teams',
             'unpause_deployed_pipelines',
             'unpause_new_pipelines',
         ]


### PR DESCRIPTION
**What this PR does / why we need it**:
in addition to org-membership, the webhook-dispatcher may now check for membership in special teams to determine whether required labels should be set automatically.
The teams that should be considered trustworthy can be configured on a per-job-mapping basis.