### PR TITLE
Update docker.py

### DIFF
--- a/cli/gardener_ci/docker.py
+++ b/cli/gardener_ci/docker.py
@@ -6,13 +6,13 @@ import oci.auth as oa
 
 def cfg(
     image_ref_prefixes: [str],
-    privileges='readwrite',
+    privileges: str ='readwrite',
 ):
     cfgs = set()
     if privileges == 'readwrite':
         privileges = oa.Privileges.READWRITE
     elif privileges in ('readonly', 'read'):
-        privileges == oa.Privileges.READONLY
+        privileges = oa.Privileges.READONLY
     else:
         raise ValueError(privileges)
 


### PR DESCRIPTION
Fix bug and expose privileges as a flag

**What this PR does / why we need it**:
Does not support us using `cli.py docker cfg` with privilege flag and there is a bug if it were to use readonly. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We work internally at SAP NS2 and need this to deploy gardener in a pipeline successfully

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: docker cfg 
Possible values:
- privileges:      string
-->

