### PR TITLE
Support email-configs referring to aws-configs

### DIFF
--- a/.ci/lint
+++ b/.ci/lint
@@ -10,6 +10,10 @@ error=0
 
 export PYTHONPATH="${src_dir}"
 
+# ensure that all required packages are installed (useful for PRs)
+echo "Making sure that packages are installed ..."
+pip3 install -r "${src_dir}/requirements.txt" --quiet
+
 echo 'running pylama for all modules (errors only)'
 (
     pushd "${src_dir}"

--- a/.ci/test
+++ b/.ci/test
@@ -7,14 +7,15 @@ if ! which pytest &>/dev/null; then
   exit 1
 fi
 
-# HACK: install awesomeversion to fix unittests until next release -> remove again
-pip3 install awesomeversion
-
 # usage: $1: <src-dir>
 
 src_dir="${1:-"$(readlink -f "$(dirname "${0}")/..")"}"
 
 export PYTHONPATH="${src_dir}:${src_dir}/cli/gardener_ci:${PYTHONPATH:-}"
+
+# ensure that all required packages are installed (useful for PRs)
+echo "Making sure that packages are installed ..."
+pip3 install -r "${src_dir}/requirements.txt" --quiet
 
 if pytest "${src_dir}" "${@}"; then
     echo 'Unittest executions succeeded'

--- a/cfg_mgmt/alicloud.py
+++ b/cfg_mgmt/alicloud.py
@@ -1,0 +1,146 @@
+import copy
+import dataclasses
+import datetime
+import dateutil.parser
+import json
+import logging
+import typing
+
+import dacite
+import aliyunsdkcore.client
+from  aliyunsdkram.request.v20150501.ListAccessKeysRequest import ListAccessKeysRequest
+from  aliyunsdkram.request.v20150501.CreateAccessKeyRequest import CreateAccessKeyRequest
+from  aliyunsdkram.request.v20150501.DeleteAccessKeyRequest import DeleteAccessKeyRequest
+from  aliyunsdkram.request.v20150501.UpdateAccessKeyRequest import UpdateAccessKeyRequest
+
+import cfg_mgmt
+import ci.log
+import model
+import model.aws
+import model.alicloud
+
+from cfg_mgmt.model import CfgQueueEntry
+
+
+logger = logging.getLogger(__name__)
+ci.log.configure_default_logging()
+
+
+@dataclasses.dataclass
+class AlicloudAccessKey:
+    AccessKeyId: str
+    Status: str
+    AccessKeySecret: str
+    CreateDate: datetime.datetime
+
+    def __post_init__(self):
+        self.CreateDate = dateutil.parser.isoparse(self.CreateDate)
+
+
+@dataclasses.dataclass
+class AccessKeyMetadata:
+    AccessKeyId: str
+    Status: str
+    CreateDate: datetime.datetime
+
+    def __post_init__(self):
+        self.CreateDate = dateutil.parser.isoparse(self.CreateDate)
+
+
+@dataclasses.dataclass
+class CreateAccessKeyResponse:
+    AccessKey: AlicloudAccessKey
+    RequestId: str
+
+
+@dataclasses.dataclass
+class AccessKeysEnumeration:
+    AccessKey: typing.List[AccessKeyMetadata]
+
+
+@dataclasses.dataclass
+class ListAccessKeysResponse:
+    RequestId: str
+    AccessKeys: AccessKeysEnumeration
+
+
+def rotate_cfg_element(
+    cfg_element: model.alicloud.AlicloudConfig,
+    cfg_factory: model.ConfigFactory,
+) ->  typing.Tuple[cfg_mgmt.revert_function, dict, model.NamedModelElement]:
+
+    client = aliyunsdkcore.client.AcsClient(
+        ak=cfg_element.access_key_id(),
+        secret=cfg_element.access_key_secret(),
+    )
+
+    # If no parameters are set on the request, the user whose access key is used will be used
+    request = ListAccessKeysRequest()
+    response = client.do_action_with_exception(request)
+
+    response: ListAccessKeysResponse = dacite.from_dict(
+        data_class=ListAccessKeysResponse,
+        data=json.loads(response),
+        config=dacite.Config(check_types=False),
+    )
+
+    access_keys = response.AccessKeys.AccessKey
+
+    # We either have one or two access keys as Alicloud does not allow more than two and we used one
+    # to get access. For the first case just create a new one. If there are already two, determine
+    # the oldest key and delete it beforehand.
+    # Note: This cannot be undone.
+    if len(access_keys) == 2:
+        logger.info('There are already two SecretAccessKeys present. Deleting oldest key ...')
+        sorted_metadata = sorted(access_keys, key=lambda m: m.CreateDate)
+        oldest_key_id = sorted_metadata[0].AccessKeyId
+        request = DeleteAccessKeyRequest()
+        request.set_UserAccessKeyId(oldest_key_id)
+        client.do_action_with_exception(request)
+
+        logger.info(f'Deleted SecretAccessKey {oldest_key_id}')
+
+    request = CreateAccessKeyRequest()
+    response = client.do_action_with_exception(request)
+
+    response: CreateAccessKeyResponse = dacite.from_dict(
+        data_class=CreateAccessKeyResponse,
+        data=json.loads(response),
+        config=dacite.Config(check_types=False),
+    )
+    access_key = response.AccessKey
+
+    raw_cfg = copy.deepcopy(cfg_element.raw)
+    new_element = model.alicloud.AlicloudConfig(
+        name=cfg_element.name(), raw_dict=raw_cfg, type_name=cfg_element._type_name
+    )
+    new_element.raw['access_key_id'] = access_key.AccessKeyId
+    new_element.raw['access_key_secret'] = access_key.AccessKeySecret
+
+    def revert_function():
+        request = DeleteAccessKeyRequest()
+        request.set_UserAccessKeyId(access_key.AccessKeyId)
+        client.do_action_with_exception(request)
+
+    secret_id = {'accessKeyId': cfg_element.access_key_id()}
+
+    return revert_function, secret_id, new_element
+
+
+def delete_config_secret(
+    cfg_element: model.aws.AwsProfile,
+    cfg_factory: model.ConfigFactory,
+    cfg_queue_entry: CfgQueueEntry,
+):
+    client = aliyunsdkcore.client.AcsClient(
+        ak=cfg_element.access_key_id(),
+        secret=cfg_element.access_key_secret(),
+    )
+    access_key_id = cfg_queue_entry.secretId['accessKeyId']
+
+    # deactivate key instead of deleting it to make manual recovery possible.
+    request = UpdateAccessKeyRequest()
+    request.set_UserAccessKeyId(access_key_id)
+    request.set_Status('Inactive')
+
+    client.do_action_with_exception(request)

--- a/cfg_mgmt/aws.py
+++ b/cfg_mgmt/aws.py
@@ -1,10 +1,10 @@
-import boto3
 import copy
 import dataclasses
 import datetime
 import logging
 import typing
 
+import boto3
 import dacite
 
 import cfg_mgmt

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -3,6 +3,7 @@ import typing
 
 import cfg_mgmt
 import cfg_mgmt.aws as cmaws
+import cfg_mgmt.alicloud as cmali
 import cfg_mgmt.azure as cma
 import cfg_mgmt.btp_application_certificate as cmbac
 import cfg_mgmt.btp_service_binding as cmb
@@ -52,6 +53,9 @@ def delete_expired_secret(
 
     elif type_name == 'aws':
         delete_func = cmaws.delete_config_secret
+
+    elif type_name == 'alicloud':
+        delete_func = cmali.delete_config_secret
 
     elif type_name == 'kubernetes':
         try:
@@ -134,6 +138,9 @@ def rotate_cfg_element(
 
     elif type_name == 'aws':
         update_secret_function = cmaws.rotate_cfg_element
+
+    elif type_name == 'alicloud':
+        update_secret_function = cmali.rotate_cfg_element
 
     elif type_name == 'kubernetes':
         try:

--- a/model/email.py
+++ b/model/email.py
@@ -12,13 +12,70 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
+import hashlib
+import hmac
 import typing
 
 import reutil
+
+import ctx
 from model.base import (
     BasicCredentials,
     NamedModelElement,
 )
+
+# These values are required to calculate the credentials for AWS SES. Do not change them.
+DATE = "11111111"
+SERVICE = "ses"
+MESSAGE = "SendRawEmail"
+TERMINAL = "aws4_request"
+VERSION = 0x04
+
+
+class EmailCredentials(BasicCredentials):
+    '''
+    Not intended to be instantiated by users of this module
+    '''
+    pass
+
+
+class AwsSesCredentials(EmailCredentials):
+    def aws_config_name(self) -> str:
+        return self.raw['aws_config_name']
+
+    def username(self, cfg_factory=None) -> str:
+        if not cfg_factory:
+            cfg_factory = ctx.cfg_factory()
+        return cfg_factory.aws(self.aws_config_name()).access_key_id()
+
+    def passwd(self, cfg_factory=None) -> str:
+        return self._calculate_ses_key(cfg_factory=cfg_factory)
+
+    def _required_attributes(self):
+        return ['aws_config_name']
+
+    def _calculate_ses_key(self, cfg_factory=None) -> str:
+        if not cfg_factory:
+            cfg_factory = ctx.cfg_factory()
+
+        aws_config = cfg_factory.aws(self.aws_config_name())
+
+        # taken and adjusted from from
+        # https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html
+
+        def sign(key, msg):
+            return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+        signature = sign(("AWS4" + aws_config.secret_access_key()).encode('utf-8'), DATE)
+        signature = sign(signature, aws_config.region())
+        signature = sign(signature, SERVICE)
+        signature = sign(signature, TERMINAL)
+        signature = sign(signature, MESSAGE)
+        signature_and_version = bytes([VERSION]) + signature
+        smtp_password = base64.b64encode(signature_and_version)
+
+        return smtp_password.decode('utf-8')
 
 
 class EmailConfig(NamedModelElement):
@@ -38,8 +95,12 @@ class EmailConfig(NamedModelElement):
     def sender_name(self):
         return self.raw.get('sender_name')
 
-    def credentials(self):
-        return EmailCredentials(self.raw.get('credentials'))
+    def credentials(self) -> EmailCredentials:
+        if credentials := self.raw.get('credentials'):
+            if 'aws_config_name' in credentials:
+                return AwsSesCredentials(credentials)
+
+        return EmailCredentials(credentials)
 
     def has_credentials(self):
         if self.raw.get('credentials'):
@@ -61,10 +122,3 @@ class EmailConfig(NamedModelElement):
         # ensure credentials are valid - validation implicitly happens in the constructor.
         if self.has_credentials():
             self.credentials()
-
-
-class EmailCredentials(BasicCredentials):
-    '''
-    Not intended to be instantiated by users of this module
-    '''
-    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Mako<2.0.0
 Sphinx
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.13
+aliyun-python-sdk-ram==3.2.0
 awesomeversion
 bcrypt<4.0.0
 boto3


### PR DESCRIPTION
Provides drop-in support for using aws-configs instead of username/password credentials in our email-configs.

**Special notes for your reviewer**:
For this iteration, I've kept the observable behaviour the same where possible.
- When `credentials()` is called with absent credentials, exactly the same error is raised as before.
- The returned EmailCredentials' `passwd()` and `username()` functions will use the default ctx-factory when called without args so that no consumer needs to be adjusted. Explicit cfg-factories can be passed, if necessary.

I haven't yet found the license under which the AWS-code-snippet I've used here is published, so we still need to check if there are any problems here. Also, I am not _too_ happy with putting it under `mail.util` but it might have uses outside of our config and we don't have `awsutils` or something like that currently.
