### PR TITLE
Change issue label prefix for ocm artefacts

### DIFF
--- a/github/compliance/issue.py
+++ b/github/compliance/issue.py
@@ -31,7 +31,7 @@ _label_os_outdated = 'os/outdated'
 _label_malware = 'malware/clamav'
 _label_cfg_policy_violation = 'cfg-element/policy-violation'
 
-_label_prefix_ocm_resource = 'ocm/resource'
+_label_prefix_ocm_artefact = 'ocm/artefact'
 _label_prefix_cicd_cfg_element = 'cicd-cfg-element'
 
 
@@ -46,7 +46,7 @@ def prefix_for_element(
     scanned_element: gcm.Target,
 ) -> str:
     if gcm.is_ocm_artefact_node(scanned_element):
-        return _label_prefix_ocm_resource
+        return _label_prefix_ocm_artefact
 
     elif isinstance(scanned_element, cmr.CfgElementStatusReport):
         return _label_prefix_cicd_cfg_element


### PR DESCRIPTION
`ocm/resource` was even used for scanned sources (checkmarx). Instead of introducing an `ocm/source` label prefix, use the more generic `ocm/artefact`.

This will fail to find existing issues with digest label prefix `ocm/resource`, therefore ensure that all labels are patched before rolling out this change.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
