### PR TITLE
Add optional compliance reporting url

### DIFF
--- a/model/concourse.py
+++ b/model/concourse.py
@@ -605,6 +605,13 @@ class JobMapping(NamedModelElement):
         '''
         return self.raw.get('trusted_teams', [])
 
+    def compliance_reporting_repo_url(self) -> str:
+        '''Target repo for compliance issues based on cfg policy violations.
+
+        If not set, reporting will still be active, just the issue generation will be disabled.
+        '''
+        return self.raw.get('compliance_reporting_repo_url', None)
+
     def _required_attributes(self):
         return [
             'concourse_target_team',
@@ -613,6 +620,7 @@ class JobMapping(NamedModelElement):
 
     def _optional_attributes(self):
         return [
+            'compliance_reporting_repo_url',
             'concourse_team_cfg_name',
             'expose_pipelines',
             'secret_cfg',


### PR DESCRIPTION
As existing cfg reporting (during replicate-secrets to Elasticsearch) will be extended by github issues, this optional
attribute is required to configure target per job_mapping // per cfg-repo.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
