### PR TITLE
Add optional explicit configuration of cfg storage

### DIFF
--- a/cfg_mgmt/util.py
+++ b/cfg_mgmt/util.py
@@ -20,7 +20,13 @@ import model
 logger = logging.getLogger(__name__)
 
 
-def generate_cfg_element_status_reports(cfg_dir: str) -> list[cmr.CfgElementStatusReport]:
+def generate_cfg_element_status_reports(
+    cfg_dir: str,
+    element_storage: str | None=None,
+) -> list[cmr.CfgElementStatusReport]:
+    '''
+    If not passed explicitly, the element_storage defaults to cfg_dir.
+    '''
     ci.util.existing_dir(cfg_dir)
 
     cfg_factory = model.ConfigFactory._from_cfg_dir(
@@ -35,6 +41,9 @@ def generate_cfg_element_status_reports(cfg_dir: str) -> list[cmr.CfgElementStat
     statuses = cfg_metadata.statuses
     responsibles = cfg_metadata.responsibles
 
+    if not element_storage:
+        element_storage = cfg_dir
+
     return [
         determine_status(
             element=element,
@@ -42,7 +51,7 @@ def generate_cfg_element_status_reports(cfg_dir: str) -> list[cmr.CfgElementStat
             rules=rules,
             statuses=statuses,
             responsibles=responsibles,
-            element_storage=cfg_dir,
+            element_storage=element_storage,
         ) for element in iter_cfg_elements(cfg_factory=cfg_factory)
     ]
 


### PR DESCRIPTION
Allow cfg storage to differ from local cfg dir.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
