### PR TITLE
Make branch part of the resource identifier

### DIFF
--- a/concourse/model/job.py
+++ b/concourse/model/job.py
@@ -86,12 +86,6 @@ class JobVariant(ModelBase):
 
         return '-'.join(parts)
 
-    def meta_resource_name(self):
-        meta_res = self._resource_registry.resource(
-            ResourceIdentifier(type_name='meta', base_name=self.variant_name)
-        )
-        return meta_res.resource_identifier().name()
-
     def steps(self):
         return self._steps_dict.values()
 

--- a/concourse/model/resources.py
+++ b/concourse/model/resources.py
@@ -42,16 +42,18 @@ class ResourceIdentifier:
         self,
         type_name,
         base_name,
+        branch_name,
         qualifier=None,
         logical_name=None,
     ):
         self._type_name = not_none(type_name)
         self._base_name = not_none(base_name)
+        self._branch_name = not_none(branch_name)
         self._qualifier = qualifier if qualifier else ''
         self._logical_name = logical_name
 
     def name(self):
-        parts = [self._type_name, self._base_name]
+        parts = [self._type_name, self._base_name, self._branch_name]
         if len(self._qualifier) > 0:
             parts.append(self._qualifier)
 
@@ -59,6 +61,9 @@ class ResourceIdentifier:
 
     def base_name(self):
         return self._base_name
+
+    def branch_name(self) -> str:
+        return self._branch_name
 
     def qualifier(self):
         return self._qualifier
@@ -259,14 +264,12 @@ class RepositoryConfig(Resource):
 
         base_name = kwargs['raw_dict']['path'].replace('/', '.')
 
-        # hack: use branch name as qualifier to support referencing the same repo
-        #       multiple times (if branch differs)
-        if not qualifier:
-            qualifier = kwargs['raw_dict'].get('branch')
+        branch_name = kwargs['raw_dict'].get('branch')
 
         resource_identifier = ResourceIdentifier(
             type_name=type_name,
             base_name=base_name,
+            branch_name=branch_name,
             qualifier=qualifier,
             logical_name=logical_name
         )
@@ -292,7 +295,7 @@ class RepositoryConfig(Resource):
 
     def resource_name(self):
         # TODO: replace usages with access to resource_id
-        return self._resource_identifier.name() + '.' + self.branch()
+        return self._resource_identifier.name()
 
     def name(self):
         # TODO: replace usages with access to resource_id

--- a/test/concourse/model/resources_test.py
+++ b/test/concourse/model/resources_test.py
@@ -8,38 +8,103 @@ class ResourceIdentifierTest(unittest.TestCase):
         examinee = ResourceIdentifier
 
         # valid invocations
-        examinee(type_name='foo', base_name='bar', qualifier='qual', logical_name='x')
-        examinee(type_name='foo', base_name='bar', qualifier='qual')
-        examinee(type_name='foo', base_name='bar')
+        examinee(
+            type_name='foo',
+            base_name='bar',
+            branch_name='baz',
+            qualifier='qual',
+            logical_name='x',
+        )
+        examinee(type_name='foo', base_name='bar', branch_name='baz', qualifier='qual')
+        examinee(type_name='foo', base_name='bar', branch_name='baz',)
 
         with self.assertRaises(ValueError):
-            examinee(type_name=None, base_name='x')
+            examinee(type_name=None, base_name='bar', branch_name='baz')
 
         with self.assertRaises(ValueError):
-            examinee(type_name='foo', base_name=None)
+            examinee(type_name='foo', base_name=None, branch_name='baz')
+
+        with self.assertRaises(ValueError):
+            examinee(type_name='foo', base_name='bar', branch_name=None)
 
     def test_ctor(self):
         examinee = ResourceIdentifier
-        result = examinee(type_name='foo', base_name='bar', qualifier='qual', logical_name='x')
+        result = examinee(
+            type_name='foo',
+            base_name='bar',
+            branch_name='baz',
+            qualifier='qual',
+            logical_name='x'
+        )
 
         self.assertEqual(result.type_name(), 'foo')
         self.assertEqual(result.base_name(), 'bar')
+        self.assertEqual(result.branch_name(), 'baz')
         self.assertEqual(result.logical_name(), 'x')
-        self.assertEqual(result.name(), 'foo-bar-qual')
+        self.assertEqual(result.name(), 'foo-bar-baz-qual')
 
-        result = examinee(type_name='foo', base_name='bar', qualifier=None)
+        result = examinee(type_name='foo', base_name='bar', branch_name='baz', qualifier=None)
 
-        self.assertEqual(result.name(), 'foo-bar')
+        self.assertEqual(result.name(), 'foo-bar-baz')
 
     def test_equal(self):
         examinee = ResourceIdentifier
 
-        left = examinee(type_name='type1', base_name='base1', qualifier='qual1')
-        right = examinee(type_name='type1', base_name='base1', qualifier='qual1')
+        left = examinee(
+            type_name='type1', base_name='base1', branch_name='branch1', qualifier='qual1',
+            )
+        right = examinee(
+            type_name='type1', base_name='base1', branch_name='branch1', qualifier='qual1',
+            )
 
         self.assertEqual(left, right)
 
-        self.assertNotEqual(left, examinee(type_name='type2', base_name='base1', qualifier='qual1'))
-        self.assertNotEqual(left, examinee(type_name='type1', base_name='base2', qualifier='qual1'))
-        self.assertNotEqual(left, examinee(type_name='type1', base_name='base1', qualifier='qual2'))
-        self.assertNotEqual(left, examinee(type_name='type1', base_name='base1'))
+        # differs in type_name
+        self.assertNotEqual(
+            left,
+            examinee(
+                type_name='type2',
+                base_name='base1',
+                branch_name='branch1',
+                qualifier='qual1',
+            ),
+        )
+        # differs in base_name
+        self.assertNotEqual(
+            left,
+            examinee(
+                type_name='type1',
+                base_name='base2',
+                branch_name='branch1',
+                qualifier='qual1',
+            ),
+        )
+        # differs in branch_name
+        self.assertNotEqual(
+            left,
+            examinee(
+                type_name='type1',
+                base_name='base1',
+                branch_name='branch2',
+                qualifier='qual1',
+            ),
+        )
+        # differs in qualifier
+        self.assertNotEqual(
+            left,
+            examinee(
+                type_name='type1',
+                base_name='base1',
+                branch_name='branch1',
+                qualifier='qual2',
+            ),
+        )
+        # absent qualifier
+        self.assertNotEqual(
+            left,
+            examinee(
+                type_name='type1',
+                base_name='base1',
+                branch_name='branch1',
+            ),
+        )

--- a/test/concourse/steps/notification_test.py
+++ b/test/concourse/steps/notification_test.py
@@ -42,7 +42,11 @@ class NotificationStepTest(unittest.TestCase):
         )
         self.job_step._notifications_cfg = NotificationCfgSet('default', {}, type_name='cfg_set')
         resource_registry = ResourceRegistry()
-        meta_resource_identifier = ResourceIdentifier(type_name='meta', base_name='a_job')
+        meta_resource_identifier = ResourceIdentifier(
+            type_name='meta',
+            base_name='a_job',
+            branch_name='a_branch',
+        )
         meta_resource = Resource(resource_identifier=meta_resource_identifier, raw_dict={})
         resource_registry.add_resource(meta_resource)
         self.job_variant = JobVariant(


### PR DESCRIPTION
With the old code there is a corner case of two resources having the same identifier even though they are different. This happens if a pipeline def defines put-steps for multiple branches of the same repository. For these resources, the qualifier of the identifier is 'output' and since all other attributes are identical (they differ only in the branch name) a duplicate is detected and one is discarded.
Later on we handle these resources correctly though, resulting in an error when setting the pipeline in Concourse - the resource is present in the task, but not the resources-definitions.
