### PR TITLE
Include metadata about ClamAV in our malware-scan results

### DIFF
--- a/clamav/cnudie.py
+++ b/clamav/cnudie.py
@@ -102,6 +102,7 @@ def scan_resources(
 
 def resource_scan_result_to_artefact_metadata(
     resource_scan_result: clamav.scan.ClamAV_ResourceScanResult,
+    clamav_version_info: clamav.client.ClamAVVersionInfo,
     datasource: str = dso.model.Datasource.CLAMAV,
     datatype: str = dso.model.Datatype.MALWARE,
     creation_date: datetime.datetime = datetime.datetime.now(),
@@ -121,6 +122,11 @@ def resource_scan_result_to_artefact_metadata(
 
     finding = dso.model.MalwareSummary(
         findings=resource_scan_result.scan_result.findings,
+        metadata=dso.model.ClamAVMetadata(
+            clamav_version_str=clamav_version_info.clamav_version_str,
+            signature_version=clamav_version_info.signature_version,
+            virus_definition_timestamp=clamav_version_info.signature_date,
+        )
     )
 
     return dso.model.ArtefactMetadata(

--- a/cli/gardener_ci/_clamav.py
+++ b/cli/gardener_ci/_clamav.py
@@ -38,6 +38,8 @@ def scan_component(
     clamav_client = ccc.clamav.client(url=clamav_url)
     oci_client = ccc.oci.oci_client()
 
+    clamav_version_info = clamav_client.clamav_version_info()
+
     for result in clamav.cnudie.scan_resources(
         resource_nodes=resource_nodes,
         oci_client=oci_client,
@@ -46,6 +48,7 @@ def scan_component(
     ):
         findings_data = clamav.cnudie.resource_scan_result_to_artefact_metadata(
             resource_scan_result=result,
+            clamav_version_info=clamav_version_info,
             datasource=dso.model.Datasource.CLAMAV,
             datatype=dso.model.Datatype.MALWARE,
         )

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -150,6 +150,9 @@ if aws_session:
 else:
   s3_client = None
 
+# Note: this assumes that all k8s-pods have the same clamav-
+# version and that the version does not change during the scan.
+clamav_version_info = clamav_client.clamav_version_info()
 
 for result in clamav.cnudie.scan_resources(
   resource_nodes=resource_nodes,
@@ -162,6 +165,7 @@ for result in clamav.cnudie.scan_resources(
   if delivery_client:
     findings_data = clamav.cnudie.resource_scan_result_to_artefact_metadata(
         resource_scan_result=result,
+        clamav_version_info=clamav_version_info,
         datasource=dso.model.Datasource.CLAMAV,
         datatype=dso.model.Datatype.MALWARE,
     )

--- a/dso/model.py
+++ b/dso/model.py
@@ -72,7 +72,6 @@ class Metadata:
     type: str
     creation_date: datetime.datetime
 
-
 @dataclasses.dataclass(frozen=True)
 class GreatestCVE:
     greatestCvss3Score: float
@@ -113,11 +112,19 @@ class FilesystemPaths:
 
 
 @dataclasses.dataclass(frozen=True)
+class ClamAVMetadata:
+    clamav_version_str: str
+    signature_version: int
+    virus_definition_timestamp: datetime.datetime
+
+
+@dataclasses.dataclass(frozen=True)
 class MalwareSummary:
     '''
     empty list of findings states "no malware found"
     '''
     findings: list[clamav.client.ScanResult]
+    metadata: ClamAVMetadata
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
With this PR our malware scan is made aware of the new `/version`-route on our ClamAV deployment. The available information is fetched and added to the data that is persisted in our delivery-db.

With this information being available in the database, the next step is then to use it to scan only if sufficiently newer virus-definitions are available to reduce scan-frequency.