### PR TITLE
Refactor clamav model

### DIFF
--- a/clamav/cnudie.py
+++ b/clamav/cnudie.py
@@ -10,8 +10,8 @@ import gci.componentmodel as cm
 import ci.log
 import ci.util
 import clamav.client
-import clamav.scan
 import clamav.model
+import clamav.scan
 import cnudie.iter
 import dso.model
 import github.compliance.model
@@ -27,7 +27,7 @@ def scan_resources(
     clamav_client: clamav.client.ClamAVClient,
     s3_client=None,
     max_workers:int = 16,
-) -> typing.Generator[clamav.model.ClamAV_ResourceScanResult, None, None]:
+) -> typing.Generator[clamav.model.ClamAVResourceScanResult, None, None]:
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
 
     def scan_resource(
@@ -74,7 +74,7 @@ def scan_resources(
         )
 
         # pylint: disable=E1123
-        return clamav.model.ClamAV_ResourceScanResult(
+        return clamav.model.ClamAVResourceScanResult(
             scan_result=scan_result,
             scanned_element=cnudie.iter.ResourceNode(
                 path=(component,),
@@ -102,7 +102,7 @@ def scan_resources(
 
 
 def resource_scan_result_to_artefact_metadata(
-    resource_scan_result: clamav.model.ClamAV_ResourceScanResult,
+    resource_scan_result: clamav.model.ClamAVResourceScanResult,
     clamav_version_info: clamav.model.ClamAVVersionInfo,
     datasource: str = dso.model.Datasource.CLAMAV,
     datatype: str = dso.model.Datatype.MALWARE,

--- a/clamav/model.py
+++ b/clamav/model.py
@@ -1,0 +1,97 @@
+import dataclasses
+import datetime
+import enum
+import typing
+
+import gci.componentmodel as cm
+import github.compliance.model as gcm
+import saf.model
+
+
+class ScanStatus(enum.Enum):
+    SCAN_SUCCEEDED = 'scan_succeeded'
+    SCAN_FAILED = 'scan_failed'
+
+
+class MalwareStatus(enum.IntEnum):
+    OK = 0
+    FOUND_MALWARE = 1
+    UNKNOWN = 2
+
+
+@dataclasses.dataclass
+class Meta:
+    scanned_octets: int
+    receive_duration_seconds: float
+    scan_duration_seconds: float
+    scanned_content_digest: str | None = None
+
+
+@dataclasses.dataclass
+class ScanResult:
+    status: ScanStatus
+    details: str
+    malware_status: MalwareStatus
+    meta: typing.Optional[Meta]
+    name: str
+
+
+@dataclasses.dataclass
+class ClamAVVersionInfo:
+    clamav_version_str: str # as returned by clamAV, example: "ClamAV 0.105.1"
+    signature_version: int # seems to increase strictly monotonically by 1 each day
+    signature_date: datetime.datetime
+
+
+class MalwareScanState(enum.Enum):
+    FINISHED_SUCCESSFULLY = 'finished_successfully'
+    FINISHED_WITH_ERRORS = 'finished_with_errors'
+
+
+@dataclasses.dataclass
+class AggregatedScanResult:
+    '''
+    overall (aggregated) scan result for a scanned resource
+    '''
+    resource_url: str
+    name: str
+    malware_status: MalwareStatus
+    findings: typing.Collection[ScanResult] # if empty, there were no findings
+    scan_count: int # amount of scanned files
+    scanned_octets: int
+    scan_duration_seconds: float
+    upload_duration_seconds: float
+
+    def summary(self, fmt:str='html') -> str:
+        if not fmt == 'html':
+            raise NotImplementedError(fmt)
+
+        def details_for_finding(scan_result: ScanResult):
+            return f'<li>{scan_result.name}: {scan_result.details}</li>'
+
+        newline = '\n'
+
+        return f'''\
+          <ul>
+            <li>{self.resource_url}:
+              <ul>{newline.join(("- " + details_for_finding(res) for res in self.findings))}</ul>
+            </li>
+          </ul>
+        '''
+
+
+@dataclasses.dataclass
+class ClamAV_ResourceScanResult(gcm.ScanResult):
+    scan_result: AggregatedScanResult
+
+
+@dataclasses.dataclass
+class MalwarescanEvidenceRequest(saf.model.EvidenceRequest):
+    EvidenceDataBinary: typing.List[ClamAV_ResourceScanResult]
+
+
+@dataclasses.dataclass
+class MalwarescanResult:
+    resource: cm.Resource
+    scan_state: MalwareScanState
+    findings: typing.List[str]

--- a/clamav/model.py
+++ b/clamav/model.py
@@ -81,17 +81,17 @@ class AggregatedScanResult:
 
 
 @dataclasses.dataclass
-class ClamAV_ResourceScanResult(gcm.ScanResult):
+class ClamAVResourceScanResult(gcm.ScanResult):
     scan_result: AggregatedScanResult
 
 
 @dataclasses.dataclass
-class MalwarescanEvidenceRequest(saf.model.EvidenceRequest):
-    EvidenceDataBinary: typing.List[ClamAV_ResourceScanResult]
+class MalwareScanEvidenceRequest(saf.model.EvidenceRequest):
+    EvidenceDataBinary: typing.List[ClamAVResourceScanResult]
 
 
 @dataclasses.dataclass
-class MalwarescanResult:
+class MalwareScanResult:
     resource: cm.Resource
     scan_state: MalwareScanState
     findings: typing.List[str]

--- a/clamav/report.py
+++ b/clamav/report.py
@@ -7,12 +7,12 @@ import github.compliance.model
 
 
 def as_table(
-    scan_results: typing.Iterable[clamav.model.ClamAV_ResourceScanResult],
+    scan_results: typing.Iterable[clamav.model.ClamAVResourceScanResult],
     tablefmt: str='simple', # see tabulate module
 ):
     headers = ('resource', 'status', 'details')
 
-    def row_from_result(scan_result: clamav.model.ClamAV_ResourceScanResult):
+    def row_from_result(scan_result: clamav.model.ClamAVResourceScanResult):
         c = scan_result.scanned_element.component
         a = github.compliance.model.artifact_from_node(scan_result.scanned_element)
         resource = f'{c.name}:{c.version}/{a.name}:{a.version}'

--- a/clamav/report.py
+++ b/clamav/report.py
@@ -2,18 +2,17 @@ import typing
 
 import tabulate
 
-import clamav.client
-import clamav.scan
+import clamav.model
 import github.compliance.model
 
 
 def as_table(
-    scan_results: typing.Iterable[clamav.scan.ClamAV_ResourceScanResult],
+    scan_results: typing.Iterable[clamav.model.ClamAV_ResourceScanResult],
     tablefmt: str='simple', # see tabulate module
 ):
     headers = ('resource', 'status', 'details')
 
-    def row_from_result(scan_result: clamav.scan.ClamAV_ResourceScanResult):
+    def row_from_result(scan_result: clamav.model.ClamAV_ResourceScanResult):
         c = scan_result.scanned_element.component
         a = github.compliance.model.artifact_from_node(scan_result.scanned_element)
         resource = f'{c.name}:{c.version}/{a.name}:{a.version}'
@@ -21,11 +20,11 @@ def as_table(
 
         status = res.malware_status
 
-        if status is clamav.client.MalwareStatus.OK:
+        if status is clamav.model.MalwareStatus.OK:
             details = 'no malware found'
-        elif status is clamav.client.MalwareStatus.UNKNOWN:
+        elif status is clamav.model.MalwareStatus.UNKNOWN:
             details = 'failed to scan'
-        elif status is clamav.client.MalwareStatus.FOUND_MALWARE:
+        elif status is clamav.model.MalwareStatus.FOUND_MALWARE:
             details = '\n'.join((
                 f'{finding.name}: {finding.details}' for finding in res.findings
             ))

--- a/clamav/util.py
+++ b/clamav/util.py
@@ -12,7 +12,7 @@ import requests.exceptions
 import ccc.oci
 import clamav.client
 import clamav.cnudie
-import clamav.scan
+import clamav.model
 import gci.componentmodel
 import oci.client as oc
 import oci.model as om
@@ -76,7 +76,7 @@ def _scan_oci_image(
     clamav_client: clamav.client.ClamAVClient,
     oci_client: oc.Client,
     image_reference: str,
-) -> typing.Generator[clamav.scan.MalwarescanResult, None, None]:
+) -> typing.Generator[clamav.model.MalwarescanResult, None, None]:
     start_time = datetime.datetime.now()
     logger.info(f'starting to scan {image_reference=}')
 
@@ -130,9 +130,9 @@ def _try_scan_image(
             image_reference=access.imageReference,
         )
 
-        return clamav.scan.MalwarescanResult(
+        return clamav.model.MalwarescanResult(
                 resource=oci_resource,
-                scan_state=clamav.scan.MalwareScanState.FINISHED_SUCCESSFULLY,
+                scan_state=clamav.model.MalwareScanState.FINISHED_SUCCESSFULLY,
                 findings=[
                     f'{path}: {scan_result.virus_signature()}'
                     for scan_result, path in clamav_findings
@@ -144,9 +144,9 @@ def _try_scan_image(
         logger.warning(warning)
         traceback.print_exc()
 
-        return clamav.scan.MalwarescanResult(
+        return clamav.model.MalwarescanResult(
                 resource=oci_resource,
-                scan_state=clamav.scan.MalwareScanState.FINISHED_WITH_ERRORS,
+                scan_state=clamav.model.MalwareScanState.FINISHED_WITH_ERRORS,
                 findings=[warning],
             )
 
@@ -157,7 +157,7 @@ def virus_scan_images(
     clamav_client: clamav.client.ClamAVClient,
     oci_client: oc.Client=None,
     max_workers=8,
-) -> typing.Generator[clamav.scan.MalwarescanResult, None, None]:
+) -> typing.Generator[clamav.model.MalwarescanResult, None, None]:
     '''Scans components of the given Component Descriptor using ClamAV
 
     Used by image-scan-trait

--- a/clamav/util.py
+++ b/clamav/util.py
@@ -76,7 +76,7 @@ def _scan_oci_image(
     clamav_client: clamav.client.ClamAVClient,
     oci_client: oc.Client,
     image_reference: str,
-) -> typing.Generator[clamav.model.MalwarescanResult, None, None]:
+) -> typing.Generator[clamav.model.MalwareScanResult, None, None]:
     start_time = datetime.datetime.now()
     logger.info(f'starting to scan {image_reference=}')
 
@@ -130,7 +130,7 @@ def _try_scan_image(
             image_reference=access.imageReference,
         )
 
-        return clamav.model.MalwarescanResult(
+        return clamav.model.MalwareScanResult(
                 resource=oci_resource,
                 scan_state=clamav.model.MalwareScanState.FINISHED_SUCCESSFULLY,
                 findings=[
@@ -144,7 +144,7 @@ def _try_scan_image(
         logger.warning(warning)
         traceback.print_exc()
 
-        return clamav.model.MalwarescanResult(
+        return clamav.model.MalwareScanResult(
                 resource=oci_resource,
                 scan_state=clamav.model.MalwareScanState.FINISHED_WITH_ERRORS,
                 findings=[warning],
@@ -157,7 +157,7 @@ def virus_scan_images(
     clamav_client: clamav.client.ClamAVClient,
     oci_client: oc.Client=None,
     max_workers=8,
-) -> typing.Generator[clamav.model.MalwarescanResult, None, None]:
+) -> typing.Generator[clamav.model.MalwareScanResult, None, None]:
     '''Scans components of the given Component Descriptor using ClamAV
 
     Used by image-scan-trait

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -62,10 +62,9 @@ import ccc.delivery
 import ccc.github
 import ccc.oci
 import ci.util
-import clamav.client
 import clamav.cnudie
+import clamav.model
 import clamav.report
-import clamav.scan
 import cnudie.retrieve
 import cnudie.iter
 import concourse.util
@@ -174,10 +173,10 @@ for result in clamav.cnudie.scan_resources(
   results.append(result)
   scan_result = result.scan_result
   logger.info(f'{scan_result}')
-  if scan_result.malware_status is clamav.client.MalwareStatus.FOUND_MALWARE:
+  if scan_result.malware_status is clamav.model.MalwareStatus.FOUND_MALWARE:
     have_findings = True
     findings_count += 1
-  elif scan_result.malware_status is clamav.client.MalwareStatus.UNKNOWN:
+  elif scan_result.malware_status is clamav.model.MalwareStatus.UNKNOWN:
     have_errors = True
     err_count += 1
 

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -25,7 +25,7 @@ import tabulate
 
 import clamav.client
 import clamav.cnudie
-import clamav.scan
+import clamav.model
 import cnudie.iter
 import concourse.model.traits.image_scan as image_scan
 import dso.cvss
@@ -121,19 +121,19 @@ def scan_result_group_collection_for_licenses(
 
 
 def scan_result_group_collection_for_malware(
-    results: tuple[clamav.scan.ClamAV_ResourceScanResult],
+    results: tuple[clamav.model.ClamAV_ResourceScanResult],
     rescoring_entries: tuple[image_scan.ClamAVRescoringEntry],
 ):
-    def malware_found(result: clamav.scan.ClamAV_ResourceScanResult):
+    def malware_found(result: clamav.model.ClamAV_ResourceScanResult):
         if not result.scan_succeeded:
             return False
 
-        if result.scan_result.malware_status is clamav.client.MalwareStatus.FOUND_MALWARE:
+        if result.scan_result.malware_status is clamav.model.MalwareStatus.FOUND_MALWARE:
             return True
         else:
             return False
 
-    def rescore(scan_result: clamav.client.ScanResult, default: gcm.Severity):
+    def rescore(scan_result: clamav.model.ScanResult, default: gcm.Severity):
         for entry in rescoring_entries:
             if not entry.digest == scan_result.meta.scanned_content_digest:
                 continue
@@ -145,7 +145,7 @@ def scan_result_group_collection_for_malware(
 
         return default
 
-    def classification_callback(result: clamav.scan.ClamAV_ResourceScanResult):
+    def classification_callback(result: clamav.model.ClamAV_ResourceScanResult):
         if not malware_found(result):
             return None
 
@@ -164,7 +164,7 @@ def scan_result_group_collection_for_malware(
 
         return worst_severity
 
-    def findings_callback(result: clamav.scan.ClamAV_ResourceScanResult):
+    def findings_callback(result: clamav.model.ClamAV_ResourceScanResult):
         if not malware_found(result=result):
             return False
 
@@ -216,10 +216,10 @@ def dump_malware_scan_request(request):
 
 
 def prepare_evidence_request(
-    scan_results: typing.Iterable[clamav.scan.ClamAV_ResourceScanResult],
+    scan_results: typing.Iterable[clamav.model.ClamAV_ResourceScanResult],
     evidence_id: str = 'gardener-mm6',
     pipeline_url: str = None,
-) -> clamav.scan.MalwarescanEvidenceRequest:
+) -> clamav.model.MalwarescanEvidenceRequest:
     '''Prepare an evidence request for the given scan results and return it.
 
     The returned evidence request contains the _actual_ clamav scans as payload (i.e. the contents
@@ -242,7 +242,7 @@ def prepare_evidence_request(
             extra_id=artefact.extraIdentity or None,
         ))
 
-    return clamav.scan.MalwarescanEvidenceRequest(
+    return clamav.model.MalwarescanEvidenceRequest(
         meta=saf.model.EvidenceMetadata(
             pipeline_url=pipeline_url,
             evidence_id=evidence_id,

--- a/concourse/steps/scan_container_images.py
+++ b/concourse/steps/scan_container_images.py
@@ -121,10 +121,10 @@ def scan_result_group_collection_for_licenses(
 
 
 def scan_result_group_collection_for_malware(
-    results: tuple[clamav.model.ClamAV_ResourceScanResult],
+    results: tuple[clamav.model.ClamAVResourceScanResult],
     rescoring_entries: tuple[image_scan.ClamAVRescoringEntry],
 ):
-    def malware_found(result: clamav.model.ClamAV_ResourceScanResult):
+    def malware_found(result: clamav.model.ClamAVResourceScanResult):
         if not result.scan_succeeded:
             return False
 
@@ -145,7 +145,7 @@ def scan_result_group_collection_for_malware(
 
         return default
 
-    def classification_callback(result: clamav.model.ClamAV_ResourceScanResult):
+    def classification_callback(result: clamav.model.ClamAVResourceScanResult):
         if not malware_found(result):
             return None
 
@@ -164,7 +164,7 @@ def scan_result_group_collection_for_malware(
 
         return worst_severity
 
-    def findings_callback(result: clamav.model.ClamAV_ResourceScanResult):
+    def findings_callback(result: clamav.model.ClamAVResourceScanResult):
         if not malware_found(result=result):
             return False
 
@@ -216,10 +216,10 @@ def dump_malware_scan_request(request):
 
 
 def prepare_evidence_request(
-    scan_results: typing.Iterable[clamav.model.ClamAV_ResourceScanResult],
+    scan_results: typing.Iterable[clamav.model.ClamAVResourceScanResult],
     evidence_id: str = 'gardener-mm6',
     pipeline_url: str = None,
-) -> clamav.model.MalwarescanEvidenceRequest:
+) -> clamav.model.MalwareScanEvidenceRequest:
     '''Prepare an evidence request for the given scan results and return it.
 
     The returned evidence request contains the _actual_ clamav scans as payload (i.e. the contents
@@ -242,7 +242,7 @@ def prepare_evidence_request(
             extra_id=artefact.extraIdentity or None,
         ))
 
-    return clamav.model.MalwarescanEvidenceRequest(
+    return clamav.model.MalwareScanEvidenceRequest(
         meta=saf.model.EvidenceMetadata(
             pipeline_url=pipeline_url,
             evidence_id=evidence_id,

--- a/dso/model.py
+++ b/dso/model.py
@@ -3,7 +3,6 @@ import datetime
 
 import gci.componentmodel as cm
 
-import clamav.client
 import dso.labels
 import unixutil.model
 
@@ -123,12 +122,29 @@ class ClamAVMetadata:
     virus_definition_timestamp: datetime.datetime
 
 
+@dataclasses.dataclass
+class MalwareFindingMeta:
+    scanned_octets: int
+    receive_duration_seconds: float
+    scan_duration_seconds: float
+    scanned_content_digest: str | None = None
+
+
+@dataclasses.dataclass
+class MalwareFinding:
+    status: str
+    details: str
+    malware_status: str
+    meta: MalwareFindingMeta | None
+    name: str
+
+
 @dataclasses.dataclass(frozen=True)
 class MalwareSummary:
     '''
     empty list of findings states "no malware found"
     '''
-    findings: list[clamav.client.ScanResult]
+    findings: list[MalwareFinding]
     metadata: ClamAVMetadata
 
 

--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -319,7 +319,7 @@ def _checkmarx_template_vars(
 def _malware_template_vars(
     result_group: gcm.ScanResultGroup,
 ) -> dict:
-    results: tuple[clamav.model.ClamAV_ResourceScanResult] = result_group.results_with_findings
+    results: tuple[clamav.model.ClamAVResourceScanResult] = result_group.results_with_findings
     summary_str = ''.join((
         result.scan_result.summary() for result in results
     )).replace('\n', '')

--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -25,7 +25,7 @@ import checkmarx.model
 import cfg_mgmt.model as cmm
 import cfg_mgmt.reporting as cmr
 import ci.util
-import clamav.scan
+import clamav.model
 import cnudie.util
 import concourse.model.traits.image_scan as image_scan
 import delivery.client
@@ -319,7 +319,7 @@ def _checkmarx_template_vars(
 def _malware_template_vars(
     result_group: gcm.ScanResultGroup,
 ) -> dict:
-    results: tuple[clamav.scan.ClamAV_ResourceScanResult] = result_group.results_with_findings
+    results: tuple[clamav.model.ClamAV_ResourceScanResult] = result_group.results_with_findings
     summary_str = ''.join((
         result.scan_result.summary() for result in results
     )).replace('\n', '')


### PR DESCRIPTION
Move all {data|model}classes we use in the clamav-package to their own module and improve consistency.