### PR TITLE
Adjust ctx module to be compatible with python 3.11

### DIFF
--- a/ctx.py
+++ b/ctx.py
@@ -59,7 +59,7 @@ class CtxCfg:
 
 @dataclasses.dataclass
 class GlobalConfig:
-    ctx: CtxCfg = CtxCfg()
+    ctx: CtxCfg = dataclasses.field(default_factory=CtxCfg)
     terminal: typing.Optional[TerminalCfg] = None
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On python 3.11, multiple tests are failing with:
```
test/model/serialisation_test.py:19: in <module>
    from model import ConfigSetSerialiser as CSS, ConfigFactory
model/__init__.py:19: in <module>
    import ctx
ctx.py:60: in <module>
    @dataclasses.dataclass
/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py:1220: in dataclass
    return wrap(cls)
/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py:1210: in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py:958: in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py:815: in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
E   ValueError: mutable default <class 'ctx.CtxCfg'> for field ctx is not allowed: use default_factory
```

From [Python 3.11 - What's New](https://docs.python.org/3/whatsnew/3.11.html#dataclasses):
>Change field default mutability check, allowing only defaults which are hashable instead of any object which is not an instance of dict, list, or set.

We could also consider freezing `CtxCfg`, but I am not fully aware of this dataclass' semantics.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
