### PR TITLE
Allow skipping of malware scans

### DIFF
--- a/clamav/cnudie.py
+++ b/clamav/cnudie.py
@@ -12,7 +12,11 @@ import ci.util
 import clamav.client
 import clamav.model
 import clamav.scan
+import clamav.util
+import github.compliance.model as gcm
 import cnudie.iter
+import delivery.client
+import delivery.model
 import dso.model
 import github.compliance.model
 import oci.client
@@ -21,21 +25,86 @@ logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 
 
+def _may_reuse_existing_scan_result(
+        resource_node: cnudie.iter.ResourceNode,
+        virus_db_max_age_days: int,
+        delivery_client: delivery.client.DeliveryServiceClient,
+        current_version_info: clamav.model.ClamAVVersionInfo = None,
+) -> bool:
+
+    previous_findings = delivery_client.artefact_metadata_for_resource_node(
+        resource_node=resource_node,
+        types=[dso.model.Datatype.MALWARE],
+    )
+
+    if not (latest_finding := max(
+        previous_findings,
+        default=None,
+        key=lambda f: f.meta.creation_date.astimezone(),
+    )):
+        return False
+
+    if isinstance(latest_finding.data, dict):
+        # In this case the previous scan we have available predates the current dataclasses.
+        # Returning False here results in a rescan which will put a new scan result into
+        # the database if there are any findings.
+        # Also, as an additional safeguard against future errors, we check that no such
+        # supposedly structurally outdated finding was put into the database after this
+        # change was added.
+        cutoff_date = datetime.datetime(year=2023, month=4, day=17)
+        if latest_finding.meta.creation_date > cutoff_date:
+            raise RuntimeError(
+                'Encountered a malware scan result with outdated schema that was created '
+                'after introduction of the new schema.'
+            )
+        return False
+
+    finding_clamav_metadata = latest_finding.data.metadata
+
+    if finding_clamav_metadata.signature_version == current_version_info.signature_version:
+        # No changes to virus signature database version. Safe to skip, as scan would not
+        # discover anything new.
+        return True
+
+    if (
+        current_version_info.signature_date
+        - finding_clamav_metadata.virus_definition_timestamp
+    ).days < virus_db_max_age_days:
+        return True
+
+    return False
+
+
 def scan_resources(
     resource_nodes: typing.Iterable[cnudie.iter.ResourceNode],
+    clamav_version_info: clamav.model.ClamAVVersionInfo,
+    virus_db_max_age_days: int,
     oci_client: oci.client.Client,
     clamav_client: clamav.client.ClamAVClient,
-    clamav_version_info: clamav.model.ClamAVVersionInfo,
+    delivery_client: delivery.client.DeliveryServiceClient = None,
     s3_client=None,
     max_workers:int = 16,
 ) -> typing.Generator[clamav.model.ClamAVResourceScanResult, None, None]:
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
 
     def scan_resource(
         resource_node: cnudie.iter.ResourceNode,
-    ):
+    ) -> clamav.model.ClamAVResourceScanResult:
         component = resource_node.component
         resource = resource_node.resource
+
+        if delivery_client and _may_reuse_existing_scan_result(
+            resource_node=resource_node,
+            delivery_client=delivery_client,
+            current_version_info=clamav_version_info,
+            virus_db_max_age_days=virus_db_max_age_days,
+        ):
+            resource_name = f'{component.name}/{resource.name}'
+            logger.info(f'Skipping scan of {resource_name}.')
+            return clamav.model.ClamAVResourceScanResult(
+                scan_result=None,
+                state=gcm.ScanState.SKIPPED,
+                scanned_element=resource_node,
+            )
 
         if isinstance(resource.access, cm.OciAccess):
             access: cm.OciAccess = resource.access
@@ -45,6 +114,7 @@ def scan_resources(
                 oci_client=oci_client,
                 clamav_client=clamav_client,
             )
+
         elif isinstance(resource.access, cm.S3Access):
             access: cm.S3Access = resource.access
             if isinstance(resource.type, enum.Enum):
@@ -65,6 +135,7 @@ def scan_resources(
                 clamav_client=clamav_client,
                 tf=tf,
             )
+
         else:
             raise NotImplementedError(type(resource.access))
 
@@ -78,18 +149,22 @@ def scan_resources(
         # pylint: disable=E1123
         return clamav.model.ClamAVResourceScanResult(
             scan_result=scan_result,
-            scanned_element=cnudie.iter.ResourceNode(
-                path=(component,),
-                resource=resource,
-            ),
+            scanned_element=resource_node,
         )
 
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
     tasks = [
         executor.submit(scan_resource, resource_node)
        for resource_node in resource_nodes
     ]
 
     logger.info(f'will scan {len(tasks)=} with {max_workers=}')
+
+    if not delivery_client:
+        logger.info(
+            'Unable to compare with previous findings in delivery-service, no client available. '
+            'All files will be scanned.'
+        )
 
     while True:
         done, not_done = concurrent.futures.wait(
@@ -101,6 +176,25 @@ def scan_resources(
         if not not_done:
             break
         tasks = not_done
+
+
+def _scan_result_to_malware_finding(
+        scan_result: clamav.model.ScanResult,
+) -> dso.model.MalwareFinding:
+    if (meta := scan_result.meta):
+        meta = dso.model.MalwareFindingMeta(
+            receive_duration_seconds=meta.receive_duration_seconds,
+            scanned_octets=meta.scanned_octets,
+            scanned_content_digest=meta.scanned_content_digest,
+            scan_duration_seconds=meta.scan_duration_seconds,
+        )
+    return dso.model.MalwareFinding(
+        status=scan_result.status.value,
+        details=scan_result.details,
+        meta=meta,
+        name=scan_result.name,
+        malware_status=scan_result.malware_status.name,
+    )
 
 
 def resource_scan_result_to_artefact_metadata(
@@ -121,24 +215,6 @@ def resource_scan_result_to_artefact_metadata(
         type=datatype,
         creation_date=creation_date,
     )
-
-    def _scan_result_to_malware_finding(
-            scan_result: clamav.model.ScanResult,
-    ) -> dso.model.MalwareFinding:
-        if (meta := scan_result.meta):
-            meta = dso.model.MalwareFindingMeta(
-                receive_duration_seconds=meta.receive_duration_seconds,
-                scanned_octets=meta.scanned_octets,
-                scanned_content_digest=meta.scanned_content_digest,
-                scan_duration_seconds=meta.scan_duration_seconds,
-            )
-        return dso.model.MalwareFinding(
-            status=scan_result.status.value,
-            details=scan_result.details,
-            meta=meta,
-            name=scan_result.name,
-            malware_status=scan_result.malware_status.name,
-        )
 
     aggregated_scan_result = resource_scan_result.scan_result
     clamav_version_info = aggregated_scan_result.clamav_version_info

--- a/clamav/report.py
+++ b/clamav/report.py
@@ -16,22 +16,25 @@ def as_table(
         c = scan_result.scanned_element.component
         a = github.compliance.model.artifact_from_node(scan_result.scanned_element)
         resource = f'{c.name}:{c.version}/{a.name}:{a.version}'
-        res = scan_result.scan_result
 
-        status = res.malware_status
-
-        if status is clamav.model.MalwareStatus.OK:
-            details = 'no malware found'
-        elif status is clamav.model.MalwareStatus.UNKNOWN:
-            details = 'failed to scan'
-        elif status is clamav.model.MalwareStatus.FOUND_MALWARE:
-            details = '\n'.join((
-                f'{finding.name}: {finding.details}' for finding in res.findings
-            ))
+        if scan_result.state is github.compliance.model.ScanState.SKIPPED:
+            return resource, 'scan skipped', ''
         else:
-            raise NotImplementedError(status)
+            res = scan_result.scan_result
+            status = res.malware_status
 
-        return resource, status, details
+            if status is clamav.model.MalwareStatus.OK:
+                details = 'no malware found'
+            elif status is clamav.model.MalwareStatus.UNKNOWN:
+                details = 'failed to scan'
+            elif status is clamav.model.MalwareStatus.FOUND_MALWARE:
+                details = '\n'.join((
+                    f'{finding.name}: {finding.details}' for finding in res.findings
+                ))
+            else:
+                raise NotImplementedError(status)
+
+            return resource, status, details
 
     def rows():
         for result in scan_results:

--- a/clamav/scan.py
+++ b/clamav/scan.py
@@ -10,6 +10,7 @@ import gci.componentmodel as cm
 import ci.log
 import clamav.client
 import clamav.model
+import clamav.util
 import oci.client
 import oci.model
 
@@ -61,16 +62,8 @@ def aggregate_scan_result(
     else:
         malware_status = clamav.model.MalwareStatus.UNKNOWN
 
-    if isinstance(resource.access, cm.OciAccess):
-        resource_url = resource.access.imageReference
-    elif isinstance(resource.access, cm.S3Access):
-        a = resource.access
-        resource_url = f's3://{a.bucketName}/{a.objectKey}'
-    else:
-        resource_url = '<unknown>'
-
     return clamav.model.AggregatedScanResult(
-        resource_url=resource_url,
+        resource_url=clamav.util.resource_url_from_resource_access(resource.access),
         name=name,
         malware_status=malware_status,
         findings=findings,

--- a/clamav/util.py
+++ b/clamav/util.py
@@ -184,3 +184,14 @@ def virus_scan_images(
     )
 
     yield from results
+
+def resource_url_from_resource_access(
+    access: gci.componentmodel.ResourceAccess,
+) -> str:
+        # TODO: replace once a more fitting method exists in component-model
+        if isinstance(access, gci.componentmodel.OciAccess):
+            return access.imageReference
+        elif isinstance(access, gci.componentmodel.S3Access):
+            return f's3://{access.bucketName}/{access.objectKey}'
+        else:
+            raise NotImplementedError(access.type)

--- a/cli/gardener_ci/_clamav.py
+++ b/cli/gardener_ci/_clamav.py
@@ -46,6 +46,7 @@ def scan_component(
         clamav_client=clamav_client,
         clamav_version_info=clamav_version_info,
         max_workers=max_worker,
+        virus_db_max_age_days=0,
     ):
         findings_data = clamav.cnudie.resource_scan_result_to_artefact_metadata(
             resource_scan_result=result,

--- a/concourse/model/traits/image_scan.py
+++ b/concourse/model/traits/image_scan.py
@@ -188,6 +188,15 @@ CLAMAV_ATTRS = (
         default=8,
     ),
     AttributeSpec.optional(
+        name='virus_db_max_age_days',
+        doc=(
+            'The maxmimum age difference (in days) the virus definition database of ClamAV may '
+            'have when being compared to the most current database before triggering rescans.'
+        ),
+        type=int,
+        default=0,
+    ),
+    AttributeSpec.optional(
         name='saf_config_name',
         doc='SAF config name to use (see cc-config)',
         type=str,
@@ -224,6 +233,9 @@ class ClamAVScanCfg(ModelBase):
 
     def parallel_jobs(self) -> int:
         return int(self.raw['parallel_jobs'])
+
+    def virus_db_max_age_days(self) -> int:
+        return self.raw['virus_db_max_age_days']
 
     def rescorings(self) -> tuple[ClamAVRescoringEntry]:
         return tuple((

--- a/concourse/steps/malware_scan.mako
+++ b/concourse/steps/malware_scan.mako
@@ -14,6 +14,7 @@ image_scan_trait = job_variant.trait('image_scan')
 filter_cfg = image_scan_trait.matching_config()
 protecode_scan = image_scan_trait.protecode()
 clam_av = image_scan_trait.clam_av()
+age_threshold = clam_av.virus_db_max_age_days()
 
 issue_tgt_repo_url = image_scan_trait.overwrite_github_issues_tgt_repository_url()
 if issue_tgt_repo_url:
@@ -104,7 +105,6 @@ resource_nodes = cnudie.iter.iter(
   node_filter=cnudie.iter.Filter.resources,
 )
 
-
 def resource_type_is_tar(resource):
   if isinstance(resource.access, cm.OciAccess):
     return True
@@ -131,7 +131,8 @@ logger.info('running malware scan for all container images')
 
 pipeline_url = concourse.util.own_running_build_url()
 
-results = []
+scanned_results = []
+skipped_results = []
 have_findings = False
 findings_count = 0
 have_errors = False
@@ -141,7 +142,6 @@ if (delivery_client := ccc.delivery.default_client_if_available()):
   logger.info('uploading results to deliverydb')
 else:
   logger.warning('not uploading results to deliverydb, client not available')
-
 
 aws_session = ccc.aws.default_session(cfg_set=cfg_set)
 if aws_session:
@@ -157,12 +157,14 @@ for result in clamav.cnudie.scan_resources(
   resource_nodes=resource_nodes,
   oci_client=oci_client,
   clamav_client=clamav_client,
+  delivery_client=delivery_client,
+  virus_db_max_age_days=${age_threshold},
   clamav_version_info=clamav_version_info,
   s3_client=s3_client,
   max_workers=${clam_av.parallel_jobs()},
 ):
 
-  if delivery_client:
+  if delivery_client and result.state is not gcm.ScanState.SKIPPED:
     findings_data = clamav.cnudie.resource_scan_result_to_artefact_metadata(
         resource_scan_result=result,
         datasource=dso.model.Datasource.CLAMAV,
@@ -170,18 +172,21 @@ for result in clamav.cnudie.scan_resources(
     )
     delivery_client.upload_metadata(data=findings_data)
 
-  results.append(result)
-  scan_result = result.scan_result
-  logger.info(f'{scan_result}')
-  if scan_result.malware_status is clamav.model.MalwareStatus.FOUND_MALWARE:
-    have_findings = True
-    findings_count += 1
-  elif scan_result.malware_status is clamav.model.MalwareStatus.UNKNOWN:
-    have_errors = True
-    err_count += 1
+  if (scan_result := result.scan_result):
+    scanned_results.append(result)
+    logger.info(f'{scan_result}')
+    if scan_result.malware_status is clamav.model.MalwareStatus.FOUND_MALWARE:
+      have_findings = True
+      findings_count += 1
+    elif scan_result.malware_status is clamav.model.MalwareStatus.UNKNOWN:
+      have_errors = True
+      err_count += 1
+  else:
+    skipped_results.append(result)
 
-# order so that "OK"-results are displayed at the end
-results = sorted(results, key=lambda r: r.scan_result.malware_status, reverse=True)
+# order so that "Skipped" and "OK"-results are displayed at the end
+results = sorted(scanned_results, key=lambda r: r.scan_result.malware_status, reverse=True)
+results.extend(skipped_results)
 
 logger.info(f'summary: {findings_count=} {err_count=}')
 logger.info('findings and errors are printed on top of table\n')
@@ -206,7 +211,7 @@ rescoring_entries = [
     config=dacite.Config(
       type_hooks={gcm.Severity: gcm.Severity.parse},
     ),
-    ) for raw in rescoring_raw
+  ) for raw in rescoring_raw
 ]
 
 result_group_collection = scan_result_group_collection_for_malware(
@@ -243,7 +248,7 @@ github.compliance.report.create_or_update_github_issues(
 )
 
 evidence_request = prepare_evidence_request(
-  scan_results=results,
+  scan_results=scanned_results,
   evidence_id='gardener-mm6',
   pipeline_url=pipeline_url,
 )

--- a/delivery/client.py
+++ b/delivery/client.py
@@ -249,7 +249,7 @@ class DeliveryServiceClient:
         component_version: str=None,
         metadata_types: list[str]=[], # empty list returns _all_ metadata-types
         select: str=None, # either `greatestVersion` or `latestDate`
-    ):
+    ) -> list[dm.ArtefactMetadata]:
         '''
         returns a list of artifact-metadata for the given component
 
@@ -270,7 +270,10 @@ class DeliveryServiceClient:
 
         resp.raise_for_status()
 
-        return resp.json()
+        return [
+            dm.ArtefactMetadata.from_dict(raw)
+            for raw in resp.json()
+        ]
 
 
 def _normalise_github_hostname(github_url: str):

--- a/delivery/client.py
+++ b/delivery/client.py
@@ -275,6 +275,34 @@ class DeliveryServiceClient:
             for raw in resp.json()
         ]
 
+    def artefact_metadata_for_resource_node(
+        self,
+        resource_node: 'cnudie.iter.ResourceNode',
+        types: list[str],
+    ) -> typing.Iterable[dm.ArtefactMetadata]:
+        '''Return an iterable that contains all stored `ArtefactMetadata` of the given type for the
+        given resource node.
+
+        For possible values for `type` see `dso.model.Datatype`.
+        '''
+
+        component = resource_node.component
+        resource = resource_node.resource
+
+        for component_metadata in self.components_metadata(
+            component_name=component.name,
+            metadata_types=types,
+            component_version=component.version,
+        ):
+            if not component_metadata.artefactId.componentName == component.name:
+                continue
+            if not component_metadata.artefactId.artefactName == resource.name:
+                continue
+            if not component_metadata.artefactId.artefactVersion == resource.version:
+                continue
+
+            yield component_metadata
+
 
 def _normalise_github_hostname(github_url: str):
     # hack: for github.com, we might get a different subdomain (api.github.com)

--- a/delivery/model.py
+++ b/delivery/model.py
@@ -1,6 +1,8 @@
 import dataclasses
 import datetime
 
+import dso.model
+
 import awesomeversion
 import dacite
 import dateutil.parser
@@ -66,5 +68,45 @@ class OsReleaseInfo:
             data=raw,
             config=dacite.Config(
                 type_hooks={datetime.date | None: _parse_date_if_present},
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ComponentArtefactId:
+    componentName: str
+    componentVersion: str
+    artefactName: str
+    artefactKind: str
+    artefactVersion: str
+    artefactType: str
+    artefactExtraId: dict
+
+
+@dataclasses.dataclass(frozen=True)
+class ArtefactMetadata:
+    # this is _almost_ (but not quite) dso.model.ArtefactMetadata :(. Namely, the structure
+    # of the ArtefactId differs and there is an additional `type` str.
+    artefactId: ComponentArtefactId
+    type: str
+    meta: dso.model.Metadata
+    data: (
+        dso.model.GreatestCVE
+        | dso.model.LicenseSummary
+        | dso.model.ComponentSummary
+        | dso.model.OsID
+        | dso.model.MalwareSummary
+        | dso.model.FilesystemPaths
+        | dso.model.CodecheckSummary
+        | dict
+    )
+
+    @staticmethod
+    def from_dict(raw: dict):
+        return dacite.from_dict(
+            data_class=ArtefactMetadata,
+            data=raw,
+            config=dacite.Config(
+                type_hooks={datetime.datetime: datetime.datetime.fromisoformat},
             ),
         )

--- a/delivery/util.py
+++ b/delivery/util.py
@@ -1,7 +1,11 @@
 import logging
+import typing
 
 import awesomeversion
 
+import ccc.delivery
+import cnudie.iter
+import delivery.client
 import delivery.model
 import delivery.util
 import unixutil.model as um

--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -662,7 +662,7 @@ def create_or_update_github_issues(
         ctx_labels = _scanned_element_ctx_label(scan_result.scanned_element)
 
         if gcm.is_ocm_artefact_node(scan_result.scanned_element):
-            if not len({r.scanned_element.component.name for r in results}) == 1:
+            if results and not len({r.scanned_element.component.name for r in results}) == 1:
                 raise ValueError('not all component names are identical')
 
         if overwrite_repository:
@@ -849,6 +849,8 @@ def create_or_update_github_issues(
         return
 
     for result_group in result_groups_without_findings:
+        if not result_group.has_attempted_scans:
+            continue
         logger.info(f'discarding issue for {result_group.name=}')
         process_result(
             result_group=result_group,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to skip some malware scans. Currently, skipping behaviour is controlled by two parameters:
- age threshold: The scan will be skipped unless the previous scans findings were based on a virus definition database older than the current by a given amount of days
- virus definition version: The scan will be skipped if there has been no change to the virus definition database at all (as determined by the signature version)
    
By default only scans with unchanged virus definition database are avoided. This should result in daily-ish scans
