### PR TITLE
Add validation hook to config rotation and update alicloud/AWS behaviour

### DIFF
--- a/cfg_mgmt/alicloud.py
+++ b/cfg_mgmt/alicloud.py
@@ -123,17 +123,15 @@ def delete_config_secret(
     )
     access_key_id = cfg_queue_entry.secretId['accessKeyId']
 
-    # deactivate key instead of deleting it to make manual recovery possible.
-    request = UpdateAccessKeyRequest()
+    request = DeleteAccessKeyRequest()
     request.set_UserAccessKeyId(access_key_id)
-    request.set_Status('Inactive')
 
     try:
         client.do_action_with_exception(request)
     except ServerException as e:
         if e.get_http_status() == 403:
             logger.warning(
-                'User is not allowed to update the status of its access key. Please make sure that '
+                'User is not allowed to delete its own access key. Please make sure that '
                 'the Account is configured to allow users to manage their own keys.'
             )
         raise

--- a/cfg_mgmt/alicloud.py
+++ b/cfg_mgmt/alicloud.py
@@ -11,7 +11,6 @@ import aliyunsdkcore.client
 from aliyunsdkram.request.v20150501.ListAccessKeysRequest import ListAccessKeysRequest
 from aliyunsdkram.request.v20150501.CreateAccessKeyRequest import CreateAccessKeyRequest
 from aliyunsdkram.request.v20150501.DeleteAccessKeyRequest import DeleteAccessKeyRequest
-from aliyunsdkram.request.v20150501.UpdateAccessKeyRequest import UpdateAccessKeyRequest
 from aliyunsdkcore.acs_exception.exceptions import ServerException
 
 import cfg_mgmt
@@ -20,7 +19,10 @@ import model
 import model.aws
 import model.alicloud
 
-from cfg_mgmt.model import CfgQueueEntry
+from cfg_mgmt.model import (
+    CfgQueueEntry,
+    ValidationError,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -74,48 +76,6 @@ def rotate_cfg_element(
         ak=cfg_element.access_key_id(),
         secret=cfg_element.access_key_secret(),
     )
-
-    # If no parameters are set on the request, the user whose access key is used will be used
-    request = ListAccessKeysRequest()
-    try:
-        response = client.do_action_with_exception(request)
-    except ServerException as e:
-        if e.get_http_status() == 403:
-            logger.warning(
-                'User is not allowed to list its own access keys. Please make sure that the '
-                'Account is configured to allow users to manage their own keys.'
-            )
-            raise
-
-    response: ListAccessKeysResponse = dacite.from_dict(
-        data_class=ListAccessKeysResponse,
-        data=json.loads(response),
-        config=dacite.Config(check_types=False),
-    )
-
-    access_keys = response.AccessKeys.AccessKey
-
-    # We either have one or two access keys as Alicloud does not allow more than two and we used one
-    # to get access. For the first case just create a new one. If there are already two, determine
-    # the oldest key and delete it beforehand.
-    # Note: This cannot be undone.
-    if len(access_keys) == 2:
-        logger.info('There are already two SecretAccessKeys present. Deleting oldest key ...')
-        sorted_metadata = sorted(access_keys, key=lambda m: m.CreateDate)
-        oldest_key_id = sorted_metadata[0].AccessKeyId
-        request = DeleteAccessKeyRequest()
-        request.set_UserAccessKeyId(oldest_key_id)
-        try:
-            response = client.do_action_with_exception(request)
-        except ServerException as e:
-            if e.get_http_status() == 403:
-                logger.warning(
-                    'User is not allowed to delete its own access key. Please make sure that the '
-                    'Account is configured to allow users to manage their own keys.'
-                )
-            raise
-
-        logger.info(f'Deleted SecretAccessKey {oldest_key_id}')
 
     request = CreateAccessKeyRequest()
     try:
@@ -177,3 +137,38 @@ def delete_config_secret(
                 'the Account is configured to allow users to manage their own keys.'
             )
         raise
+
+
+def validate_for_rotation(
+    cfg_element: model.alicloud.AlicloudConfig,
+):
+    access_key_id = cfg_element.access_key_id()
+    client = aliyunsdkcore.client.AcsClient(
+        ak=access_key_id,
+        secret=cfg_element.access_key_secret(),
+    )
+
+    request = ListAccessKeysRequest()
+    try:
+        response = client.do_action_with_exception(request)
+    except ServerException as e:
+        if e.get_http_status() == 403:
+            logger.warning(
+                'User is not allowed to list its own access keys. Please make sure that the '
+                'Account is configured to allow users to manage their own keys.'
+            )
+            raise
+
+    response: ListAccessKeysResponse = dacite.from_dict(
+        data_class=ListAccessKeysResponse,
+        data=json.loads(response),
+        config=dacite.Config(check_types=False),
+    )
+
+    access_keys = response.AccessKeys.AccessKey
+
+    if len(access_keys) == 2:
+        raise ValidationError(
+            'There are already two keys present in Alicloud for Access Key '
+            f"'{access_key_id}'. Will not attempt rotation."
+        )

--- a/cfg_mgmt/aws.py
+++ b/cfg_mgmt/aws.py
@@ -94,8 +94,7 @@ def delete_config_secret(
         aws_secret_access_key=cfg_element.secret_access_key(),
     )
     access_key_id = cfg_queue_entry.secretId['accessKeyId']
-    # deactivate key instead of deleting it to make manual recovery possible.
-    iam_client.update_access_key(AccessKeyId=access_key_id, Status='Inactive')
+    iam_client.delete_access_key(AccessKeyId=access_key_id)
 
 
 def validate_for_rotation(

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -148,6 +148,7 @@ def rotate_cfg_element(
         update_secret_function = cmaws.rotate_cfg_element
 
     elif type_name == 'alicloud':
+        rotation_validation_function = cmali.validate_for_rotation
         update_secret_function = cmali.rotate_cfg_element
 
     elif type_name == 'kubernetes':

--- a/cfg_mgmt/rotate.py
+++ b/cfg_mgmt/rotate.py
@@ -145,6 +145,7 @@ def rotate_cfg_element(
         update_secret_function = cmbac.rotate_cfg_element
 
     elif type_name == 'aws':
+        rotation_validation_function = cmaws.validate_for_rotation
         update_secret_function = cmaws.rotate_cfg_element
 
     elif type_name == 'alicloud':


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR generifies the pre-rotation validation used for k8s-config elements and adds validation for Alicloud and AWS. Furthermore, it changes the behaviour for these two providers so that old keys are deleted when the rotation queue is processed, instead of deactivated. This is necessary as our compliance scanners still trip over these deactivated keys and raise alerts.