### PR TITLE
Add support for OciImageIndex

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -147,7 +147,10 @@ def replicate_artifact(
         manifest = json.loads(raw_manifest)
         media_type = manifest.get('mediaType', om.DOCKER_MANIFEST_SCHEMA_V2_MIME)
 
-        if media_type == om.DOCKER_MANIFEST_LIST_MIME:
+        if media_type in (
+            om.DOCKER_MANIFEST_LIST_MIME,
+            om.OCI_IMAGE_INDEX_MIME,
+        ):
             # multi-arch
             manifest = dacite.from_dict(
                 data_class=om.OciImageManifestList,
@@ -230,7 +233,8 @@ def replicate_artifact(
                             size=len(manifest_bytes),
                             platform=platform,
                         ),
-                    ]
+                    ],
+                    mediaType=om.DOCKER_MANIFEST_LIST_MIME,
                 )
 
                 manifest_list_bytes = json.dumps(

--- a/oci/client.py
+++ b/oci/client.py
@@ -512,8 +512,10 @@ class Client:
 
         manifest_dict = res.json()
 
-        distribution_list_mediatype = 'application/vnd.docker.distribution.manifest.list.v2+json'
-        if manifest_dict.get('mediaType') == distribution_list_mediatype:
+        if manifest_dict.get('mediaType') in (
+            om.DOCKER_MANIFEST_LIST_MIME,
+            om.OCI_IMAGE_INDEX_MIME,
+        ):
             manifest = dacite.from_dict(
                 data_class=om.OciImageManifestList,
                 data=manifest_dict,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for [OCI Image Index](https://github.com/opencontainers/image-spec/blob/main/image-index.md) manifests to our oci package

**Special notes for your reviewer**:
We will soon have one image as part of our BoM that uses this kind of manifest, so we'll need to add support.
This new kind of manifest is very similar to image list manifests (see https://github.com/opencontainers/image-spec/blob/main/media-types.md#compatibility-matrix for a discription of the differences), so for this initial PR the new manifest is just used with the existing code.
