### PR TITLE
add missing return statement

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -1014,3 +1014,4 @@ class Client:
             logger.warning(f'{image_reference=} {res.status_code=} {digest=} - PUT may have failed')
 
         res.raise_for_status()
+        return res


### PR DESCRIPTION
**What this PR does / why we need it**:
small fix in OCI library, put_blob() fails to return http response in some cases.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
