### PR TITLE
Support multiple ctx-repos in the update component dependencies trait

### DIFF
--- a/concourse/model/traits/update_component_deps.py
+++ b/concourse/model/traits/update_component_deps.py
@@ -160,6 +160,29 @@ ATTRIBUTES = (
         type=MergePolicy,
     ),
     AttributeSpec.optional(
+        name='additional_ctx_repositories',
+        default=dict(),
+        doc='''
+            Additional context repositories to look up components in. The entries are expected
+            to be mappings of context repo config names to a list of component names.
+
+            Example:
+
+            .. code-block:: yaml
+
+                additional_ctx_repositories:
+                    ctx_repo_config_name:
+                    - example/component/name
+                    - another/example/component
+                    ctx_repo_config_name_two:
+                    - yet/another/component
+
+            If a component name is configured for two context repository config names the last
+            mention will take precedence.
+        ''',
+        type=dict,
+    ),
+    AttributeSpec.optional(
         name='merge_policies',
         default=(),
         doc=(
@@ -218,6 +241,9 @@ class UpdateComponentDependenciesTrait(Trait):
 
     def upstream_update_policy(self):
         return UpstreamUpdatePolicy(self.raw.get('upstream_update_policy'))
+
+    def additional_ctx_repositories(self):
+        return self.raw['additional_ctx_repositories']
 
     def merge_policies(self):
         # handle default here


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR our `update component dependencies` trait can be given an additional mapping of ctx-repo config names to component names. This will prompt the trait to look in the given ctx-repo when checking for/proposing component upgrade PRs. If no config is provided for a component, the same source as before is used (the ctx-repository as given by the `component descriptor` or, if this is not configured, the ctx-repository of the base-component itself)

**Special notes for your reviewer**:
Currently this is configured as a mapping of ctx-repo-config-name to a list of component-names, e.g.:
```yaml
  additional_ctx_repositories:
    onmetal:
    - github.com/onmetal/gardener-extension-provider-onmetal
```
We might also consider allowing base-urls in addition (or instead of) ctx-repository config names. 
