### PR TITLE
Add limited support for downgrade pull requests

### DIFF
--- a/github/util.py
+++ b/github/util.py
@@ -171,6 +171,11 @@ class UpgradePullRequest:
         else:
             raise NotImplementedError(from_ref.type)
 
+    def is_downgrade(self) -> bool:
+        from_ver = version.parse_to_semver(self.from_ref.version)
+        to_ver = version.parse_to_semver(self.to_ref.version)
+        return from_ver > to_ver
+
     def is_obsolete(
         self,
         reference_component: gci.componentmodel.Component,


### PR DESCRIPTION
With this, downgrade pull requests will be proposed if
- the component is configured to _strictly follow_ version changes and
- the component being tracked is itself a dependency of an upstream component

The intention is to allow components to closely follow the trajectory of their counterpart in the original component-reference.

Suppose we have two components, `A` and `B` that both depend on `C` with `B` following `A`s version of `C`. With this change, `B` can receive automatically created downgrade pull requests for `C` when `A` _downgrades_ its version of `C` for whatever reason. Downgrades of immediately tracked components are not proposed.

Downgrade pull request creation operates with the same rules as upgrade pull request creation, notably
- only one downgrade pull request will ever be proposed for a given version, unless the pull request is made unrecognizable to our coding at a later point
- merge policy is respected, so automatic merges may happen.