### PR TITLE
Support multiple ctx-repos in the update component dependencies trait

### DIFF
--- a/cnudie/upload.py
+++ b/cnudie/upload.py
@@ -1,0 +1,118 @@
+import dataclasses
+import enum
+import hashlib
+import json
+
+import ccc.oci
+import cnudie.util
+import gci.componentmodel as cm
+import gci.oci
+import oci.model as om
+
+
+class UploadMode(enum.StrEnum):
+    SKIP = 'skip'
+    FAIL = 'fail'
+    OVERWRITE = 'overwrite'
+
+
+def upload_component_descriptor(
+    component_descriptor: cm.ComponentDescriptor | cm.Component,
+    on_exist=UploadMode.SKIP,
+    ocm_repository: cm.OciRepositoryContext | str = None,
+):
+    if isinstance(component_descriptor, cm.Component):
+        component_descriptor = cm.ComponentDescriptor(
+            component=component_descriptor,
+            meta=cm.Metadata(),
+            signatures=[],
+        )
+
+    schema_version = component_descriptor.meta.schemaVersion
+    if not schema_version is cm.SchemaVersion.V2:
+        raise RuntimeError(f'unsupported component-descriptor-version: {schema_version=}')
+
+    client = ccc.oci.oci_client()
+
+    if ocm_repository:
+        if isinstance(ocm_repository, str):
+            ocm_repository = cm.OciRepositoryContext(baseUrl=ocm_repository)
+        elif isinstance(ocm_repository, cm.OciRepositoryContext):
+            pass
+        else:
+            raise TypeError(type(ocm_repository))
+
+        if  not component_descriptor.component.current_repository_ctx() == ocm_repository:
+            component_descriptor.component.repositoryContexts.append(ocm_repository)
+
+    target_ref = cnudie.util.oci_artefact_reference(component_descriptor.component)
+
+    if on_exist in (UploadMode.SKIP, UploadMode.FAIL):
+        # check whether manifest exists (head_manifest does not return None)
+        if client.head_manifest(image_reference=target_ref, absent_ok=True):
+            if on_exist is UploadMode.SKIP:
+                return
+            if on_exist is UploadMode.FAIL:
+                # XXX: we might still ignore it, if the to-be-uploaded CD is equal to the existing
+                # one
+                raise ValueError(f'{target_ref=} already existed')
+    elif on_exist is UploadMode.OVERWRITE:
+        pass
+    else:
+        raise NotImplementedError(on_exist)
+
+    raw_fobj = gci.oci.component_descriptor_to_tarfileobj(component_descriptor)
+    cd_digest = hashlib.sha256()
+    while (chunk := raw_fobj.read(4096)):
+        cd_digest.update(chunk)
+
+    cd_octets = raw_fobj.tell()
+    cd_digest = cd_digest.hexdigest()
+    cd_digest_with_alg = f'sha256:{cd_digest}'
+    raw_fobj.seek(0)
+
+    client.put_blob(
+        image_reference=target_ref,
+        digest=cd_digest_with_alg,
+        octets_count=cd_octets,
+        data=raw_fobj,
+    )
+
+    cfg = gci.oci.ComponentDescriptorOciCfg(
+        componentDescriptorLayer=gci.oci.ComponentDescriptorOciBlobRef(
+            digest=cd_digest_with_alg,
+            size=cd_octets,
+        )
+    )
+    cfg_raw = json.dumps(dataclasses.asdict(cfg)).encode('utf-8')
+    cfg_octets = len(cfg_raw)
+    cfg_digest = hashlib.sha256(cfg_raw).hexdigest()
+    cfg_digest_with_alg = f'sha256:{cfg_digest}'
+
+    client.put_blob(
+        image_reference=target_ref,
+        digest=cfg_digest_with_alg,
+        octets_count=cfg_octets,
+        data=cfg_raw,
+    )
+
+    manifest = om.OciImageManifest(
+        config=gci.oci.ComponentDescriptorOciCfgBlobRef(
+            digest=cfg_digest_with_alg,
+            size=cfg_octets,
+        ),
+        layers=[
+            gci.oci.ComponentDescriptorOciBlobRef(
+                digest=cd_digest_with_alg,
+                size=cd_octets,
+            ),
+        ],
+    )
+
+    manifest_dict = manifest.as_dict()
+    manifest_bytes = json.dumps(manifest_dict).encode('utf-8')
+
+    client.put_manifest(
+        image_reference=target_ref,
+        manifest=manifest_bytes,
+    )

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -331,9 +331,12 @@ class ComponentDescriptorTrait(Trait):
         return self.raw['component_labels']
 
     def ocm_repository_mappings(self) -> list:
+        ctx_repository_url = self.ctx_repository_base_url()
+        if ctx_repository_url is None:
+            return []
         if not (ocm_repository_mappings := self.raw['ocm_repository_mappings']):
             ocm_repository_mappings = [{
-                'ocm_repo_url': self.ctx_repository_base_url(),
+                'ocm_repo_url': ctx_repository_url,
                 'prefix': '',
                 'use_for': 'readonly',
             }]

--- a/concourse/model/traits/component_descriptor.py
+++ b/concourse/model/traits/component_descriptor.py
@@ -22,6 +22,7 @@ import dacite
 from ci.util import not_none
 from gci.componentmodel import Label
 import ci.util
+import cnudie.util
 import gci.componentmodel as cm
 import version
 
@@ -178,7 +179,39 @@ ATTRIBUTES = (
         default=[],
         type=typing.List[StepInput],
         doc='inputs to expose to component-descriptor step',
-    )
+    ),
+    AttributeSpec.optional(
+        name='ocm_repository_mappings',
+        default=[], # cannot define a proper default here because this depends on another (optional)
+                    # config-value. At least not in a way that would be represented in our
+                    # rendered documentation.
+        type=typing.List[cnudie.util.OcmLookupMapping],
+        doc='''
+            used to explicitly configure where to lookup component descriptors. Example:
+
+            .. code-block:: yaml
+
+                - ocm_repo_url: ocm_repo_url
+                  prefix: github.com/some-org/
+                - ocm_repo_url: ocm_repo_url
+                  prefix: github.com/another-org/
+                  priority: 10 # default
+                - ocm_repo_url: another_ocm_repo_url
+                  component_names: github.com/yet-another-org/
+
+            If not given, a default mapping will be applied that is equivalent to the following:
+
+            .. code-block:: yaml
+
+                - ocm_repo_url: <ctx_repository_base_url>
+                  prefix: ''
+
+            .. note::
+                If multiple mappings match a component name, they will be tried in order of priority
+                with longest matching prefix first.
+
+        '''
+    ),
 )
 
 
@@ -296,6 +329,16 @@ class ComponentDescriptorTrait(Trait):
 
     def component_labels(self):
         return self.raw['component_labels']
+
+    def ocm_repository_mappings(self) -> list:
+        if not (ocm_repository_mappings := self.raw['ocm_repository_mappings']):
+            ocm_repository_mappings = [{
+                'ocm_repo_url': self.ctx_repository_base_url(),
+                'prefix': '',
+                'use_for': 'readonly',
+            }]
+
+        return ocm_repository_mappings
 
     def inputs(self) -> typing.List[StepInput]:
         return [

--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -44,6 +44,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import traceback
 
 import dacite
@@ -178,6 +179,11 @@ if os.path.isfile(descriptor_script):
   with open(base_descriptor_file_v2, 'w') as f:
     f.write(dump_component_descriptor_v2(base_descriptor_v2))
 
+  ocm_config_out_dir = tempfile.TemporaryDirectory()
+  ocm_config_file = tempfile.NamedTemporaryFile(dir=ocm_config_out_dir.name, delete=False)
+  with open(ocm_config_file.name, 'w') as f:
+    f.write(mapping_config.to_ocm_software_config())
+
   subproc_env = os.environ.copy()
   subproc_env['${main_repo_path_env_var}'] = main_repo_path
   subproc_env['MAIN_REPO_DIR'] = main_repo_path
@@ -187,6 +193,7 @@ if os.path.isfile(descriptor_script):
   subproc_env['COMPONENT_VERSION'] = effective_version
   subproc_env['EFFECTIVE_VERSION'] = effective_version
   subproc_env['CURRENT_COMPONENT_REPOSITORY'] = ctx_repository_base_url
+  subproc_env['OCM_CONFIG_PATH'] = ocm_config_file.name
 
   # pass predefined command to add dependencies for convenience purposes
   add_dependencies_cmd = ' '.join((

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -40,12 +40,14 @@ component_descriptor_path = os.path.join(
 
 component_descriptor_trait = job_variant.trait('component_descriptor')
 component_name = component_descriptor_trait.component_name()
+ocm_repository_mappings = component_descriptor_trait.ocm_repository_mappings()
 
 release_callback_path = release_trait.release_callback_path()
 next_version_callback_path = release_trait.next_version_callback_path()
 %>
 import ccc.github
 import ci.util
+import cnudie.util
 import concourse.steps.component_descriptor_util as cdu
 import concourse.steps.release
 import github.util
@@ -68,6 +70,10 @@ githubrepobranch = github.util.GitHubRepoBranch(
     repo_owner='${repo.repo_owner()}',
     repo_name='${repo.repo_name()}',
     branch=repository_branch,
+)
+
+mapping_config = cnudie.util.OcmLookupMappingConfig.from_dict(
+    raw_mappings = ${ocm_repository_mappings},
 )
 
 try:
@@ -118,5 +124,6 @@ concourse.steps.release.release_and_prepare_next_dev_cycle(
   % endif
   github_release_tag=${github_release_tag},
   git_tags=${git_tags},
+  mapping_config=mapping_config,
 )
 </%def>

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -42,7 +42,6 @@ from github.util import (
     GitHubRepositoryHelper,
     GitHubRepoBranch,
 )
-import product.v2
 from concourse.model.traits.release import (
     ReleaseCommitPublishingPolicy,
     ReleaseNotesPolicy,
@@ -683,11 +682,11 @@ class UploadComponentDescriptorStep(TransactionalStep):
 
                 component = components_by_id[component.identity()]
 
-                tgt_ref = product.v2._target_oci_ref(component=component)
+                tgt_ref = cnudie.util.target_oci_ref(component=component)
 
                 logger.info(f'publishing CNUDIE-Component-Descriptor to {tgt_ref=}')
                 cnudie.upload.upload_component_descriptor(
-                    component_descriptor_v2=component,
+                    component_descriptor=component,
                 )
 
         upload_component_descriptors(components=components)

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -29,6 +29,7 @@ from ci.util import (
 )
 import cnudie.iter
 import cnudie.retrieve
+import cnudie.upload
 import cnudie.util
 import cnudie.validate
 import dockerutil
@@ -685,7 +686,7 @@ class UploadComponentDescriptorStep(TransactionalStep):
                 tgt_ref = product.v2._target_oci_ref(component=component)
 
                 logger.info(f'publishing CNUDIE-Component-Descriptor to {tgt_ref=}')
-                product.v2.upload_component_descriptor_v2_to_oci_registry(
+                cnudie.upload.upload_component_descriptor(
                     component_descriptor_v2=component,
                 )
 

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -602,15 +602,19 @@ class UploadComponentDescriptorStep(TransactionalStep):
         github_helper: GitHubRepositoryHelper,
         components: tuple[cm.Component],
         release_on_github: bool,
+        mapping_config: cnudie.util.OcmLookupMappingConfig,
     ):
         self.github_helper = not_none(github_helper)
         self.components = components
         self.release_on_github = release_on_github
+        self.mapping_config = mapping_config
 
     def name(self):
         return "Upload Component Descriptor"
 
     def validate(self):
+        lookup = cnudie.retrieve.oci_component_descriptor_lookup(mapping_config=self.mapping_config)
+
         components: tuple[cm.Component] = tuple(
             cnudie.util.iter_sorted(
                 self.components,
@@ -623,6 +627,7 @@ class UploadComponentDescriptorStep(TransactionalStep):
         def iter_components():
             for component in components:
                 yield from cnudie.iter.iter(
+                    lookup=lookup,
                     component=component,
                     recursion_depth=0,
                 )
@@ -643,6 +648,10 @@ class UploadComponentDescriptorStep(TransactionalStep):
         exit(1)
 
     def apply(self):
+        lookup = cnudie.retrieve.oci_component_descriptor_lookup(
+            mapping_config=self.mapping_config,
+            default_absent_ok=False,
+        )
         if self.release_on_github:
             create_release_step_output = self.context().step_output('Create Release')
             release_tag_name = create_release_step_output['release_tag_name']
@@ -655,10 +664,13 @@ class UploadComponentDescriptorStep(TransactionalStep):
 
         # todo: mv to `validate`
         def resolve_dependencies(component: cm.Component):
-            for _ in cnudie.retrieve.components(component=component):
+            for _ in cnudie.retrieve.components(
+                component=component,
+                component_descriptor_lookup=lookup,
+            ):
                 pass
 
-        def upload_component_descriptors(components):
+        def upload_component_descriptors(components: tuple[cm.Component]):
             for component in components:
                 try:
                     resolve_dependencies(component=component)
@@ -906,6 +918,7 @@ def release_and_prepare_next_dev_cycle(
     git_tags: list,
     github_release_tag: dict,
     release_commit_callback_image_reference: str,
+    mapping_config,
     component_descriptor_path: str=None,
     next_cycle_commit_message_prefix: str=None,
     next_version_callback: str=None,
@@ -1037,6 +1050,7 @@ def release_and_prepare_next_dev_cycle(
         github_helper=github_helper,
         components=components,
         release_on_github=release_on_github,
+        mapping_config=mapping_config,
     )
 
     step_list.append(upload_component_descriptor_step)
@@ -1073,6 +1087,7 @@ def release_and_prepare_next_dev_cycle(
         release_note_blocks = release_notes.fetch.fetch_release_notes(
             repo_path=repo_dir,
             component=component,
+            mapping_config=mapping_config,
             current_version=version.parse_to_semver(release_version),
         )
         release_notes_markdown = '\n'.join(

--- a/release_notes/fetch.py
+++ b/release_notes/fetch.py
@@ -191,6 +191,7 @@ def fetch_release_notes(
         repo_path: str,
         current_version: typing.Optional[semver.VersionInfo] = None,
         previous_version: typing.Optional[semver.VersionInfo] = None,
+        mapping_config: cnudie.util.OcmLookupMappingConfig | None = None,
 ) -> set[rnm.ReleaseNote]:
     ''' Fetches and returns a set of release notes for the specified component.
 
@@ -198,8 +199,11 @@ def fetch_release_notes(
     :param repo_path: The (local) path to the git-repository.
     :param current_version: Optional argument to retrieve release notes up to a specific version.
         If not given, the current `HEAD` is used.
-    :param previous_version: Optional argument to retrieve release notes starting at a specific
-        version. If not given, the closest version to `current_version` is used
+    :param previous_version: Optional argument to retrieve release notes starting at a specific \
+        version. If not given, the closest version to `current_version` is used.
+    :param mapping_config: An optional `OcmLookupMappingConfig` that will be used when fetching \
+        component descriptors. If none is given, the ocm repository context of the passed \
+        component will be used.
 
     :return: A set of ReleaseNote objects for the specified component.
     '''
@@ -221,10 +225,17 @@ def fetch_release_notes(
 
     # find all available versions
     component_versions: dict[semver.VersionInfo, str] = {}
-    for ver in cnudie.retrieve.component_versions(
-            component.name,
-            component.current_repository_ctx()
-    ):
+
+    if not mapping_config:
+        version_lookup = cnudie.retrieve.version_lookup(
+            default_ctx_repo=component.current_repository_ctx(),
+        )
+    else:
+        version_lookup = cnudie.retrieve.version_lookup(
+            mapping_config=mapping_config,
+        )
+
+    for ver in version_lookup(component.identity()):
         parsed_version = version.parse_to_semver(ver)
         if parsed_version.prerelease:  # ignore pre-releases
             continue

--- a/test/concourse/steps/update_component_deps_test.py
+++ b/test/concourse/steps/update_component_deps_test.py
@@ -5,6 +5,8 @@ import os
 import pathlib
 
 import gci.componentmodel as cm
+import cnudie.util
+import concourse.steps.update_component_deps
 
 import test_utils
 
@@ -76,110 +78,118 @@ def test_determine_reference_versions():
     # Case 1: No Upstream
     greatest_version = '2.1.1'
     component_name = 'example.org/foo/bar'
-    base_url = "foo" # actual value not relevant here
-    ctx_repo = cm.OciRepositoryContext(baseUrl=base_url)
+    mapping_config = cnudie.util.OcmLookupMappingConfig(
+        [cnudie.util.OcmLookupMapping(ocm_repo_url='foo', prefix='', priority=10)]
+    )
 
     examinee = functools.partial(
         determine_reference_versions,
         component_name=component_name,
-        ctx_repo=ctx_repo,
+        mapping_config=mapping_config,
     )
-    with unittest.mock.patch('cnudie.retrieve') as cnudie_retrieve_mock:
-        cnudie_retrieve_mock.greatest_component_version.return_value = greatest_version
+    greatest_component_version_mock = unittest.mock.Mock()
+    concourse.steps.update_component_deps.greatest_component_version = (
+        greatest_component_version_mock
+    )
+    greatest_component_version_mock.return_value = greatest_version
 
-        # no upstream component -> expect latest version to be returned
-        assert examinee(
-                reference_version='2.1.0',
-                upstream_component_name=None,
-            ) == (greatest_version,)
+    # no upstream component -> expect latest version to be returned
+    assert examinee(
+            reference_version='2.1.0',
+            upstream_component_name=None,
+        ) == (greatest_version,)
 
-        cnudie_retrieve_mock.greatest_component_version.assert_called_with(
-            component_name=component_name,
-            ctx_repo=ctx_repo,
-            ignore_prerelease_versions=False,
-        )
+    greatest_component_version_mock.assert_called_with(
+        component_name=component_name,
+        mapping_config=mapping_config,
+        ignore_prerelease_versions=False,
+    )
 
-        cnudie_retrieve_mock.greatest_component_version.reset_mock()
+    greatest_component_version_mock.reset_mock()
 
-        assert examinee(
-                reference_version='2.2.0', # same result, if our version is already greater
-                upstream_component_name=None,
-            ) == (greatest_version,)
+    assert examinee(
+            reference_version='2.2.0', # same result, if our version is already greater
+            upstream_component_name=None,
+        ) == (greatest_version,)
 
-        cnudie_retrieve_mock.greatest_component_version.assert_called_with(
-            component_name=component_name,
-            ctx_repo=ctx_repo,
-            ignore_prerelease_versions=False,
-        )
+    greatest_component_version_mock.assert_called_with(
+        component_name=component_name,
+        mapping_config=mapping_config,
+        ignore_prerelease_versions=False,
+    )
 
     # Case 2: Upstream component defined
     examinee = functools.partial(
         determine_reference_versions,
         component_name='example.org/foo/bar',
         upstream_component_name='example.org/foo/bar',
-        ctx_repo=ctx_repo,
+        mapping_config=mapping_config,
     )
 
-    with unittest.mock.patch(
-        'concourse.steps.update_component_deps.latest_component_version_from_upstream'
-    ) as upstream_version_mock:
+    latest_component_version_mock = unittest.mock.Mock()
+    concourse.steps.update_component_deps.latest_component_version_from_upstream = (
+        latest_component_version_mock
+    )
 
-        upstream_version = '2.2.0'
-        UUP = update_component_deps.UpstreamUpdatePolicy
+    upstream_version = '2.2.0'
+    UUP = update_component_deps.UpstreamUpdatePolicy
 
-        upstream_version_mock.return_value = upstream_version
+    latest_component_version_mock.return_value = upstream_version
 
-        # should return upstream version, by default (default to strict-following)
-        assert examinee(
-            reference_version='1.2.3', # does not matter
-        ) == (upstream_version,)
+    # should return upstream version, by default (default to strict-following)
+    assert examinee(
+        reference_version='1.2.3', # does not matter
+    ) == (upstream_version,)
 
-        upstream_version_mock.assert_called_once_with(
-            component_name=component_name,
-            upstream_component_name='example.org/foo/bar',
-            ctx_repo=ctx_repo,
-            ignore_prerelease_versions=False,
-        )
+    latest_component_version_mock.assert_called_once_with(
+        component_name=component_name,
+        upstream_component_name='example.org/foo/bar',
+        mapping_config=mapping_config,
+        ignore_prerelease_versions=False,
+    )
 
-        upstream_version_mock.reset_mock()
+    latest_component_version_mock.reset_mock()
 
-        # same behaviour if explicitly configured
-        assert examinee(
-            reference_version='1.2.3', # does not matter
-            upstream_update_policy=UUP.STRICTLY_FOLLOW,
-        ) == (upstream_version,)
+    # same behaviour if explicitly configured
+    assert examinee(
+        reference_version='1.2.3', # does not matter
+        upstream_update_policy=UUP.STRICTLY_FOLLOW,
+    ) == (upstream_version,)
 
-        upstream_version_mock.assert_called_once_with(
-            component_name=component_name,
-            upstream_component_name='example.org/foo/bar',
-            ctx_repo=ctx_repo,
-            ignore_prerelease_versions=False,
-        )
+    latest_component_version_mock.assert_called_once_with(
+        component_name=component_name,
+        upstream_component_name='example.org/foo/bar',
+        mapping_config=mapping_config,
+        ignore_prerelease_versions=False,
+    )
 
-        upstream_version_mock.reset_mock()
+    latest_component_version_mock.reset_mock()
 
-        with unittest.mock.patch('cnudie.retrieve') as cnudie_retrieve_mock:
-            # if not strictly following, should consider hotfix
-            reference_version = '1.2.3'
-            upstream_hotfix_version = '2.2.3'
-            cnudie_retrieve_mock.greatest_component_version_with_matching_minor.return_value = \
-                upstream_hotfix_version
+    greatest_component_version_with_matching_minor_mock = unittest.mock.Mock()
+    concourse.steps.update_component_deps.greatest_component_version_with_matching_minor = (
+        greatest_component_version_with_matching_minor_mock
+    )
 
-            assert examinee(
-                reference_version=reference_version, # does not matter
-                upstream_update_policy=UUP.ACCEPT_HOTFIXES,
-            ) == (upstream_hotfix_version, upstream_version)
+    # if not strictly following, should consider hotfix
+    reference_version = '1.2.3'
+    upstream_hotfix_version = '2.2.3'
+    greatest_component_version_with_matching_minor_mock.return_value = \
+        upstream_hotfix_version
 
-            upstream_version_mock.assert_called_once_with(
-                component_name=component_name,
-                upstream_component_name='example.org/foo/bar',
-                ctx_repo=ctx_repo,
-                ignore_prerelease_versions=False,
-            )
-            cnudie_retrieve_mock.greatest_component_version_with_matching_minor.\
-                assert_called_once_with(
-                component_name=component_name,
-                ctx_repo=ctx_repo,
-                reference_version=reference_version,
-                ignore_prerelease_versions=False,
-            )
+    assert examinee(
+        reference_version=reference_version, # does not matter
+        upstream_update_policy=UUP.ACCEPT_HOTFIXES,
+    ) == (upstream_hotfix_version, upstream_version)
+
+    latest_component_version_mock.assert_called_once_with(
+        component_name=component_name,
+        upstream_component_name='example.org/foo/bar',
+        mapping_config=mapping_config,
+        ignore_prerelease_versions=False,
+    )
+    greatest_component_version_with_matching_minor_mock.assert_called_once_with(
+        component_name=component_name,
+        mapping_config=mapping_config,
+        reference_version=reference_version,
+        ignore_prerelease_versions=False,
+    )

--- a/version.py
+++ b/version.py
@@ -432,6 +432,34 @@ def find_latest_version_with_matching_minor(
     return latest_candidate_str
 
 
+def greatest_version_before(
+    reference_version: Union[semver.VersionInfo, str],
+    versions: Iterable[Union[semver.VersionInfo, str]],
+    ignore_prerelease_versions: bool=False,
+) -> str | None:
+    latest_candidate_semver = None
+    latest_candidate_str = None
+
+    if isinstance(reference_version, str):
+        reference_version = parse_to_semver(reference_version)
+
+    for candidate in versions:
+        if isinstance(candidate, str):
+            candidate_semver = parse_to_semver(candidate)
+        else:
+            candidate_semver = candidate
+
+        if ignore_prerelease_versions and candidate_semver.prerelease:
+            continue
+
+        if candidate_semver < reference_version:
+            if not latest_candidate_semver or candidate_semver > latest_candidate_semver:
+                latest_candidate_semver = candidate_semver
+                latest_candidate_str = candidate
+
+    return latest_candidate_str
+
+
 def partition_by_major_and_minor(
     versions: Iterable[semver.VersionInfo],
 ) -> Iterable[Set[semver.VersionInfo]]:


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR our `update component dependencies` trait can be given an additional mapping of ctx-repo config names to component names. This will prompt the trait to look in the given ctx-repo when checking for/proposing component upgrade PRs. If no config is provided for a component, the same source as before is used (the ctx-repository as given by the `component descriptor` or, if this is not configured, the ctx-repository of the base-component itself)

**Special notes for your reviewer**:
Currently this is configured as a mapping of ctx-repo-config-name to a list of component-names, e.g.:
```yaml
  ocm_repository_mappings:
    - ocm_repo_url: <url>
      component_names: [ … ]
      use_for: 'readonly' | 'readwrite'
```
