### PR TITLE
Optionally merge release-commit from tag to default-branch

### DIFF
--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -85,6 +85,12 @@ class ReleaseCommitPublishingPolicy(EnumWithDocumentation):
         doc='publish release tag to dead-end',
     )
 
+    TAG_AND_MERGE_BACK = EnumValueWithDocumentation(
+        value='tag_and_merge_back',
+        doc='publish release tag to dead-end and merge back release commit to default branch',
+    )
+
+
 
 ATTRIBUTES = (
     AttributeSpec.optional(


### PR DESCRIPTION
Release commits can be pushed to tag only (publish policy `tag_only`). However, if release-commit has side-effects, e.g. version bumps via release-callback, these are missing on default branch.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
