### PR TITLE
Allow passing of `ctx_repo` to override lookup `ctx_repo` in `cnudie.iter`

### DIFF
--- a/cnudie/iter.py
+++ b/cnudie/iter.py
@@ -52,7 +52,8 @@ def iter(
     lookup: cnudie.retrieve.ComponentDescriptorLookupById=None,
     recursion_depth: int=-1,
     prune_unique: bool=True,
-    node_filter: typing.Callable[[Node], bool]=None
+    node_filter: typing.Callable[[Node], bool]=None,
+    ctx_repo: cm.RepositoryContext | str=None,
 ):
     '''
     returns a generator yielding the transitive closure of nodes accessible from the given component.
@@ -68,6 +69,7 @@ def iter(
                             component dependencies
     @param prune_unique: if true, redundant component-versions will only be traversed once
     @node_filter:        use to filter emitted nodes (see Filter for predefined filters)
+    @param ctx_repo:     optional ctx_repo to be used to override in the lookup
     '''
     if isinstance(component, cm.ComponentDescriptor):
         component = component.component
@@ -112,7 +114,10 @@ def iter(
                 name=cref.componentName,
                 version=cref.version,
             )
-            referenced_component_descriptor = lookup(cref_id)
+            if ctx_repo:
+                referenced_component_descriptor = lookup(cref_id, ctx_repo)
+            else:
+                referenced_component_descriptor = lookup(cref_id)
             referenced_component = referenced_component_descriptor.component
 
             yield from inner_iter(


### PR DESCRIPTION
Before, if the specified lookup did not have a `ctx_repo` specified, the iteration would break. In this case, one can pass a `ctx_repo` to the iterator and use that repo instead.
This is in particular relevant for the Delivery-Service because its component descriptor lookup has no `ctx_repo` specified on initialisation but instead reads it at runtime.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
