### PR TITLE
added `ignore_prerelease_versions` to `greatest_component_versions` in `cnudie.retrieve` 

### DIFF
--- a/cnudie/retrieve.py
+++ b/cnudie/retrieve.py
@@ -568,7 +568,8 @@ def greatest_component_versions(
     ctx_repo: cm.RepositoryContext,
     max_versions: int = 5,
     greatest_version: str = None,
-    oci_client: oc.Client=None,
+    oci_client: oc.Client = None,
+    ignore_prerelease_versions: bool = False,
 ) -> list[str]:
     if not isinstance(ctx_repo, cm.OciRepositoryContext):
         raise NotImplementedError(ctx_repo)
@@ -584,6 +585,9 @@ def greatest_component_versions(
 
     if not versions:
         return []
+
+    if ignore_prerelease_versions:
+        versions = [v for v in versions if not (pv := version.parse_to_semver(v)).prerelease and not pv.build]
 
     versions = sorted(versions, key=version.parse_to_semver)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `ignore_prerelease_versions` attribut to the `greatest_component_versions` function in `cnudie.retrieve`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
