### PR TITLE
Allow rescoring to `NONE` again

### DIFF
--- a/dso/cvss.py
+++ b/dso/cvss.py
@@ -322,7 +322,7 @@ def matching_rescore_rules(
 def rescore(
     rescoring_rules: typing.Iterable[RescoringRule],
     severity: CVESeverity,
-    minimum_severity: int=CVESeverity.LOW,
+    minimum_severity: int=CVESeverity.NONE,
 ) -> CVESeverity:
     for rule in rescoring_rules:
         if rule.rescore is Rescore.NO_CHANGE:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
