### PR TITLE
Avoid unnecessary dependencies in pipeline-graph

### DIFF
--- a/concourse/model/job.py
+++ b/concourse/model/job.py
@@ -86,7 +86,7 @@ class JobVariant(ModelBase):
 
         return '-'.join(parts)
 
-    def steps(self):
+    def steps(self) -> typing.Iterable[concourse.model.step.PipelineStep]:
         return self._steps_dict.values()
 
     def step_names(self):

--- a/concourse/model/traits/publish.py
+++ b/concourse/model/traits/publish.py
@@ -521,6 +521,9 @@ class PublishTraitTransformer(TraitTransformer):
                 continue
             if step.name.startswith('build_oci_image'):
                 continue
+            if 'publish' in step.trait_depends():
+                # don't depend on steps that have been explicitly configured to depend on publish.
+                continue
             prepare_step._add_dependency(step)
 
     @classmethod


### PR DESCRIPTION
do not cause an obvious circular dependency here only to attempt to resolve it later on during rendering.
