### PR TITLE
Add (some of) component's resources to release-note

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -1112,6 +1112,12 @@ def release_and_prepare_next_dev_cycle(
         release_notes_markdown = '\n'.join(
             str(i) for i in release_notes.markdown.render(release_note_blocks)
         ) or 'no release notes available'
+
+        if (component_resources_markdown := release_notes.markdown.release_note_for_ocm_component(
+            component=component,
+        )):
+            release_notes_markdown += '\n\n' + component_resources_markdown
+
         github_helper.update_release_notes(
             tag_name=release_version,
             body=release_notes_markdown,

--- a/gci/componentmodel.py
+++ b/gci/componentmodel.py
@@ -19,18 +19,18 @@ dc = dataclasses.dataclass
 logger = logging.getLogger(__name__)
 
 
-class ValidationMode(enum.Enum):
+class ValidationMode(enum.StrEnum):
     FAIL = 'fail'
     WARN = 'warn'
     NONE = 'none'
 
 
-class SchemaVersion(enum.Enum):
+class SchemaVersion(enum.StrEnum):
     V1 = 'v1'
     V2 = 'v2'
 
 
-class AccessType(enum.Enum):
+class AccessType(enum.StrEnum):
     GITHUB = 'github' # XXX: new: gitHub/v1
     LOCAL_BLOB = 'localBlob/v1'
     NONE = 'None'  # the resource is only declared informally (e.g. generic)
@@ -146,7 +146,7 @@ class S3Access(Access):
     region: typing.Optional[str] = None
 
 
-class ArtefactType(enum.Enum):
+class ArtefactType(enum.StrEnum):
     COSIGN_SIGNATURE = 'cosignSignature'
     GIT = 'git'
     OCI_IMAGE = 'ociImage'


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, additional information about a components resources will be added to the release-notes upon release. The format is identical to the way the gardener colleagues set it by hand.

- Currently only set up for OciImages with OciAccess and will return/add nothing for other resource- and access-types.
- Categories are simply sorted alphabetically.
- Will not be added to draft-releases.
