### PR TITLE
Use `update-metadata` instead of `upload-/delete-metadata` route to sync bdba results with delivery-db and add retries

### DIFF
--- a/delivery/client.py
+++ b/delivery/client.py
@@ -65,13 +65,6 @@ class DeliveryServiceRoutes:
             'update-metadata',
         )
 
-    def delete_metadata(self):
-        return ci.util.urljoin(
-            self._base_url,
-            'artefacts',
-            'delete-metadata',
-        )
-
     def query_metadata(self):
         return ci.util.urljoin(
             self._base_url,
@@ -150,22 +143,6 @@ class DeliveryServiceClient:
     ):
         res = requests.put(
             url=self._routes.update_metadata(),
-            json={'entries': [
-                dataclasses.asdict(
-                    artefact_metadata,
-                    dict_factory=ci.util.dict_to_json_factory,
-                ) for artefact_metadata in data
-            ]},
-        )
-
-        res.raise_for_status()
-
-    def delete_metadata(
-        self,
-        data: typing.Iterable[dso.model.ArtefactMetadata],
-    ):
-        res = requests.delete(
-            url=self._routes.delete_metadata(),
             json={'entries': [
                 dataclasses.asdict(
                     artefact_metadata,

--- a/delivery/client.py
+++ b/delivery/client.py
@@ -58,6 +58,13 @@ class DeliveryServiceRoutes:
             'upload-metadata',
         )
 
+    def update_metadata(self):
+        return ci.util.urljoin(
+            self._base_url,
+            'artefacts',
+            'update-metadata',
+        )
+
     def delete_metadata(self):
         return ci.util.urljoin(
             self._base_url,
@@ -127,6 +134,22 @@ class DeliveryServiceClient:
     ):
         res = requests.post(
             url=self._routes.upload_metadata(),
+            json={'entries': [
+                dataclasses.asdict(
+                    artefact_metadata,
+                    dict_factory=ci.util.dict_to_json_factory,
+                ) for artefact_metadata in data
+            ]},
+        )
+
+        res.raise_for_status()
+
+    def update_metadata(
+        self,
+        data: typing.Iterable[dso.model.ArtefactMetadata],
+    ):
+        res = requests.put(
+            url=self._routes.update_metadata(),
             json={'entries': [
                 dataclasses.asdict(
                     artefact_metadata,

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -19,7 +19,6 @@ import typing
 
 import ci.log
 import delivery.client
-import delivery.model as dm
 import dso.model
 import gci.componentmodel as cm
 import github.compliance.model
@@ -36,129 +35,17 @@ def sync_results_with_delivery_db(
     bdba_cfg_name: str,
 ):
     try:
-        delivery_client.upload_metadata(
+        # Delete vulnerabilites with new triages from delivery-db for now
+        # XXX in the future, implement own triage object in delivery-db
+        delivery_client.update_metadata(
             data=iter_artefact_metadata(
                 results=results,
                 bdba_cfg_name=bdba_cfg_name,
             ),
         )
-        # Delete vulnerabilites with new triages from delivery-db for now
-        # XXX in the future, implement own triage object in delivery-db
-        delivery_client.delete_metadata(
-            data=iter_artefact_metadata_with_triages(
-                results=results,
-            ),
-        )
-        # Delete findings with no package version if the package without
-        # version is not part of the scan results anymore -> i.e. version
-        # was set manually and therefore the finding is not relevant anymore
-        delivery_client.delete_metadata(
-            data=iter_artefact_metadata_without_package_version(
-                delivery_client=delivery_client,
-                results=results,
-            ),
-        )
     except:
         import traceback
         traceback.print_exc()
-
-
-def iter_artefact_metadata_without_package_version(
-    delivery_client: delivery.client.DeliveryServiceClient,
-    results: typing.Collection[pm.BDBAScanResult],
-) -> typing.Generator[dso.model.ArtefactMetadata, None, None]:
-    component_metadata = dict()
-    for result in results:
-        if isinstance(result, pm.ComponentsScanResult):
-            result: pm.ComponentsScanResult
-
-            a = github.compliance.model.artifact_from_node(result.scanned_element)
-            a_ref = dso.model.component_artefact_id_from_ocm(
-                component=result.scanned_element.component,
-                artefact=a,
-            )
-
-            packages_without_version = {
-                package.name() for package in result.result.components()
-                if not package.version()
-            }
-            seen_package_names = set()
-
-            for package in result.result.components():
-                if package.name() in packages_without_version.union(seen_package_names):
-                    continue
-
-                # there is no instance of the package without a version
-                # delete all findings for that package without version from db (if any)
-                key = result.scanned_element.component_id
-                if not key in component_metadata:
-                    metadata_raw = delivery_client.query_metadata_raw(
-                        components=[key],
-                        type=dso.model.Datatype.VULNERABILITIES_CVE,
-                    )
-                    component_metadata[key] = [
-                        dm.ArtefactMetadata.from_dict(raw).to_dso_model_artefact_metadata()
-                        for raw in metadata_raw
-                    ]
-
-                filtered_metadata = [
-                    cm for cm in component_metadata[key]
-                    if (
-                        cm.artefact.artefact.artefact_name == a_ref.artefact.artefact_name and
-                        cm.artefact.artefact.artefact_version == a_ref.artefact.artefact_version and
-                        cm.artefact.artefact.artefact_type == a_ref.artefact.artefact_type and
-                        dm.ComponentArtefactId.normalise_artefact_extra_id(
-                            artefact_extra_id=cm.artefact.artefact.artefact_extra_id,
-                        ) == dm.ComponentArtefactId.normalise_artefact_extra_id(
-                            artefact_extra_id=a_ref.artefact.artefact_extra_id,
-                        ) and
-                        cm.artefact.artefact_kind == a_ref.artefact_kind and
-                        cm.data.affected_package_name == package.name() and
-                        cm.data.affected_package_version is None
-                    )
-                ]
-                yield from filtered_metadata
-
-
-def iter_artefact_metadata_with_triages(
-    results: typing.Collection[pm.BDBAScanResult],
-) -> typing.Generator[dso.model.ArtefactMetadata, None, None]:
-    for result in results:
-        if isinstance(result, pm.VulnerabilityScanResult):
-            result: pm.VulnerabilityScanResult
-
-            if not result.vulnerability.has_triage():
-                continue
-
-            artefact = github.compliance.model.artifact_from_node(result.scanned_element)
-            artefact_ref = dso.model.component_artefact_id_from_ocm(
-                component=result.scanned_element.component,
-                artefact=artefact,
-            )
-
-            meta = dso.model.Metadata(
-                datasource='',
-                type=dso.model.Datatype.VULNERABILITIES_CVE,
-            )
-
-            cve = dso.model.CVE(
-                cve=result.vulnerability.cve(),
-                cvss3Score=-1,
-                cvss=result.vulnerability.cvss,
-                affected_package_name=result.affected_package.name(),
-                affected_package_version=result.affected_package.version(),
-                reportUrl='',
-                product_id=-1,
-                group_id=-1,
-                base_url='',
-                bdba_cfg_name='',
-            )
-
-            yield dso.model.ArtefactMetadata(
-                artefact=artefact_ref,
-                meta=meta,
-                data=cve,
-            )
 
 
 def iter_artefact_metadata(

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -33,6 +33,8 @@ def sync_results_with_delivery_db(
     delivery_client: delivery.client.DeliveryServiceClient,
     results: typing.Iterable[pm.BDBAScanResult],
     bdba_cfg_name: str,
+    max_retries: int=3,
+    retry_count: int=0,
 ):
     try:
         # Delete vulnerabilites with new triages from delivery-db for now
@@ -46,6 +48,14 @@ def sync_results_with_delivery_db(
     except:
         import traceback
         traceback.print_exc()
+        if retry_count < max_retries:
+            sync_results_with_delivery_db(
+                delivery_client=delivery_client,
+                results=results,
+                bdba_cfg_name=bdba_cfg_name,
+                max_retries=max_retries,
+                retry_count=retry_count + 1,
+            )
 
 
 def iter_artefact_metadata(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
