### PR TITLE
fix: Do not revert submodule updates on release

### DIFF
--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -390,6 +390,9 @@ class CreateTagsStep(TransactionalStep):
                 )
                 self.git_helper.rebase(commit_ish=upstream_commit.hexsha)
 
+                # do not revert potential submodule changes applied with rebase
+                self.git_helper.repo.submodule_update()
+
                 merge_commit = create_merge_commit(upstream_commit)
                 self.context().merge_release_back_to_default_branch_commit = merge_commit
 

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -390,7 +390,8 @@ class CreateTagsStep(TransactionalStep):
                 )
                 self.git_helper.rebase(commit_ish=upstream_commit.hexsha)
 
-                # do not revert potential submodule changes applied with rebase
+                # if repository contains submodules, update worktree to prevent subsequent "git add" from worktree will not
+                # overwrite received upstream changes from rebase. for repositories w/o submodules, this is (almost) a no-op
                 self.git_helper.repo.submodule_update()
 
                 merge_commit = create_merge_commit(upstream_commit)


### PR DESCRIPTION
Prior to merging-back the release-commit, we rebase to apply latest upstream changes. If these changes include a submodule change (e.g. version bump via upgrade-pull-request), they are ultimately reverted. This is caused by rebase not updating the submodule, but only the `pointer` (`.git/modules/<name>/HEAD`). When creating merge-commit with `index-to-commit` semantics, the submodule version from the actual (not updated) submodule is taken and overwrites the `pointer`.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
