### PR TITLE
Automatically set version_interface to 'callback' when callbacks are set

### DIFF
--- a/concourse/model/traits/version.py
+++ b/concourse/model/traits/version.py
@@ -59,7 +59,11 @@ ATTRIBUTES = (
     AttributeSpec.optional(
         name='version_interface',
         default=VersionInterface.FILE,
-        doc='how the version can be read/written. This is done automatically set to "callback", if "read_callback" and "write_callback" are set. Only here for compatibility reasons.',
+        doc='''\
+        how the version can be read/written. This is done automatically set to
+        "callback", if "read_callback" and "write_callback" are set. Only here
+        for compatibility reasons.
+        ''',
         type=VersionInterface,
     ),
     AttributeSpec.optional(
@@ -122,8 +126,11 @@ class VersionTrait(Trait):
         if not self.preprocess in self.PREPROCESS_OPS:
             raise ValueError('preprocess must be one of: ' + ', '.join(self.PREPROCESS_OPS))
 
-        if self.read_callback() and (not self.write_callback()) or (not self.read_callback()) and self.write_callback():
-            raise ModelValidationError(f"write_callback is '{self.write_callback()}' and read_callback is '{self.read_callback()}'. Either set both callbacks or none!")
+        if self.read_callback() and (not self.write_callback()) or \
+          (not self.read_callback()) and self.write_callback():
+            raise ModelValidationError(
+                f"{self.write_callback()=}' {self.read_callback()=}'. Set either both or none!"
+            )
 
 
 ENV_VAR_NAME = 'version_path'

--- a/concourse/model/traits/version.py
+++ b/concourse/model/traits/version.py
@@ -58,7 +58,7 @@ ATTRIBUTES = (
     AttributeSpec.optional(
         name='version_interface',
         default=VersionInterface.FILE,
-        doc='how the version can be read/written',
+        doc='how the version can be read/written. This is done automatically set to "callback", if "read_callback" and "write_callback" are set. Only here for compatibility reasons.',
         type=VersionInterface,
     ),
     AttributeSpec.optional(

--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -4,7 +4,6 @@ import os
 from makoutil import indent_func
 from concourse.steps import step_lib
 from concourse.model.traits.release import TagConflictAction
-from concourse.model.traits.version import VersionInterface
 
 main_repo = job_variant.main_repository()
 head_sha_file = main_repo.head_sha_path()
@@ -26,17 +25,8 @@ legacy_version_file = os.path.join(job_step.output('version_path'), 'number')
 if (read_callback := version_trait.read_callback() or ''):
   read_callback = os.path.join(main_repo.resource_name(), read_callback)
 
-
 if (write_callback := version_trait.write_callback() or ''):
   write_callback = os.path.join(main_repo.resource_name(), write_callback)
-
-# Validate that either both callbacks are set or none
-if (write_callback == '' and read_callback != '') or (write_callback != '' and read_callback == ''):
-  raise ValueError(f"write_callback is '{write_callback}' and read_callback is '{read_callback}'. Either set both callbacks or none!")
-
-# Set version_interface to 'callback' if write_callback and read_callback are set
-if (write_callback != '' and read_callback != ''):
-  version_trait.raw['version_interface']='callback'
 
 version_operation = version_trait.preprocess
 branch_name = main_repo.branch()


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the `version_interface` still uses its default of `file`, even if you specify callbacks in your pipeline. You'd need to set it specifically to `version_interface: callback`, otherwise the callbacks would be ignored and the `VERSION` file is taken.
With this PR, `version_interface` will be automatically changed if callbacks are specified. Additionally, we introduce a validation that both callbacks are set – only being able to read but not write a version is probably not what we want?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set `version_interface: callback` automatically when callback scripts are defined. No need to do this manually in your pipelines anymore.
```
