### PR TITLE
Add optional cross-rotation for AWS and GCP

### DIFF
--- a/cfg_mgmt/aws.py
+++ b/cfg_mgmt/aws.py
@@ -8,9 +8,11 @@ import boto3
 import dacite
 
 import cfg_mgmt
+import cfg_mgmt.util as cmu
 import ci.log
 import model
 import model.aws
+import model.base
 
 from cfg_mgmt.model import (
     CfgQueueEntry,
@@ -51,21 +53,47 @@ class ListAccessKeysResponse:
     Marker: typing.Optional[str] # only present when IsTruncated is True
 
 
+def rotation_cfg_or_none(
+    aws_cfg: model.aws.AwsProfile,
+    cfg_factory: model.ConfigFactory,
+):
+    if (rotation_cfg_reference := aws_cfg.rotation_cfg()):
+        return cfg_factory.resolve_cfg_element_reference(
+            cfg_element_reference=rotation_cfg_reference,
+        )
+
+    return None
+
+
 def rotate_cfg_element(
     cfg_element: model.aws.AwsProfile,
     cfg_factory: model.ConfigFactory,
 ) ->  typing.Tuple[cfg_mgmt.revert_function, dict, model.NamedModelElement]:
+    rotation_cfg = rotation_cfg_or_none(
+        aws_cfg=cfg_element,
+        cfg_factory=cfg_factory,
+    ) or cfg_element
+
+    logger.info(f'using {rotation_cfg.name()=} for rotation')
+
+    iam_user_name = cfg_element.iam_user_name()
 
     iam_client = boto3.client(
         'iam',
-        aws_access_key_id=cfg_element.access_key_id(),
-        aws_secret_access_key=cfg_element.secret_access_key(),
-        region_name=cfg_element.region(),
+        aws_access_key_id=rotation_cfg.access_key_id(),
+        aws_secret_access_key=rotation_cfg.secret_access_key(),
+        region_name=rotation_cfg.region(),
     )
+
+    if iam_user_name:
+        data = iam_client.create_access_key(UserName=iam_user_name)
+
+    else:
+        data = iam_client.create_access_key()
 
     response: CreateAccessKeyResponse = dacite.from_dict(
         data_class=CreateAccessKeyResponse,
-        data=iam_client.create_access_key(),
+        data=data,
     )
     access_key = response.AccessKey
 
@@ -77,7 +105,13 @@ def rotate_cfg_element(
     new_element.raw['secret_access_key'] = access_key.SecretAccessKey
 
     def revert_function():
-        iam_client.delete_access_key(AccessKeyId=access_key.AccessKeyId)
+        if iam_user_name:
+            iam_client.delete_access_key(
+                AccessKeyId=access_key.AccessKeyId,
+                UserName=iam_user_name,
+            )
+        else:
+            iam_client.delete_access_key(AccessKeyId=access_key.AccessKeyId)
 
     secret_id = {'accessKeyId': cfg_element.access_key_id()}
 
@@ -89,20 +123,40 @@ def delete_config_secret(
     cfg_factory: model.ConfigFactory,
     cfg_queue_entry: CfgQueueEntry,
 ) -> model.aws.AwsProfile | None:
+    rotation_cfg = rotation_cfg_or_none(
+        aws_cfg=cfg_element,
+        cfg_factory=cfg_factory,
+    ) or cfg_element
+
+    logger.info(f'using {rotation_cfg.name()=} for deletion')
+
+    iam_user_name = cfg_element.iam_user_name()
+
     iam_client = boto3.client(
         'iam',
-        aws_access_key_id=cfg_element.access_key_id(),
-        aws_secret_access_key=cfg_element.secret_access_key(),
-        region_name=cfg_element.region(),
+        aws_access_key_id=rotation_cfg.access_key_id(),
+        aws_secret_access_key=rotation_cfg.secret_access_key(),
+        region_name=rotation_cfg.region(),
     )
     access_key_id = cfg_queue_entry.secretId['accessKeyId']
-    iam_client.delete_access_key(AccessKeyId=access_key_id)
+
+    if iam_user_name:
+        iam_client.delete_access_key(
+            UserName=iam_user_name,
+            AccessKeyId=access_key_id,
+        )
+
+    else:
+        iam_client.delete_access_key(AccessKeyId=access_key_id)
+
     return None
 
 
 def validate_for_rotation(
     cfg_element: model.aws.AwsProfile,
 ):
+    cfg_element.validate()
+
     access_key_id = cfg_element.access_key_id()
     iam_client = boto3.client(
         'iam',

--- a/cfg_mgmt/util.py
+++ b/cfg_mgmt/util.py
@@ -13,6 +13,7 @@ import cfg_mgmt.rotate as cmro
 import concourse.util
 import gitutil
 import model
+import model.base
 
 
 logger = logging.getLogger(__name__)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -18,6 +18,7 @@ import yaml
 import ci.log
 import ctx
 
+import model.base
 from model.base import (
     ConfigElementNotFoundError,
     ModelValidationError,
@@ -495,6 +496,15 @@ class ConfigFactory:
         serialised_elements[ConfigFactory.CFG_TYPES] = self._cfg_types_raw()
 
         return json.dumps(serialised_elements, indent=2)
+
+    def resolve_cfg_element_reference(
+        self,
+        cfg_element_reference: model.base.CfgElementReference,
+    ):
+        return self._cfg_element(
+            cfg_type_name=cfg_element_reference.type_name,
+            cfg_name=cfg_element_reference.element_name,
+        )
 
 
 class ConfigSetSerialiser:

--- a/model/aws.py
+++ b/model/aws.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from model.base import (
-    NamedModelElement,
-)
+import dacite
+
+import model.base
 
 
-class AwsProfile(NamedModelElement):
+class AwsProfile(model.base.NamedModelElement):
     def region(self):
         return self.raw['region']
 
@@ -28,5 +28,31 @@ class AwsProfile(NamedModelElement):
     def secret_access_key(self):
         return self.raw['secret_access_key']
 
+    def rotation_cfg(self) -> model.base.CfgElementReference:
+        '''
+        used to specify cfg-element to use for cross-rotation
+        '''
+        raw = self.raw.get('rotation_cfg')
+        if raw:
+            return dacite.from_dict(
+                data_class=model.base.CfgElementReference,
+                data=raw,
+            )
+
+        return None
+
+    def iam_user_name(self):
+        '''
+        used to specify own iam user when rotating with cross-rotation
+        '''
+        return self.raw.get('iam_user_name')
+
     def _required_attributes(self):
-        return ['region','access_key_id','secret_access_key']
+        static_attributes = [
+            'region',
+            'access_key_id',
+            'secret_access_key',
+        ]
+        dynamic_attributes = ['iam_user_name'] if self.rotation_cfg() else []
+
+        return static_attributes + dynamic_attributes

--- a/model/base.py
+++ b/model/base.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 import ci.util
 
 
@@ -175,3 +177,10 @@ class TokenCredentials(ModelBase):
 
     def _required_attributes(self):
         return ['token']
+
+
+@dataclasses.dataclass(frozen=True)
+class CfgElementReference:
+    type_name: str
+    element_name: str
+    purpose: str | None = None

--- a/model/gcp.py
+++ b/model/gcp.py
@@ -1,9 +1,9 @@
-from model.base import (
-    NamedModelElement,
-)
+import dacite
+
+import model.base
 
 
-class GcpServiceAccount(NamedModelElement):
+class GcpServiceAccount(model.base.NamedModelElement):
     def service_account_key(self):
         '''
         service-account-key (credentials) as retrieved from GCP's IAM & Admin console
@@ -24,6 +24,19 @@ class GcpServiceAccount(NamedModelElement):
 
     def private_key_id(self) -> str:
         return self.service_account_key()['private_key_id']
+
+    def rotation_cfg(self) -> model.base.CfgElementReference:
+        '''
+        used to specify cfg-element to use for cross-rotation
+        '''
+        raw = self.raw.get('rotation_cfg')
+        if raw:
+            return dacite.from_dict(
+                data_class=model.base.CfgElementReference,
+                data=raw,
+            )
+
+        return None
 
     def _required_attributes(self):
         return ['service_account_key','project']


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds optional "cross-rotation" (rotate User A with credentials of user B) for GCP and AWS ServiceAccounts.
Can be opt-in by adding attribute `rotation_cfg_name`.
AWS also requires to specify ServiceAccount name via attribute `iam_user_name`.

If `rotation_cfg_name` is not specified the regular "self-rotation" is performed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
