### PR TITLE
Add option to delete old BDBA products

### DIFF
--- a/protecode/client.py
+++ b/protecode/client.py
@@ -203,10 +203,12 @@ class ProtecodeApi:
         '''
         replaces "invalid" underscore characters (setting metadata fails silently if
         those are present). Note: dash characters are implcitly converted to underscore
-        by protecode.
+        by protecode. Also, translates `None` to an empty string as header fields with
+        `None` are going to be silently ignored while an empty string is used to remove
+        a metadata attribute
         '''
         return {
-            'META-' + str(k).replace('_', '-'): v
+            'META-' + str(k).replace('_', '-'): v if not None else ''
             for k,v in custom_attributes.items()
         }
 


### PR DESCRIPTION
Using this option, an interval X can be set after which "old" products (i.e. products which were not (re-)scanned for the last X period) are going to be deleted. Hence, this interval must not be set smaller than the specified rescan interval since then the products are going to be deleted continuously. Also, products belonging to resources which are not scanned anymore (in no version) are not going to be deleted.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
