### PR TITLE
Oci layer blobs from local blob accesses

### DIFF
--- a/cnudie/upload.py
+++ b/cnudie/upload.py
@@ -91,7 +91,6 @@ def upload_component_descriptor(
     on_exist:UploadMode|str=UploadMode.SKIP,
     ocm_repository: cm.OciOcmRepository | str = None,
     oci_client: oci.client.Client=None,
-    extra_layers: list[gci.oci.OciBlobRef]=[],
 ):
     if not oci_client:
         oci_client = ccc.oci.oci_client()
@@ -173,12 +172,14 @@ def upload_component_descriptor(
         data=cfg_raw,
     )
 
-    for blob_ref in _iter_oci_blob_refs(
-        component=component,
-        oci_client=oci_client,
-        oci_image_reference=target_ref,
-    ):
-        extra_layers.append(blob_ref)
+    local_blob_layers = [
+        blob_ref for blob_ref in
+        _iter_oci_blob_refs(
+            component=component,
+            oci_client=oci_client,
+            oci_image_reference=target_ref,
+        )
+    ]
 
     manifest = om.OciImageManifest(
         config=gci.oci.ComponentDescriptorOciCfgBlobRef(
@@ -190,7 +191,7 @@ def upload_component_descriptor(
                 digest=cd_digest_with_alg,
                 size=cd_octets,
             ),
-        ] + extra_layers,
+        ] + local_blob_layers,
     )
 
     manifest_dict = manifest.as_dict()

--- a/cnudie/upload.py
+++ b/cnudie/upload.py
@@ -172,14 +172,14 @@ def upload_component_descriptor(
         data=cfg_raw,
     )
 
-    local_blob_layers = [
+    local_blob_layers = { # use set for deduplication
         blob_ref for blob_ref in
         _iter_oci_blob_refs(
             component=component,
             oci_client=oci_client,
             oci_image_reference=target_ref,
         )
-    ]
+    }
 
     manifest = om.OciImageManifest(
         config=gci.oci.ComponentDescriptorOciCfgBlobRef(
@@ -191,7 +191,7 @@ def upload_component_descriptor(
                 digest=cd_digest_with_alg,
                 size=cd_octets,
             ),
-        ] + local_blob_layers,
+        ] + list(local_blob_layers),
     )
 
     manifest_dict = manifest.as_dict()

--- a/gci/componentmodel.py
+++ b/gci/componentmodel.py
@@ -83,6 +83,7 @@ class LocalBlobAccess(Access):
     '''
     type: AccessTypeOrStr = AccessType.LOCAL_BLOB
     localReference: str
+    size: int = None
     mediaType: str = 'application/data'
     referenceName: typing.Optional[str] = None
     globalAccess: typing.Optional[LocalBlobGlobalAccess | dict | None] = None
@@ -521,6 +522,12 @@ class Component(LabelMethodsMixin):
 
     def identity(self):
         return ComponentIdentity(name=self.name, version=self.version)
+
+    def iter_artefacts(self) -> typing.Generator[None, None, Source | Resource]:
+        if self.sources:
+            yield from self.sources
+        if self.resources:
+            yield from self.resources
 
 
 @functools.lru_cache

--- a/oci/model.py
+++ b/oci/model.py
@@ -200,6 +200,30 @@ class OciBlobRef:
         raw = {k:v for k,v in raw.items() if v is not None}
         return raw
 
+    def __hash__(self):
+        annotations = tuple(sorted(self.annotations.items())) if self.annotations else ()
+        return hash((self.digest, self.size, self.mediaType, annotations))
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, OciBlobRef):
+            return False
+
+        other: OciBlobRef
+
+        if not self.digest == other.digest:
+            return False
+
+        if not self.mediaType == other.mediaType:
+            return False
+
+        if not self.size == other.size:
+            return False
+
+        if not self.annotations == other.annotations:
+            return False
+
+        return True
+
 
 @dataclasses.dataclass
 class OciImageManifest:


### PR DESCRIPTION
**What this PR does / why we need it**

If publishing a component-descriptor containing local blob accesses, it is necessary to also reference those blobs as OCI Image Layers in the (synthesised) OCI Image Manifest. Do this by inspecting all accesses of a given Component Descriptor (note: this code assumes that referenced blobs were uploaded prior to invoking `upload_component_descriptor` function).

Add non-standard `size` attribute to local blob access, use it if set (size is required for OCI Image Layer entries) to avoid a http-head request in case of absent globalAccess attribute. As fallback, determine blob's size from passed OCI Image Reference.

**Special notes for your reviewer**

This change is backwards-incompatible, as it removes the `extra_layers` parameter (no longer required after this change).

