### PR TITLE
Fix ocm cfg type name

### DIFF
--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -597,7 +597,7 @@ class OcmResolverConfig:
 class OcmSoftwareConfig:
     resolvers: list[OcmResolverConfig]
     aliases: typing.Optional[dict[str, dict]] = None
-    type: str = 'credentials.config.ocm.software'
+    type: str = 'ocm.config.ocm.software'
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
**What this PR does / why we need it**:

The ocm configuration's `type` should be `ocm.config.ocm.software` instead of `credentials.config.ocm.software`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @fabianburth @ccwienk @AndreasBurger 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
