### PR TITLE
Github token replication for Solinas service

### DIFF
--- a/concourse/steps/replicate_secrets.py
+++ b/concourse/steps/replicate_secrets.py
@@ -230,10 +230,11 @@ def _put_sugar_solinas_service_secret(
     cfg_factory: model.ConfigFactory,
     target: model.config_repo.SugarSolinasServiceTarget,
 ):
-    team_id = target.team_id
-    credentials = cfg_factory.sugar(team_id).credentials()
+    cfg_name = target.sugar_config_name
+    credentials = cfg_factory.sugar(cfg_name).credentials()
     service_account = credentials['service_account']
     password = credentials['password']
+    team_id = target.team_id
     github = target.github
     auth_token = cfg_factory.github(github).credentials().auth_token()
     client = SugarUpdateClient(service_account, password, auth_token)

--- a/model/config_repo.py
+++ b/model/config_repo.py
@@ -26,13 +26,14 @@ class KubernetesSecretTarget:
 @dataclasses.dataclass
 class SugarSolinasServiceTarget:
     type: str
+    sugar_config_name: str
     team_id: str
     github: str
 
 
 @dataclasses.dataclass
 class ReplicationMapping:
-    target: SecretsServerTarget | KubernetesSecretTarget
+    target: SecretsServerTarget | KubernetesSecretTarget | SugarSolinasServiceTarget
     cfg_set: str
 
 

--- a/model/config_repo.py
+++ b/model/config_repo.py
@@ -24,6 +24,13 @@ class KubernetesSecretTarget:
 
 
 @dataclasses.dataclass
+class SugarSolinasServiceTarget:
+    type: str
+    team_id: str
+    github: str
+
+
+@dataclasses.dataclass
 class ReplicationMapping:
     target: SecretsServerTarget | KubernetesSecretTarget
     cfg_set: str

--- a/model/sugar.py
+++ b/model/sugar.py
@@ -14,6 +14,12 @@ class Sugar(NamedModelElement):
         '''
         return self.raw['github']
 
+    def team_id(self):
+        '''
+        solinas API team_id
+        '''
+        return self.raw['team_id']
+
     def credentials(self):
         '''
         credentials (service_account and password) used for updating github_token
@@ -21,4 +27,4 @@ class Sugar(NamedModelElement):
         return self.raw['credentials']
 
     def _required_attributes(self):
-        return ['github', 'credentials']
+        return ['team_id', 'github', 'credentials']


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up of #939.
The Solinas service (SUGAR) only needs the new github token, but no rotation of a user.
Therefore instead of using the rotation functionality, it is integrated with the secrets replication to simplify it.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Github token replication for Solinas service
```
