### PR TITLE
Adding TagAsLatestUploader uploader to ctt

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -465,6 +465,21 @@ def process_images(
             oci_client=oci_client,
         )
 
+        if extra_tags := processing_job.extra_tags:
+            target_ref = om.OciImageReference(processing_job.upload_request.target_ref)
+            target_repo = target_ref.ref_without_tag
+            manifest_bytes = oci_client.manifest_raw(
+                image_reference=f'{target_repo}{docker_content_digest}',
+            ).content
+
+        for extra_tag in extra_tags:
+            push_target = f'{target_repo}:{extra_tag}'
+
+            oci_client.put_manifest(
+                image_reference=push_target,
+                manifest=manifest_bytes,
+            )
+
         if not docker_content_digest:
             raise RuntimeError(f'No Docker_Content_Digest returned for {processing_job=}')
 

--- a/ctt/processing_model.py
+++ b/ctt/processing_model.py
@@ -23,3 +23,4 @@ class ProcessingJob:
     upload_request: ContainerImageUploadRequest
     processed_resource: cm.Resource | None = None  # added after re-upload
     inject_ocm_coordinates_into_oci_manifest: bool = False
+    extra_tags: tuple[str] = ()

--- a/ctt/uploaders.py
+++ b/ctt/uploaders.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import typing
 
 import ci.util
-import gci.componentmodel as cm
-import oci.client
-
 import ctt.processing_model as pm
 import ctt.util as ctt_util
+import gci.componentmodel as cm
+import oci.client
 import oci.model as om
 
 original_ref_label_name = 'cloud.gardener.cnudie/migration/original_ref'
@@ -178,6 +178,20 @@ class TagSuffixUploader:
             processing_job,
             upload_request=upload_request
         )
+
+
+class ExtraTagUploader:
+    '''
+    Uploader that will push additional (static) tags to uploaded images. Useful to e.g. add
+    `latest` tag. Extra-Tags will be overwritten as a hardcoded behaviour of this uploader.
+    '''
+    def __init__(self, extra_tags: typing.Iterable[str]):
+        self.extra_tags = tuple(extra_tags)
+
+    def process(self, processing_job, target_as_source=False):
+        processing_job.extra_tags = self.extra_tags
+
+        return processing_job
 
 
 class DigestUploader:


### PR DESCRIPTION
**What this PR does / why we need it**:
PR adds uploader to the CTT that allows to move the `latest` tag to the id/digest of the image in CM.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
PR passed `.ci/lint` and `.ci/test` steps but was not tested beyond that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
ctt now has 'TagAsLatestUploader' uploader
```
