### PR TITLE
[btp_application_certificate] Store intermediate certificate and send it on client authentication

### DIFF
--- a/cfg_mgmt/btp_application_certificate.py
+++ b/cfg_mgmt/btp_application_certificate.py
@@ -55,10 +55,6 @@ class CertServiceClient:
         self.access_token = resp.json()['access_token']
 
     def create_client_certificate_chain(self, csr_pem: str, validity_in_days: int) -> dict:
-        '''
-        see https://pages.github.tools.sap/sap-pki-certificate-service/consumer-guide/getting-started/get-client-certificate/
-        see https://pages.github.tools.sap/sap-pki-certificate-service/consumer-guide/specifications/api/
-        '''
         headers = {
             'Accept': 'application/json',
             'Authorization': f'Bearer {self.access_token}',
@@ -214,10 +210,10 @@ def _extract_client_certificate(cert_response: dict) -> str:
     certs = pkcs7.load_pem_pkcs7_certificates(pkcs7_pem.encode('utf-8'))
     if not certs:
         raise ValueError('no certificates found in response')
-    allCerts = ""
+    all_certs = ""
     for c in certs:
-        allCerts += c.public_bytes(serialization.Encoding.PEM).decode('utf-8')
-    return allCerts
+        all_certs += c.public_bytes(serialization.Encoding.PEM).decode('utf-8')
+    return all_certs
 
 
 def rotate_cfg_element(
@@ -280,10 +276,3 @@ def delete_config_secret(
             gbaas_client.delete_certificate(info.cn, info.id)
 
     return None
-
-
-def test(cfg_factory: model.ConfigFactory):
-    gbaas_auth = cfg_factory.btp_application_certificate("dev-i503479-gbaas-rotation")
-    gbaas_client = GBaasAppClient(gbaas_auth)
-    for info in  gbaas_client.list_certificates_by_base("dev.k8s.ondemand.com"):
-      print(info)


### PR DESCRIPTION

**What this PR does / why we need it**:
The certificate service introduced a new intermediate certificate which causes problems with client authentication like
```
requests.exceptions.SSLError: HTTPSConnectionPool(host='agw0s98rn.accounts.ondemand.com', port=443): Max retries exceeded with url: /service/sps/74e3f610-893d-4e75-86e6-f480a120a156/apiCertificate (Caused by SSLError(SSLError(1, '[SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:1006)')))
```

The issue is fixed by sending both certificate and the intermediate certificate on client authentication.

Additionally, small improvements have been included:
- use new v3 for certificate generation
- change key size to 3072


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[btp_application_certificate] Store intermediate certificate and send it on client authentication
```
