### PR TITLE
Rotation of Service Account kubeconfigs from Garden

### DIFF
--- a/cfg_mgmt/util.py
+++ b/cfg_mgmt/util.py
@@ -168,6 +168,11 @@ def write_named_element(
     # To avoid this for kubernetes configs, only update the part that holds the kubeconfig
     if cfg_element._type_name == 'kubernetes':
         file_contents[cfg_element.name()]['kubeconfig'] = cfg_element.raw['kubeconfig']
+
+        if not cfg_element.raw.get('bound_secret_name'):
+            return
+
+        file_contents[cfg_element.name()]['bound_secret_name'] = cfg_element.raw['bound_secret_name']
     # for all other cases, just replace the contents of the top-level element (this will resolve
     # anchors)
     else:

--- a/model/kubernetes.py
+++ b/model/kubernetes.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import enum
 import typing
 
 from model.base import (
@@ -23,6 +24,10 @@ class ServiceAccountConfig(ModelBase):
     def namespace(self) -> str:
         return self.raw['namespace']
 
+
+class RotationStrategy(enum.StrEnum):
+    SECRET = 'secret'
+    TOKEN_REQUEST = 'tokenRequest'
 
 class KubernetesConfig(NamedModelElement):
     def _required_attributes(self):
@@ -47,3 +52,8 @@ class KubernetesConfig(NamedModelElement):
         fallback to default if no namespace is configured
         '''
         return self.raw.get('namespace', 'default')
+
+    def rotation_strategy(self) -> RotationStrategy:
+        raw = self.raw.get('rotation_strategy', 'secret')
+        return RotationStrategy(raw)
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatic rotation for kubeconfigs of Service Account tokens in the Garden. 
This introduces a new attribute for "rotation_strategy" for the kubeconfig configs, for example
```
cluster-management:
  service_account:
    name: cluster-manager
    namespace: garden-mycluster

  rotation_strategy: tokenRequest

  kubeconfig:
  [...]
  bound_secret_name: cluster-manager-token
```
If set to the value "tokenRequest", a new token for the Service Account with max. validity of 90d is created and bound to a new Secret (opaque) created. The secret name is stored in kubeconfig with attribute "bound_secret_name",  which will be used in the next rotation cycle to added to the deletion queue. 

If no attribute "rotation_strategy", function works like before as default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
