### PR TITLE
retain attributes from unknown `access`-types

### DIFF
--- a/test/gci/componentmodel_test.py
+++ b/test/gci/componentmodel_test.py
@@ -37,9 +37,10 @@ def test_deserialisation_of_custom_resources():
     )
     component = component_descriptor.component
 
-    assert isinstance(component.resources[0].access, cm.Access)
+    assert isinstance(component.resources[0].access, dict)
+    assert component.resources[0].access.type == 'localFilesystemBlob'
     assert component.resources[1].access is None
-    assert isinstance(component.resources[2].access, cm.Access)
+    assert isinstance(component.resources[2].access, dict)
     assert isinstance(component.resources[3].access, cm.RelativeOciAccess)
 
 


### PR DESCRIPTION
OCM is designed as a typed, extensible model. For operations not requiring the processing of certain aspects of model elements (e.g. opaque replication of OCM Component Descriptors), it is the desired behaviour for tooling to accept unknonwn model elements and retain them unmodified.

Therefore, add `dict` as fallback deserialisation type for `dacite`. For the sake of keeping code api-compatible, use custom `AccessDict` to still expose attribute `type`, which is expected to be accessible as attribute from existing users.

