### PR TITLE
Correct image ref format when adding extra tags

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -447,7 +447,7 @@ def process_images(
             target_ref = om.OciImageReference(processing_job.upload_request.target_ref)
             target_repo = target_ref.ref_without_tag
             manifest_bytes = oci_client.manifest_raw(
-                image_reference=f'{target_repo}{oci_manifest_digest}',
+                image_reference=f'{target_repo}@{oci_manifest_digest}',
             ).content
 
         for extra_tag in extra_tags:


### PR DESCRIPTION
**What this PR does / why we need it**:

Correcting the process for adding extra tags when referencing image digests. Currently it fails with messages, similar to:

```
2024-03-29 13:36:42,134 [WARNING] oci.client: rq against url='https://repo.example.com/gardener/someimagesha256/manifests/412d2bc598c95df013b56ca64555734ec2d27628524c6b6569abe02a413f630e' failed res.status_code=404 res.reason='Not Found' method='GET' b'{"errors":[{"code":"MANIFEST_UNKNOWN","message":"Failed to fetch \\"412d2bc598c95df013b56ca64555734ec2d27628524c6b6569abe02a413f630e\\""}]}\n'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
