### PR TITLE
Don't use fallback ocm repos in case of "allowed" errors

### DIFF
--- a/delivery/client.py
+++ b/delivery/client.py
@@ -120,7 +120,6 @@ class DeliveryServiceClient:
         ocm_repo_url: str=None,
         version_filter: str | None=None,
         validation_mode: cm.ValidationMode=cm.ValidationMode.NONE,
-        ignore_errors: tuple[Exception]=tuple(),
     ):
         params = {
             'component_name': name,
@@ -132,16 +131,13 @@ class DeliveryServiceClient:
         if version_filter is not None:
             params['version_filter'] = version_filter
 
-        try:
-            res = self.session.get(
-                url=self._routes.component_descriptor(),
-                params=params,
-                timeout=(4, 31),
-            )
+        res = self.session.get(
+            url=self._routes.component_descriptor(),
+            params=params,
+            timeout=(4, 31),
+        )
 
-            res.raise_for_status()
-        except ignore_errors:
-            return
+        res.raise_for_status()
 
         return cm.ComponentDescriptor.from_dict(
             res.json(),


### PR DESCRIPTION
To prevent unintended behaviours, don't use fallback ocm repositories in case an "allowed" error is caught. Instead, stop the current lookup (i.e. delivery service lookup) and continue with the next lookup (if any). Only use fallback ocm repos in case a 404 http error is caught.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
