### PR TITLE
Add support for build metadata in version string

### DIFF
--- a/ccc/oci.py
+++ b/ccc/oci.py
@@ -1,3 +1,4 @@
+import collections.abc
 import functools
 import logging
 import traceback
@@ -67,6 +68,8 @@ def oci_client(
     install_logging_handler: bool=True,
     cfg_factory=None,
     http_connection_pool_size:int=16,
+    tag_preprocessing_callback: collections.abc.Callable[[str], str]=None,
+    tag_postprocessing_callback: collections.abc.Callable[[str], str]=None,
 ) -> oc.Client:
     def base_api_lookup(image_reference):
         registry_cfg = model.container_registry.find_config(
@@ -107,6 +110,8 @@ def oci_client(
         credentials_lookup=credentials_lookup,
         routes=routes,
         session=session,
+        tag_preprocessing_callback=tag_preprocessing_callback,
+        tag_postprocessing_callback=tag_postprocessing_callback,
     )
 
 

--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -22,6 +22,8 @@ ComponentName = (
     | str
 )
 
+META_SEPARATOR = '.build-'
+
 
 def to_component_id(
     component: ComponentId, /
@@ -566,3 +568,24 @@ def diff_resources(
             _add_if_not_duplicate(resource_diff.resource_refs_only_right, i)
 
     return resource_diff
+
+
+def sanitise_version(version: str) -> str:
+    '''
+    Additional build metadata as defined in SemVer can be added via `+` to the version. However,
+    OCI registries don't support `+` as tag character, which is why it has to be sanitised, for
+    example using `META_SEPARATOR`.
+    '''
+    sanitised_version = version.replace('+', META_SEPARATOR)
+
+    return sanitised_version
+
+
+def desanitise_version(version: str) -> str:
+    '''
+    This function reverts the sanitisation of the `sanitise_version` function, which allows
+    processing the version the same way as prior to using `sanitise_version`.
+    '''
+    desanitised_version = version.replace(META_SEPARATOR, '+')
+
+    return desanitised_version


### PR DESCRIPTION
**What this PR does / why we need it**:
To be compatible with SemVer, we should be able to handle versions which include optional build metadata
([see](https://semver.org/#spec-item-10)). In general, this is already the case. However, (some) OCI registries don't allow `+` in their tags, which is used as separator for these build metadata. That's why, the version has to be sanitised prior to uploading to a registry or after retrieving it from there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
