### PR TITLE
fix: properly validate uniqueness of resource-names

### DIFF
--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -181,6 +181,9 @@ component_v2.resources.append(
     name='${helmchart.name}',
     version=effective_version, # always inherited from component
     type='helmChart',
+    extraIdentity={
+      'type': 'helmChart', # allow images w/ same name
+    },
     relation=cm.ResourceRelation.LOCAL,
     access=cm.OciAccess(
       type=cm.AccessType.OCI_REGISTRY,


### PR DESCRIPTION
Remove old codepath, originally intended for kaniko (+ remove check for extra-push-target, which was a limitation for (removed) kaniko-builder). Instead, validate uniqueness of resource-names.

