### PR TITLE
store helmchart-imagemap w/ same name as helmchart

### DIFF
--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -173,9 +173,12 @@ oci_client.put_blob(
 
 component.resources.append(
   cm.Resource(
-    name='${helmchart.name}-imagemap',
+    name='${helmchart.name}',
     version=version_str,
     type='helmchart-imagemap',
+    extraIdentity={
+      'type': 'helmchart-imagemap',
+    },
     access=cm.LocalBlobAccess(
       mediaType='application/data',
       localReference=mapping_digest,


### PR DESCRIPTION
Helmcharts built/published from pipeline-template will often by convention be named the same as the (main) OCI Image they reference/install. To avoid name-clashes, helmcharts declare their type as extraIdentity when being added into OCM Component-Descriptors.

Following that approach, also use same names for automatically generated imagemap-resources, and also add their type as extraIdentity.

