### PR TITLE
Don't store component version for BDBA scan results

### DIFF
--- a/protecode/model.py
+++ b/protecode/model.py
@@ -356,7 +356,7 @@ class BdbaScanError(Exception):
     def print_stacktrace(self):
         c = self.component
         a = self.artefact
-        name = f'{c.name}:{c.version}/{a.name}:{a.version}'
+        name = f'{c.name}/{a.name}:{a.version}'
 
         if not self.exception:
             return name + ' - no exception available'

--- a/protecode/util.py
+++ b/protecode/util.py
@@ -53,14 +53,13 @@ def iter_artefact_metadata(
     license_cfg: image_scan.LicenseCfg=None,
     delivery_client: delivery.client.DeliveryServiceClient=None,
 ) -> collections.abc.Generator[dso.model.ArtefactMetadata, None, None]:
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     discovery_date = datetime.date.today()
     datasource = dso.model.Datasource.BDBA
 
-    artefact = gcm.artifact_from_node(node=scanned_element)
     artefact_ref = dso.model.component_artefact_id_from_ocm(
         component=scanned_element.component,
-        artefact=artefact,
+        artefact=scanned_element.resource,
     )
 
     base_url = scan_result.base_url()
@@ -284,16 +283,12 @@ def enum_triages(
 def component_artifact_metadata(
     component: cm.Component,
     artefact: cm.Artifact,
-    omit_component_version: bool,
     omit_resource_version: bool,
     oci_client: oci.client.Client,
 ):
     ''' returns a dict for querying bdba scan results (use for custom-data query)
     '''
     metadata = {'COMPONENT_NAME': component.name}
-
-    if not omit_component_version:
-        metadata |= {'COMPONENT_VERSION': component.version}
 
     if isinstance(artefact.access, cm.OciAccess):
         metadata['IMAGE_REFERENCE_NAME'] = artefact.name


### PR DESCRIPTION
**What this PR does / why we need it**:
We do already re-use existing BDBA scans for an artefact version in case only the component version has changed. However, we have still stored the scan results for each component version separately, resulting in duplicated findings in case the artefact version did not change. To deduplicate those findings, don't store the component version anymore. However, this also requires downstream adjustments since with this change it is not possible anymore to retrieve all findings for a component version directly, but instead the included artefact versions must be specified as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
