### PR TITLE
Add optional `references` to `ComponentArtefactId`

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -51,7 +51,7 @@ def normalise_artefact_extra_id(
 @dataclasses.dataclass(frozen=True)
 class LocalArtefactId:
     artefact_name: str | None
-    artefact_type: str
+    artefact_type: str | None
     artefact_version: str | None = None
     artefact_extra_id: dict = dataclasses.field(default_factory=dict)
 
@@ -80,19 +80,27 @@ def is_ocm_artefact(artefact_kind: ArtefactKind) -> bool:
 class ComponentArtefactId:
     component_name: str | None
     component_version: str | None
-    artefact: LocalArtefactId
+    artefact: LocalArtefactId | None
     artefact_kind: ArtefactKind = ArtefactKind.ARTEFACT
+    references: list['ComponentArtefactId'] = dataclasses.field(default_factory=list)
 
     def as_frozenset(self) -> frozenset[str]:
-        return frozenset((
+        props = (
             self.component_name,
             self.component_version,
             self.artefact_kind,
-            self.artefact.artefact_name,
-            self.artefact.artefact_version,
-            self.artefact.artefact_type,
-            # frozenset(self.artefact.artefact_extra_id.items()),
-        ))
+            frozenset(self.references),
+        )
+
+        if self.artefact:
+            props += (
+                self.artefact.artefact_name,
+                self.artefact.artefact_version,
+                self.artefact.artefact_type,
+                # frozenset(self.artefact.artefact_extra_id.items()),
+            )
+
+        return frozenset(props)
 
     def __hash__(self):
         return hash(self.as_frozenset())


### PR DESCRIPTION
In case of runtime artefacts, the existence of a OCM component descriptor `<component_name>:<component_version>` where the defined artefact is referenced in does not have to exist. However, it may be related to such a component or artefact (or both). To allow expressing such semantics, a new field `references` is added, which allows defining such relations in a recursive manner.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
