### PR TITLE
Add support for merged diki report

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -330,7 +330,7 @@ class ClamAVMalwareFinding(Finding):
 @dataclasses.dataclass(frozen=True)
 class DikiCheck:
     message: str
-    targets: list[dict]
+    targets: list[dict] | dict[str, list[dict]]
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
**What this PR does / why we need it**:
Merged diki reports contain compliance data from more than 1 evaluated instance. The targets of the merged checks is a map with keys the id of a specific instance and value the found targets of that instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
