### PR TITLE
Do not risk inconsistencies during component updates

### DIFF
--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -12,6 +12,7 @@ import gci.componentmodel as cm
 
 main_repo = job_variant.main_repository()
 repo_name = main_repo.repo_name()
+repo_hostname = main_repo.repo_hostname()
 repo_relpath = main_repo.resource_name()
 repo_owner = main_repo.repo_owner()
 repo_branch = main_repo.branch()
@@ -101,16 +102,6 @@ pull_request_util = github.util.PullRequestUtil(
     github_cfg=github_cfg,
 )
 
-## hack / workaround: rebase to workaround concourse sometimes not refreshing git-resource
-git_helper = gitutil.GitHelper(
-    repo=REPO_ROOT,
-    github_cfg=github_cfg,
-    github_repo_path=f'{REPO_OWNER}/{REPO_NAME}',
-)
-git_helper.rebase(
-    commit_ish=REPO_BRANCH,
-)
-
 upgrade_pull_requests = pull_request_util.enumerate_upgrade_pull_requests(
     state='all',
 )
@@ -186,6 +177,7 @@ for from_ref, to_version in determine_upgrade_prs(
         version_lookup=version_lookup,
         merge_policy=merge_policy,
         merge_method=merge_method,
+        repo_hostname=repo_hostname,
 % if after_merge_callback:
         after_merge_callback='${after_merge_callback}',
 % endif

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -1,7 +1,9 @@
+import collections.abc
 import logging
 import os
 import subprocess
 import tempfile
+import textwrap
 import time
 import traceback
 import typing
@@ -10,10 +12,13 @@ import gci.componentmodel
 import github3.exceptions
 import github3.repos.repo
 
+import ccc.concourse
 import ccc.github
 import ci.util
 import cnudie.retrieve
 import cnudie.util
+import concourse.client.api
+import concourse.client.model
 import concourse.model.traits.update_component_deps
 import concourse.paths
 import concourse.steps.component_descriptor_util as cdu
@@ -30,6 +35,7 @@ from concourse.model.traits.update_component_deps import (
 from github.util import (
     GitHubRepoBranch,
 )
+
 
 logger = logging.getLogger('step.update_component_deps')
 
@@ -362,6 +368,30 @@ def _import_release_notes(
     return release_notes
 
 
+def _iter_concourse_resources(
+    concourse_api: concourse.client.api.ConcourseApiBase,
+    repo_hostname: str,
+    repo_path: str,
+) -> collections.abc.Generator[concourse.client.model.PipelineConfigResource, None, None]:
+    resources_gen = concourse_api.pipeline_resources(
+        concourse_api.pipelines(),
+        resource_type=concourse.client.model.ResourceType.GIT,
+    )
+
+    for resource in resources_gen:
+        resource: concourse.client.model.PipelineConfigResource
+
+        ghs = resource.github_source()
+
+        if not ghs.hostname() == repo_hostname:
+            continue
+
+        if not ghs.repo_path().lstrip('/') == repo_path:
+            continue
+
+        yield resource
+
+
 def create_upgrade_pr(
     component: gci.componentmodel.Component,
     from_ref: gci.componentmodel.ComponentReference,
@@ -377,6 +407,7 @@ def create_upgrade_pr(
     merge_method: MergeMethod,
     version_lookup,
     component_descriptor_lookup,
+    repo_hostname: str,
     after_merge_callback=None,
     container_image:str=None,
 ) -> github.util.UpgradePullRequest:
@@ -563,6 +594,26 @@ def create_upgrade_pr(
                 f'Unable to merge upgrade pull request #{pull_request.number} '
                 f'({pull_request.html_url}).'
             )
+            pull_request.create_comment(textwrap.dedent(
+                '''
+                Unable to auto-merge PR.
+                This is most likely caused by merge conflicts.
+                Will trigger resource-check and retry, next PR should be successfully merged.
+                '''
+            ))
+            pull_request.close()
+
+            concourse_api = ccc.concourse.client_from_env()
+            for resource in _iter_concourse_resources(
+                concourse_api=concourse_api,
+                repo_hostname=repo_hostname,
+                repo_path=githubrepobranch.github_repo_path(),
+            ):
+                logger.info('triggering resource check for: ' + resource.name)
+                concourse_api.trigger_resource_check(
+                    pipeline_name=resource.pipeline_name(),
+                    resource_name=resource.name,
+                )
 
     _merge_pr(merge_method=merge_method, pull_request=pull_request, attempts=3)
 


### PR DESCRIPTION
Rebasing git repository is not sufficient as component updates also consider component version range for release notes. Rather fail current component update build and trigger resource check, so next iteration will succeed.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
