### PR TITLE
Release asset files

### DIFF
--- a/concourse/model/step.py
+++ b/concourse/model/step.py
@@ -306,9 +306,11 @@ class PipelineStep(ModelBase):
             raise ValueError(f'expected a dict, but received: {type(raw_dict)} ({raw_dict})')
 
         raw_dict['depends'] = set(raw_dict['depends'])
-        if raw_dict.get('output_dir', None):
-            name = raw_dict['output_dir']
-            self.add_output(name=name + '_path', variable_name=name + '_path')
+        if (name := raw_dict.get('output_dir', None)):
+            self.add_output(
+                name=name,
+                variable_name=f'{name}_path',
+            )
 
         # add hard-coded output "on_error" (allows build steps to pass custom
         # notification cfg for build errors)
@@ -394,12 +396,7 @@ class PipelineStep(ModelBase):
         return self.raw.get('registry', None)
 
     def output_dir(self):
-        if not self.raw['output_dir']:
-            return None
-
-        # an optional attribute specifying the "output directory"
-        # due to "historical" reasons, append '-path' suffix
-        return self.raw.get('output_dir') + '_path'
+        return self.raw['output_dir']
 
     def output(self, name):
         outputs = self.outputs()

--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -426,9 +426,8 @@ class ReleaseTraitTransformer(TraitTransformer):
                 main_repo._trigger = False
 
         # validate assets if present
-        step_names = {step.name for step in pipeline_args.steps()}
         for asset in self.trait.assets:
-            if asset.step_name not in step_names:
+            if not pipeline_args.has_step(asset.step_name):
                 raise ValueError(f'{asset=}\'s step_name refers to an absent build-step')
 
     @classmethod


### PR DESCRIPTION
Allow files (or directory trees) output from pipeline-steps to be included as (OCM-)release-assets.