### PR TITLE
fix: guard against adding step-output multiple times

### DIFF
--- a/concourse/model/step.py
+++ b/concourse/model/step.py
@@ -422,8 +422,8 @@ class PipelineStep(ModelBase):
         ci.util.not_none(name)
         ci.util.not_none(variable_name)
 
-        if variable_name in self._inputs_dict:
-            raise ValueError(f'input already exists: {variable_name}')
+        if variable_name in self._inputs_dict and name != self._inputs_dict[variable_name]:
+            raise ValueError(f'conflict: {variable_name} was tried to be reset to different value')
         self._inputs_dict[variable_name] = name
 
     def remove_input(self, name):


### PR DESCRIPTION
If multiple release-assets are added, we must not add input multiple times (as, at least currently, doing so will result in a validation error).

It might also be considered to simply remove said check; which was originally intended to detect programming or configuration errors.