### PR TITLE
Enable people to get notified via slack

### DIFF
--- a/concourse/model/traits/notifications.py
+++ b/concourse/model/traits/notifications.py
@@ -41,11 +41,6 @@ class NotificationTriggeringPolicy(EnumWithDocumentation):
 class NotificationRecipients(EnumWithDocumentation):
     EMAIL_ADDRESSES = EnumValueWithDocumentation(
         value='email_addresses',
-        doc='notify committers of the last commit',
-    )
-
-    COMMITTERS = EnumValueWithDocumentation(
-        value='committers',
         doc='''
                 notifiy specific email addresses
 
@@ -60,6 +55,11 @@ class NotificationRecipients(EnumWithDocumentation):
                 ''',
     )
 
+    COMMITTERS = EnumValueWithDocumentation(
+        value='committers',
+        doc='notify committers of the last commit',
+    )
+
     COMPONENT_DIFF_OWNERS = EnumValueWithDocumentation(
         value='component_diff_owners',
         doc='notify the codeowners of a component. CODEOWNERS file must exist',
@@ -68,6 +68,26 @@ class NotificationRecipients(EnumWithDocumentation):
     CODEOWNERS = EnumValueWithDocumentation(
         value='codeowners',
         doc='notify the codeowners of the repository. CODEOWNERS file must exist',
+    )
+
+
+class NotificationSlack(EnumWithDocumentation):
+    CHANNEL_CFGS = EnumValueWithDocumentation(
+        value='channel_cfgs',
+        doc='''
+                the slack channel configurations to use
+
+                Example:
+
+                .. code-block:: yaml
+
+                    slack:
+                      channel_cfgs:
+                      - channel_names:
+                        - 'my_slack_channel'
+                        - 'my_other_slack_channel'
+                        slack_cfg_name: 'my_slack_cfg_name'
+                ''',
     )
 
 
@@ -108,6 +128,12 @@ NOTIFICATION_CFG_ATTRS = (
         ''',
         type=typing.List[str],
     ),
+    AttributeSpec.optional(
+        name='slack',
+        default=None,
+        doc='send notification via Slack',
+        type=NotificationSlack,
+    )
 )
 
 
@@ -135,6 +161,9 @@ class NotificationCfg(ModelBase):
 
     def cfg_callback(self):
         return self.raw.get('cfg_callback')
+
+    def slack(self):
+        return self.raw.get('slack')
 
 
 NOTIFICATION_CFG_SET_ATTRS = (

--- a/concourse/steps/notification.mako
+++ b/concourse/steps/notification.mako
@@ -64,6 +64,7 @@ import ci.util
 import ci.log
 import github
 import mailutil
+import slackclient.util
 import version
 
 from ci.util import ctx
@@ -249,4 +250,17 @@ mailutil.notify(
     email_cfg_name=email_cfg_name,
     recipients=email_cfg['recipients'],
 )
+% if on_error_cfg.slack():
+slack_cfg = ${on_error_cfg.slack()}
+for channel_cfg in slack_cfg.get('channel_cfgs', []):
+  slack_cfg_name = channel_cfg['slack_cfg_name']
+  slack_helper = slackclient.util.SlackHelper(cfg_factory.slack(slack_cfg_name))
+  for slack_channel in channel_cfg['channel_names']:
+    logger.info(f'Posting notification to "{slack_channel}" with "{slack_cfg_name}"')
+    slack_helper.post_to_slack(
+      channel=slack_channel,
+      title=email_cfg['subject'],
+      message=body
+    )
+% endif
 </%def>

--- a/doc/traits/notifications.rst
+++ b/doc/traits/notifications.rst
@@ -27,5 +27,10 @@ Example
                    - committers
                    - component_diff_owners
                    - codeowners
+                   slack:
+                       channel_cfgs:
+                         - channel_names: 
+                           - 'my_slack_channel'
+                           slack_cfg_name: 'my_slack_cfg_name'
                    inputs:
                    - component_descriptor_dir

--- a/doc/traits/slack.rst
+++ b/doc/traits/slack.rst
@@ -19,4 +19,4 @@ Example
     slack:
       channel_cfgs:
       - channel_name: 'my_slack_channel'
-        slack_cfg_name: 'scp_workspace' # see cc-config repository
+        slack_cfg_name: 'my_slack_cfg_name'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the notification system by adding support for Slack notifications alongside existing email notifications. With this change, users can configure notifications to be sent to Slack channels of their choice in case of errors in  pipelines.

By integrating Slack notifications, we ensure that important alerts are more visible in the team's primary communication platform, helping to reduce the time to resolution for critical issues.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
