### PR TITLE
fix: do not add publish-repository for notification-steps

### DIFF
--- a/concourse/templates/default.mako
+++ b/concourse/templates/default.mako
@@ -197,8 +197,6 @@ subject = 'Step {s} for {p}:{b} failed!'.format(
 def repos():
   if job_variant.has_main_repository():
     yield job_variant.main_repository()
-    if job_variant.has_publish_repository(job_variant.main_repository().logical_name()):
-      yield job_variant.publish_repository(job_variant.main_repository().logical_name())
 
 repo_cfgs = list(repos())
 src_dirs = [repo_cfg.resource_name() for repo_cfg in repo_cfgs]


### PR DESCRIPTION
"publish-repositories" are flavours of git-repo-resources that allow for write-access, which are only exposed (and used) by build-steps explicitly requesting that (via pipeline-definition).

They are special-handled (via resource-put). Such special-handling is neither in place, nor desired for notification-steps (which are run on error to send notifications, such as error-emails). However, declaring output-steps as input for those notification-steps will lead to "missing inputs: <resource-name>" errors if steps not configuring publish-repository are executed (which happens only upon errors, and therefore likely has slipped us for the past years.
