### PR TITLE
Add option to set timestamp as prerelease in version trait

### DIFF
--- a/concourse/model/traits/version.py
+++ b/concourse/model/traits/version.py
@@ -77,6 +77,7 @@ class VersionTrait(Trait):
         'finalize-skip-patchlevel-zero',
         'inject-branch-name',
         'inject-commit-hash',
+        'inject-timestamp',
         'noop',
         'use-branch-name',
     }

--- a/concourse/steps/component_descriptor.py
+++ b/concourse/steps/component_descriptor.py
@@ -45,6 +45,9 @@ def base_component_descriptor_v2(
     if parsed_version.finalize_version() == parsed_version:
         # "final" version --> there will be a tag, later (XXX hardcoded hack)
         src_ref = f'refs/tags/{effective_version}'
+    elif parsed_version.prerelease.startswith('timestamp'):
+        # prerelease is the build timestamp, not a "real" ref
+        src_ref = None
     else:
         # let's hope the version contains something committish
         if parsed_version.build:

--- a/concourse/steps/version.mako
+++ b/concourse/steps/version.mako
@@ -1,5 +1,6 @@
 <%def name="version_step(job_step, job_variant, indent)", filter="indent_func(indent),trim">
 <%
+import datetime
 import os
 from makoutil import indent_func
 from concourse.steps import step_lib
@@ -43,6 +44,9 @@ elif version_operation in ('finalize-skip-patchlevel-zero', 'finalise-skip-patch
   version_operation_kwargs['skip_patchlevel_zero'] = True
 elif version_operation == 'noop':
   version_operation_kwargs['operation'] = 'noop'
+elif version_operation == 'inject-timestamp':
+  version_operation_kwargs['operation'] = 'set_prerelease'
+  prerelease = f'timestamp-{int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())}'
 elif version_operation == 'inject-branch-name':
   version_operation_kwargs['operation'] = 'set_prerelease'
   prerelease = branch_name

--- a/doc/traits/version.rst
+++ b/doc/traits/version.rst
@@ -26,6 +26,8 @@ Component versions must be valid `SemVer <https://semver.org>`_ versions.
 +--------------------+------------------------------------------------------+
 | inject-commit-hash | set version suffix to main repo's head commit hash   |
 +--------------------+------------------------------------------------------+
+| inject-timestamp   | set version suffix to the POSIX timestamp            |
++--------------------+------------------------------------------------------+
 | inject-branch-name | set version suffix to main repository's branch name  |
 +--------------------+------------------------------------------------------+
 | use-branch-name    | set version to branch name                           |


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
