### PR TITLE
Allow PrefixUploader to join a prefix without added `/`

### DIFF
--- a/ctt/uploaders.py
+++ b/ctt/uploaders.py
@@ -91,10 +91,16 @@ class PrefixUploader:
         if self._mangle:
             src_base_ref = src_base_ref.replace('.', self._mangle_replacement_char)
 
-        tgt_ref = ci.util.urljoin(
-            self._prefix,
-            src_base_ref,
-        )
+        # if a prefix is to be removed from existing src base ref, it is likely that it should be
+        # replaced by the new prefix, instead of only prepended (where a joining `/` is reasonable).
+        # Instead, leave it up to the configuration to decide on the joining character.
+        if not self._remove_prefixes:
+            tgt_ref = ci.util.urljoin(
+                self._prefix,
+                src_base_ref,
+            )
+        else:
+            tgt_ref = self._prefix + src_base_ref
 
         if src_ref.has_digest_tag:
             tgt_ref = f'{tgt_ref}@{src_tag}'


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
