### PR TITLE
fix: ignore case for github-url-matching

### DIFF
--- a/model/github.py
+++ b/model/github.py
@@ -124,7 +124,7 @@ class GithubConfig(NamedModelElement):
 
         repo_url = ci.util.urljoin(parsed_repo_url.hostname, parsed_repo_url.path)
         for repo_url_regex in self.repo_urls():
-            if re.fullmatch(repo_url_regex, repo_url):
+            if re.fullmatch(repo_url_regex, repo_url, re.RegexFlag.IGNORECASE):
                 return True
 
         return False


### PR DESCRIPTION
GitHub effectively does case-folding (i.e. URLs with cases deviating from org/repo-names are redirected). Therefore, ignore cases to avoid unnecessary lookup-failures for irrelevant misconfiguration.

