### PR TITLE
fix: also strip trailing `/`

### DIFF
--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -267,9 +267,9 @@ for f in matching_files:
   tf.add(
     name=f,
 %    if asset.prefix:
-    arcname=f.removeprefix(step_output_dir).removeprefix('${asset.prefix}'),
+    arcname=f.removeprefix(step_output_dir + '/').removeprefix('${asset.prefix}'),
 %    else:
-    arcname=f.removeprefix(step_output_dir),
+    arcname=f.removeprefix(step_output_dir + '/'),
 %    endif
   )
 tf.close()


### PR DESCRIPTION
If retaining trailing slash, arcnames will have a leading `/` (which - depending on parameterisation might cause them to be extracted into root directory). Also, it will require `prefix` to include a leading `/`, which is quite unintuitive.

