### PR TITLE
Overhaul CTT processing behaviour

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -540,7 +540,7 @@ def process_images(
             # update the digest, because we might have changed the oci-artefact
             if (
                 digest.hashAlgorithm.upper() == 'SHA-256'
-                and digest.normalisationAlgorithm == 'ociArtifactDigest/v1'
+                and digest.normalisationAlgorithm == cm.NormalisationAlgorithm.OCI_ARTIFACT_DIGEST
             ):
                 digest.value = oci_manifest_digest.removeprefix('sha256:')
 

--- a/gci/componentmodel.py
+++ b/gci/componentmodel.py
@@ -238,10 +238,15 @@ class LabelMethodsMixin:
         )
 
 
+class NormalisationAlgorithm(enum.StrEnum):
+    JSON_NORMALISATION = 'jsonNormalisation/v1'
+    OCI_ARTIFACT_DIGEST = 'ociArtifactDigest/v1'
+
+
 @dc
 class DigestSpec:
     hashAlgorithm: str
-    normalisationAlgorithm: str
+    normalisationAlgorithm: NormalisationAlgorithm | str
     value: str
 
     @property


### PR DESCRIPTION
**What this PR does / why we need it**:

This change will adjust the CTT behaviour in such that:
- "jobs" are only being created for components which don't have an existing component descriptor in the target OCM repo -> previously, _all_ resources were processed (i.e. accesses were patched) and replicated to the new target url -> however, component descriptors were not overwritten resulting in replicated resources which were not referenced _anywere_ -> now, only those resources are being processed and replicated, which will be also reflected in the component descriptor
- only the components which don't exist in the target OCM repo are being tried to be uploaded there (less OCI requests as OCM lookup is used instead)
- it is worked on component descriptor level instead of component level now, which allows to keep signature information of referenced components as well
- removal of special handling for root component during upload process -> there is no case anymore, where the root component does not exist in the source OCM repo, hence the special handling is not required anymore
- the yielded component and resource nodes are now directly retrieved from the target OCM repo, so they reflect the actual state -> before, they only reflected the "optimistic" state that no component descriptor existed in the target before and hence all patches were applied successfully

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
