### PR TITLE
Extend greatest_component_versions to support filtering by date range

### DIFF
--- a/delivery/client.py
+++ b/delivery/client.py
@@ -311,6 +311,8 @@ class DeliveryServiceClient:
         greatest_version: str=None,
         ocm_repo: ocm.OcmRepository=None,
         version_filter: str | None=None,
+        start_date: datetime.date=None,
+        end_date: datetime.date=None,
     ):
         params = {
             'component_name': component_name,
@@ -324,6 +326,12 @@ class DeliveryServiceClient:
             params['ocm_repo_url'] = ocm_repo.oci_ref
         if version_filter is not None:
             params['version_filter'] = version_filter
+
+        if start_date:
+            params['start_date'] = start_date.isoformat()
+
+        if end_date:
+            params['end_date'] = end_date.isoformat()
 
         res = self.request(
             url=self._routes.greatest_component_versions(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the greatest_component_versions route in the delivery-service to support filtering by a specified date range. Users can now provide optional start_date and end_date parameters to retrieve component versions within a specific timeframe.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
