### PR TITLE
Omit `features` field from oci-platform if no contents

### DIFF
--- a/concourse/steps/publish.mako
+++ b/concourse/steps/publish.mako
@@ -100,7 +100,7 @@ def to_manifest_list_entry(image_ref_template: str, oci_client=oci_client):
       architecture=arch,
       os=os_id,
       variant=cfg_blob.get('variant', None),
-      features=cfg_blob.get('features', []),
+      features=cfg_blob.get('features', None),
     ),
   )
 

--- a/oci/model.py
+++ b/oci/model.py
@@ -368,7 +368,7 @@ class OciPlatform:
     architecture: str
     os: str # could also be a dict (see spec)
     variant: str | None = None
-    features: list[str] | None = dataclasses.field(default_factory=list)
+    features: list[str] | None = None
 
     def as_dict(self) -> dict:
         # need custom serialisation, because some OCI registries do not like null-values

--- a/oci/model.py
+++ b/oci/model.py
@@ -378,6 +378,9 @@ class OciPlatform:
         if not self.variant:
             del raw['variant']
 
+        if not self.features:
+            del raw['features']
+
         return raw
 
     def __eq__(self, other):


### PR DESCRIPTION
Some oci-registries do not support features field yet. As we do not use this field (at least for now), omit entirely on serialisation if it has no entries.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
