### PR TITLE
Add helper function to parse signing algorithm according to rfc

### DIFF
--- a/model/signing_server.py
+++ b/model/signing_server.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import enum
+import typing
 
 from model.base import (
     ModelBase,
@@ -14,6 +15,18 @@ from model.proxy import DockerImageConfig
 class SigningAlgorithm(enum.StrEnum):
     RSASSA_PSS = 'rsassa-pss'
     RSASSA_PKCS1_V1_5 = 'rsassa-pkcs1-v1_5'
+
+    @staticmethod
+    def as_rfc_standard(algorithm: typing.Union['SigningAlgorithm', str]) -> str:
+        # parses the algorithm to the standard format described in
+        # https://datatracker.ietf.org/doc/html/rfc3447
+        algorithm = SigningAlgorithm(algorithm.lower())
+        if algorithm is SigningAlgorithm.RSASSA_PSS:
+            return 'RSASSA-PSS'
+        elif algorithm is SigningAlgorithm.RSASSA_PKCS1_V1_5:
+            return 'RSASSA-PKCS1-v1_5'
+        else:
+            raise NotImplementedError(algorithm)
 
 
 class SigningServerEndpoint(NamedModelElement):


### PR DESCRIPTION
**What this PR does / why we need it**:
Lakom expects signing algorithm to match the standard format described in https://datatracker.ietf.org/doc/html/rfc3447, hence adding a helper function to create the expected format.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Altough it is an option, it may not be beneficial to directly adjust the enum to mirror the standard described in the rfc because (1) existing cosign signatures would not be reused but instead new signatures would be appended because it seems the algorithm had changed (2) OCM cli expects algorithms to be upper case

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
