### PR TITLE
fix: clean build-dir between package-builds

### DIFF
--- a/.ci/build_python_packages
+++ b/.ci/build_python_packages
@@ -49,9 +49,12 @@ if $running_in_pipeline; then
 fi
 
 # build into "${repo_dir}/dist"
-python3 "${repo_dir}/setup.oci.py" sdist bdist_wheel
-python3 "${repo_dir}/setup.py" sdist bdist_wheel
-python3 "${repo_dir}/setup.whd.py" sdist bdist_wheel
+python3 "${repo_dir}/setup.oci.py" bdist_wheel
+rm -rf "${repo_dir}/build"
+python3 "${repo_dir}/setup.py" bdist_wheel
+rm -rf "${repo_dir}/build"
+python3 "${repo_dir}/setup.whd.py" bdist_wheel
+rm -rf "${repo_dir}/build"
 
 # keep for subsequent docker build
 cp dist/* ${out_dir}
@@ -62,7 +65,7 @@ cp dist/* ${out_dir}
 
 cli_dir="${repo_dir}/cli"
 cd "${cli_dir}"
-python3 "${cli_dir}/setup.py" sdist bdist_wheel
+python3 "${cli_dir}/setup.py" bdist_wheel
 
 # do not cp for local build
 if [ "${out_dir}" != "${repo_dir}" ]; then

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -128,16 +128,17 @@ jobs:
         ; do
          echo "building distribution package from ${path}"
          python3 ${path} \
-            sdist \
             bdist_wheel \
             --dist-dir ${pkg_dir}
+         set -x
+         rm -rf build
+         set +x
         done
 
         # special-case: cli-package (need to chdir in order to not confuse setuptools)
         (
           cd cli
           python3 setup.py \
-            sdist \
             bdist_wheel \
             --dist-dir ${pkg_dir}
         )


### PR DESCRIPTION
Apparently, setuptools' sdist and bdist_wheel-subcommands ignore (under certain cirumustances) packages/modules specified via `modules` | `packages` parameters (from setup.py) in that it will include additional files.

This is problematic, because as a result, built packages have overlapping packages they will claim via (generated during installation) egg-info `RECORD` files. This is specifically a problem, considering re-installation.

Considering `gardener-oci` is depended-on by `gardener-cicd-libs`, reinstalling (e.g. for an update) `gardener-cicd-libs` will cause `oci` package to be removed (although it should actually _not_ be touched by `gardener-cicd-libs`, but by `gardener-oci` distribuation package). While this will still work, if upgradring between package-versions that consistently have wrong (too many) packages, this will result in a broken state once upgrading to a new package-version no longer containing extra-packages.

It was observed, that for `bdist_wheel`-build, existing build-directories from previous builds seem to be blindly included in resulting wheels; thus recursively unlinking said (temporary) build directory seems to be an obvious fix.

However, `sdist` build seems to also include extra-files, even upon empty build-directory. Considering wheels are prefered by pip (and pypa / other installers) anyhow, drop building `sdist` packages.

Caveat: even though this change will fix future distribution-packages, it is necessary to do a one-time force (re-)installation for upgrade-scenarios (scratch-installations should not be affected).

