### PR TITLE
fix warning / switch from deprecated attribute

### DIFF
--- a/ccc/elasticsearch.py
+++ b/ccc/elasticsearch.py
@@ -130,7 +130,7 @@ class ElasticSearchClient:
             return self._api.index(
                 index=index,
                 doc_type='_doc',
-                body=body,
+                document=body,
                 *args,
                 **kwargs,
             )


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-py/issues/1698 