### PR TITLE
Enhance pr body generation to omit component details when length exceeds

### DIFF
--- a/test/cnudie/cnudie_util_test.py
+++ b/test/cnudie/cnudie_util_test.py
@@ -75,23 +75,27 @@ def test_componentdiff_to_str(cid):
         names_only_right={'c'},
         names_version_changed={'d'},
     )
-    result = cnudie.util.format_component_diff(
+    formatted_diff = cnudie.util.format_component_diff(
         component_diff=diff,
         delivery_dashboard_url_view_diff=None,
         delivery_dashboard_url=None,
     )
 
-    max_length = 10
-    if len(result) > max_length:
-        truncated_result = result[:result.find('## Component Details:')]
-        truncated_result += '\n... [Component details omitted]\n'
-        body = truncated_result
-    else:
-        body = result
+    release_notes = 'Release Notes\n' + 'A' * 500
 
-    assert '### Added Components:' in body
-    assert '... [Component details omitted]' in body
-    assert '## Component Details:' not in body
+    max_pr_body_length = 100
+
+    additional_notes = []
+    pr_body = release_notes
+
+    if len(formatted_diff) <= max_pr_body_length - len(pr_body):
+        pr_body += '\n\n' + formatted_diff
+    else:
+        additional_notes.append(formatted_diff)
+
+    assert len(pr_body) > max_pr_body_length, 'PR body exceeds the maximum allowed length'
+    assert len(additional_notes) > 0, 'additional notes should contain truncated content'
+    assert formatted_diff in additional_notes, 'diff should be in additional notes if truncated'
 
 
 def test_iter_sorted():


### PR DESCRIPTION
**What this PR does / why we need it**:
When the combined length of the release notes and formatted diff surpasses the allowed pr body length, the component details are now omitted

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
