### PR TITLE
Refactor GitHub-Actions-Pipeline some more

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -68,5 +68,13 @@ runs:
 
         echo "commit-digest=$(cat ${commit_out})" >> ${GITHUB_OUTPUT}
         echo "commit-objects=$(cat ${objects_out} | base64 -w0)" >> ${GITHUB_OUTPUT}
+        cat << EOF > ${GITHUB_STEP_SUMMARY}
+        ## Capture-Commit Summary
+        commit-digest: \`$(cat ${commit_out})\`
+        objects-listing (tarfile):
+        $(tar tf ${objects_out})
+        commit-message:
+        $(git show)
+        EOF
         git clean -dfx
       shell: bash

--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -1,0 +1,72 @@
+name: capture-commit
+description: |
+  captures the head commit in serialised form in order to be shared w/ other jobs.
+
+  This action is intended for the use-case of sharing a "release-commit" (where typically
+  some metadata-bearing files (e.g. containing version) are modified) with other jobs, without
+  persisting it, yet (as subsequent jobs might still fail).
+
+  This action will only work if git-repository is cloned using `git` (i.e. git-repository must be
+  present). It will work well if repository was cloned as `shallow`. The action needs a reference
+  timestamp, which is passed via regular file. Said file *must* be created _prior_ to creating the
+  commit to serialise (/"capture"). It leverages git's internal organisation of objects, where new
+  objects will be created in separate files; such newly created object-files will be picked up, thus
+  containing both added/changed blobs, as well as tree-objects, and commit.
+
+  As release-commits are commonly rather small (typically just changing some versions in a few
+  files), the resulting data is typically only a few kiBs in size, which allows it to be exported
+  as a (base64-encoded) output (thus making passing-around somewhat less cumbersome).
+
+  Thus-exported commits can be imported, retaining the exact same commit-digest, provided the
+  importing repository has the same head-commit, into which the commit passed to this action had.
+
+  Note: this action makes use of git-internals (mostly layout of object-db). It will only work if
+  those are not violated (e.g. no git-gc or repack must be done prior to calling this action).
+
+inputs:
+  timestamp-reference:
+    required: true
+    description: |
+      a filepath pointing to a file that was created before the head-commit
+
+outputs:
+  commit-digest:
+    description: |
+      the commit-digest of the head-commit (for convenience - previous step might already know
+      it, of course)
+    value: ${{ steps.capture.outputs.commit-digest }}
+  commit-objects:
+    description: |
+      a base64-encoded tarfile containing the objects required to restore the head-commit.
+    value: ${{ steps.capture.outputs.commit-objects }}
+
+runs:
+  using: composite
+  steps:
+    - name: install-git
+      run: |
+        if which git &>/dev/null; then exit 0; fi
+        apt-get install -y git
+      shell: bash
+    - name: capture-commit
+      id: capture
+      run: |
+        ts_ref=${{ inputs.timestamp-reference }}
+        if [ ! -f ${ts_ref} ]; then
+          echo "no timestamp-reference-file at expected path: ${ts_ref}"
+          exit 1
+        fi
+        objects_out='commit-objects.tar'
+        commit_out='commit-digest'
+        GIT_DIR=$PWD/.git \
+          ${GITHUB_ACTION_PATH}/capture-commit \
+            ${objects_out} \
+            ${ts_ref} \
+            ${commit_out}
+
+        tar tf commit-objects.tar
+
+        echo "commit-digest=$(cat ${commit_out})" >> ${GITHUB_OUTPUT}
+        echo "commit-objects=$(cat ${objects_out} | base64 -w0)" >> ${GITHUB_OUTPUT}
+        git clean -dfx
+      shell: bash

--- a/.github/actions/capture-commit/capture-commit
+++ b/.github/actions/capture-commit/capture-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# usage:
+# export GIT_DIR
+# $1: path to target-archive
+# $2: path to ref-file (must be older than commit)
+# $3: path to output-file for commit-digest (defaults to commit-digest)
+
+if [ -z "${GIT_DIR:-}" ]; then
+  echo "must set GIT_DIR"
+  exit 1
+fi
+
+if [ -z "${1:-}" ]; then
+  echo "must pass target-file as ARGV[1]"
+  exit 1
+else
+  archive=${1}
+fi
+
+if [ -z "${2:-}" ]; then
+  echo "must pass ref-file as ARGV[2]"
+  exit 1
+else
+  ref=$(readlink -f "${2}")
+fi
+
+if [ -z "${3:-}" ]; then
+  commit_digest_out='commit-digest'
+else
+  commit_digest_out=${3}
+fi
+
+
+object_paths=$(
+  cd $(dirname $GIT_DIR)
+  find .git/objects -type f -neweraa ${ref} | grep -v pack
+)
+
+# objects are already gzipped - there is no point in compressing them again
+tar cf "${archive}" -C $(dirname "${GIT_DIR}") ${object_paths}
+git rev-parse @ > ${commit_digest_out}

--- a/.github/actions/import-commit/action.yaml
+++ b/.github/actions/import-commit/action.yaml
@@ -1,0 +1,39 @@
+name: import-commit
+description: |
+  imports a commit previously exported using `capture-commit`.
+
+  This action is intended for the use-case of sharing a "release-commit" (where typically
+  some metadata-bearing files (e.g. containing version) are modified) with other jobs, without
+  persisting it, yet (as subsequent jobs might still fail).
+
+  This action will only work if git-repository is cloned using `git` (i.e. git-repository must be
+  present). It will work well if repository was cloned as `shallow`. The repository should have the
+  same state as it had when `capture-commit` was executed.
+
+inputs:
+  commit-objects:
+    required: true
+    description: |
+      a base64-encoded tarfile containing the objects to import into git-repository. The expected
+      format matches the one output from `capture-commit` action.
+  commit-digest:
+    required: true
+    description: |
+      the digest of the commit to import. This action will run a `git rebase` against this commit
+      after importing the needed objects, thus leaving the repository (and worktree) in a state
+      identical to what it would be if the commit would have been created locally.
+
+runs:
+  using: composite
+  steps:
+    - name: install-git
+      run: |
+        if which git &>/dev/null; then exit 0; fi
+        apt-get install -y git
+      shell: bash
+    - name: import-commit
+      run: |
+        echo 'importing objects into .git-dir'
+        echo "${{ inputs.commit-objects }}" | base64 -d | tar x
+        git rebase ${{ inputs.commit-digest }}
+      shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -18,6 +18,12 @@ on:
       release-commit-digest:
         description: release-commit's digest
         value: ${{ jobs.version.outputs.release-commit-digest }}
+      effective-version:
+        description: effective version used during build
+        value: ${{ jobs.version.outputs.effective_version }}
+      next-version:
+        description: next version (for bump-commits)
+        value: ${{ jobs.version.outputs.next_version }}
   push:
 
 jobs:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,13 @@ jobs:
       next_version: ${{ steps.version.outputs.next_version }}
       repo_version: ${{ steps.version.outputs.repo_version }}
       setuptools_version: ${{ steps.version.outputs.setuptools_version }}
+      release-commit-objects: ${{ steps.capture-commit.outputs.commit-objects }}
+      release-commit-digest: ${{ steps.capture-commit.outputs.commit-digest }}
     steps:
+    - name: install git
+      run: |
+        if which git &>/dev/null; then exit 0; fi
+        apt-get install -y git
     - uses: actions/checkout@v4
     - name: calculate-effective-version
       id: version
@@ -75,13 +81,33 @@ jobs:
         echo "effective_version=${effective_version}" >> "${GITHUB_OUTPUT}"
         echo "repo_version=${src_version}" >> "${GITHUB_OUTPUT}"
         echo "setuptools_version=${setuptools_version}" >> "${GITHUB_OUTPUT}"
+    - name: create commit with effective version
+      run: |
+        git config --global --add safe.directory $PWD
+        git config user.name 'Gardener-CICD Bot'
+        git config user.email 'gardener.ci.user@gmail.com'
+        echo ${{ steps.version.outputs.effective_version }} | .ci/write-version
+        touch /tmp/timestamp-ref
+        git add .
+        if ${{ inputs.release || false }}; then
+          git commit -m "Release ${{ steps.version.outputs.effective_version }}"
+        else
+          git commit -m "Build ${{ steps.version.outputs.effective_version }}"
+        fi
+
+    - name: capture commit with effective version
+      uses: ./.github/actions/capture-commit
+      id: capture-commit
+      with:
+        timestamp-reference: /tmp/timestamp-ref
 
   package:
     runs-on: ubuntu-latest
     environment: build
     outputs:
       ocm_resources: ${{ steps.package.outputs.ocm_resources }}
-    needs: version
+    needs:
+      - version
     container:
       image: python:alpine
     steps:
@@ -191,7 +217,6 @@ jobs:
       - unittests
       - documentation
     outputs:
-      release_commit_digest: ${{  steps.releasecommit.commitdigest }}
       ocm_repository: ${{ steps.params.outputs.ocm_repository }}
     steps:
       - name: Install Packages
@@ -216,8 +241,14 @@ jobs:
         with:
           name: documentation
           path: /tmp/documentation-out.d
+      - name: Import Release-Commit
+        if: ${{ inputs.release }}
+        uses: ./.github/actions/import-commit
+        with:
+          commit-objects: ${{ needs.version.release-commit-objects }}
+          commit-digest: ${{ needs.version.release-commit-digest }}
 
-      - name: Create Release and Bump-Commits
+      - name: Push Release and Bump-Commits
         id: releasecommit
         if: ${{ inputs.release }}
         run: |
@@ -226,12 +257,7 @@ jobs:
           git config user.name 'Gardener-CICD Bot'
           git config user.email 'gardener.ci.user@gmail.com'
           effective_version=${{ needs.version.outputs.effective_version }}
-          echo "${effective_version}" | .ci/write-version
-          git add .
-          git commit -m "Release ${effective_version}"
-          git show
           commit_digest=$(git rev-parse @)
-          echo "release_commit_digest=${commit_digest}" >> "${GITHUB_OUTPUT}"
           tgt_ref="refs/tags/${effective_version}"
           echo "pushing release-commit ${commit_digest} to ${tgt_ref}"
           git push origin "@:${tgt_ref}"
@@ -280,7 +306,7 @@ jobs:
             > component-descriptor.yaml
 
           if ${{ inputs.release || false }}; then
-            commit_digest=${{ steps.releasecommit.outputs.release_commit_digest || '' }}
+            commit_digest=${{ needs.version.outputs.release-commit-digest || '' }}
           else
             commit_digest=${{ github.sha }}
           fi
@@ -355,7 +381,6 @@ jobs:
       - name: Publish Documentation
         if: ${{ inputs.release }}
         run: |
-          release_commit_digest=${{ steps.releasecommit.outputs.release_commit_digest || '' }}
           git fetch origin gh-pages
           git checkout gh-pages
           git clean -dfx

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -212,7 +212,7 @@ jobs:
         path: dist/
 
   component_descriptor:
-    name: OCM + Release (only on manual triggering)
+    name: Generate + Publish OCM-Component-Descriptor
     runs-on: ubuntu-latest
     container:
       image: python:alpine

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,7 +1,7 @@
 name: Build and Test
 run-name: Building and testing
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       release:
         required: false
@@ -11,6 +11,13 @@ on:
         required: false
         type: boolean
         default: false
+    outputs:
+      release-commit-objects:
+        description: release-commit-objects (for importing release-commit)
+        value: ${{ jobs.version.outputs.release-commit-objects }}
+      release-commit-digest:
+        description: release-commit's digest
+        value: ${{ jobs.version.outputs.release-commit-digest }}
   push:
 
 jobs:
@@ -82,6 +89,7 @@ jobs:
         echo "repo_version=${src_version}" >> "${GITHUB_OUTPUT}"
         echo "setuptools_version=${setuptools_version}" >> "${GITHUB_OUTPUT}"
     - name: create commit with effective version
+      if: ${{ inputs.release }}
       run: |
         git config --global --add safe.directory $PWD
         git config user.name 'Gardener-CICD Bot'
@@ -89,13 +97,10 @@ jobs:
         echo ${{ steps.version.outputs.effective_version }} | .ci/write-version
         touch /tmp/timestamp-ref
         git add .
-        if ${{ inputs.release || false }}; then
-          git commit -m "Release ${{ steps.version.outputs.effective_version }}"
-        else
-          git commit -m "Build ${{ steps.version.outputs.effective_version }}"
-        fi
+        git commit -m "Release ${{ steps.version.outputs.effective_version }}"
 
     - name: capture commit with effective version
+      if: ${{ inputs.release }}
       uses: ./.github/actions/capture-commit
       id: capture-commit
       with:
@@ -236,39 +241,6 @@ jobs:
         with:
           name: linting-logs # targetpath: bandit.tar.gz
           path: /tmp/linting-logs
-      - name: Retrieve Documentation
-        uses: actions/download-artifact@v4
-        with:
-          name: documentation
-          path: /tmp/documentation-out.d
-      - name: Import Release-Commit
-        if: ${{ inputs.release }}
-        uses: ./.github/actions/import-commit
-        with:
-          commit-objects: ${{ needs.version.release-commit-objects }}
-          commit-digest: ${{ needs.version.release-commit-digest }}
-
-      - name: Push Release and Bump-Commits
-        id: releasecommit
-        if: ${{ inputs.release }}
-        run: |
-          echo "gha-creds*" >> .git/info/exclude
-          git config --global --add safe.directory $PWD
-          git config user.name 'Gardener-CICD Bot'
-          git config user.email 'gardener.ci.user@gmail.com'
-          effective_version=${{ needs.version.outputs.effective_version }}
-          commit_digest=$(git rev-parse @)
-          tgt_ref="refs/tags/${effective_version}"
-          echo "pushing release-commit ${commit_digest} to ${tgt_ref}"
-          git push origin "@:${tgt_ref}"
-          next_version=${{ needs.version.outputs.next_version }}
-          echo "next version: ${next_version}"
-          git reset --hard @~
-          echo "${next_version}" | .ci/write-version
-          git add .
-          git commit -m"Prepare next Dev-Cycle"
-          git pull --rebase
-          git push origin
       - name: GAR-Auth
         id: auth
         uses: ./.github/actions/gar-auth
@@ -306,7 +278,7 @@ jobs:
             > component-descriptor.yaml
 
           if ${{ inputs.release || false }}; then
-            commit_digest=${{ needs.version.outputs.release-commit-digest || '' }}
+            commit_digest=${{ needs.version.outputs.release-commit-digest }}
           else
             commit_digest=${{ github.sha }}
           fi
@@ -378,25 +350,6 @@ jobs:
           python -m ocm upload \
             --file component-descriptor.yaml \
             --blobs-dir /tmp/dist/blobs.d
-      - name: Publish Documentation
-        if: ${{ inputs.release }}
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          git clean -dfx
-          git status
-          echo "let's hope our worktree is clean"
-          tar c -C /tmp/documentation-out.d . | tar x -C.
-          git status
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "no changes in documentation - no need to update documentation"
-            git checkout master # needed for post-gar
-            exit 0
-          fi
-          git add -A
-          git commit -m "update documentation"
-          git push origin refs/heads/gh-pages
-          git checkout master # needed for post-gar
 
   lint:
     runs-on: ubuntu-latest
@@ -495,35 +448,6 @@ jobs:
         touch /tmp/fake-cfg.d/config_types.yaml
         export CC_CONFIG_DIR=/tmp/fake-cfg.d
         .ci/test
-
-  pypi:
-    if: ${{ inputs.release-to-pypi }}
-    runs-on: ubuntu-latest
-    name: Publish to PYPI
-    needs:
-      - version
-      - package
-      - params
-      - lint
-      - unittests
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Retrieve Distribution Packages
-        uses: actions/download-artifact@v4
-        with:
-          name: distribution-packages
-          path: /tmp/dist
-      - name: prepare build-filesystem
-        id: prepare
-        run: |
-          cp -r /tmp/dist .
-          ls -lta dist/
-          rm -rf dist/blobs.d dist/ocm_resources.yaml
-          ls -lta dist/
-      - name: publish to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
 
   images:
     name: Build OCI Images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,106 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      release-to-pypi:
+        required: false
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-and-test.yaml
+    with:
+      release: true
+      release-to-pypi: ${{ inputs.release-to-pypi }}
+
+
+  publish-release-and-bump-commit:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: install git
+        run: |
+          if ! which git &>/dev/null; then
+            apt-get install git -y
+          fi
+      - uses: actions/checkout@v4
+      - name: Import Release-Commit
+        uses: ./.github/actions/import-commit
+        with:
+          commit-objects: ${{ needs.build.outputs.release-commit-objects }}
+          commit-digest: ${{ needs.build.outputs.release-commit-digest }}
+
+      - name: Push Release and Bump-Commits
+        id: releasecommit
+        run: |
+          echo "gha-creds*" >> .git/info/exclude
+          git config --global --add safe.directory $PWD
+          git config user.name 'Gardener-CICD Bot'
+          git config user.email 'gardener.ci.user@gmail.com'
+          effective_version=${{ needs.build.outputs.effective-version }}
+          commit_digest=$(git rev-parse @)
+          tgt_ref="refs/tags/${effective_version}"
+          echo "pushing release-commit ${commit_digest} to ${tgt_ref}"
+          git push origin "@:${tgt_ref}"
+          next_version=${{ needs.version.outputs.next_version }}
+          echo "next version: ${next_version}"
+          git reset --hard @~
+          echo "${next_version}" | .ci/write-version
+          git add .
+          git commit -m"Prepare next Dev-Cycle ${next_version}"
+          git pull --rebase
+          git push origin
+      - name: Retrieve Documentation
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation
+          path: /tmp/documentation-out.d
+      - name: Publish Documentation
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          git clean -dfx
+          git status
+          echo "let's hope our worktree is clean"
+          tar c -C /tmp/documentation-out.d . | tar x -C.
+          git status
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "no changes in documentation - no need to update documentation"
+            git checkout master # needed for post-gar
+            exit 0
+          fi
+          git add -A
+          git commit -m "update documentation"
+          git push origin refs/heads/gh-pages
+          git checkout master # needed for post-gar
+
+  pypi:
+    if: ${{ inputs.release-to-pypi }}
+    runs-on: ubuntu-latest
+    name: Publish to PYPI
+    needs:
+      - build
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Retrieve Distribution Packages
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-packages
+          path: /tmp/dist
+      - name: prepare build-filesystem
+        id: prepare
+        run: |
+          cp -r /tmp/dist .
+          ls -lta dist/
+          rm -rf dist/blobs.d dist/ocm_resources.yaml
+          ls -lta dist/
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           tgt_ref="refs/tags/${effective_version}"
           echo "pushing release-commit ${commit_digest} to ${tgt_ref}"
           git push origin "@:${tgt_ref}"
-          next_version=${{ needs.version.outputs.next_version }}
+          next_version=${{ needs.build.outputs.next_version }}
           echo "next version: ${next_version}"
           git reset --hard @~
           echo "${next_version}" | .ci/write-version


### PR DESCRIPTION
- split release-jobs into separate workflow
- create release-commit upfront via capture-commit-action
- import release-commit in release-workflow via import-commit-action