### PR TITLE
refactor/cleanup: mv `main_source` -> ocm.util

### DIFF
--- a/.ci/lint-flake8
+++ b/.ci/lint-flake8
@@ -8,11 +8,15 @@ src_dir="${1:-"$(readlink -f "$(dirname "${0}")/..")"}"
 error=0
 
 # ignore files that are not under version-ctrl (helpful for local runs)
-GIT_DIR="${src_dir}/.git" \
-GIT_WORKTREE="${src_dir}" \
-    untracked=$(git status --porcelain=v2 | grep -e '^? ' | sed 's/^? //g')
+if which git &>/dev/null; then
+    GIT_DIR="${src_dir}/.git" \
+    GIT_WORKTREE="${src_dir}" \
+        untracked=$(git status --porcelain=v2 | grep -e '^? ' | sed 's/^? //g')
 
-exclude_args=$(echo -n "${untracked}" | tr \\n ,)
+    exclude_args=$(echo -n "${untracked}" | tr \\n ,)
+else
+    exclude_args=""
+fi
 
 # flake8 / the linter it instruments cannot handle our special type-hints (CliHint)
 if flake8 \

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -378,7 +378,7 @@ jobs:
     needs:
       - package
     container:
-      image: python:alpine
+      image: python:3.12-alpine
     steps:
     - name: install git
       run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -380,9 +380,6 @@ jobs:
     container:
       image: python:3.12-alpine
     steps:
-    - name: install git
-      run: |
-        apk add --no-cache git
     - uses: actions/checkout@v4
     - name: Retrieve Distribution Packages
       uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -391,6 +391,10 @@ jobs:
         path: /tmp/dist
     - name: lint
       run: |
+        # debug
+        which python
+        which python3
+        python3 --version
         echo "install dependencies for python-packages"
         if ! apk add --no-cache $(cat gardener-cicd-libs.apk-packages) >/tmp/apk.log; then
           echo "error while trying to install apk-packages:"

--- a/cli/gardener_ci/compliance.py
+++ b/cli/gardener_ci/compliance.py
@@ -26,9 +26,9 @@ import yaml
 import ci.util
 import cnudie.iter
 import cnudie.retrieve
-import cnudie.util
 import ctx
 import ocm
+import ocm.util
 import reutil
 
 
@@ -196,7 +196,7 @@ def diff(
     ]
 
     def resource_as_dict(component, resource, resource_id):
-        if (main_src := cnudie.util.main_source(component, absent_ok=True)):
+        if (main_src := ocm.util.main_source(component, no_source_ok=True)):
             src_url = main_src.access.repoUrl
         elif isinstance(resource.access, ocm.OciAccess):
             src_url = resource.access.imageReference

--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -3,6 +3,8 @@ import dataclasses
 import graphlib
 import textwrap
 
+import deprecated
+
 import ci.util
 import ocm
 import oci.model as om
@@ -260,6 +262,7 @@ def target_oci_ref(
     )
 
 
+@deprecated.deprecated('use ocm.util.main_source instead')
 def main_source(
     component: ocm.Component,
     absent_ok: bool=True,

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -111,6 +111,7 @@ import concourse.model.traits.release
 import concourse.util
 import ocm
 import ocm.upload
+import ocm.util
 import github.util
 import gitutil
 
@@ -217,7 +218,7 @@ build_plan = current_build.plan()
 ## assuming buildlogs are typically not of interest for gh-releases, hardcode to omit those
 github_assets = []
 
-main_source = cnudie.util.main_source(component)
+main_source = ocm.util.main_source(component)
 main_source_ref = {
   'name': main_source.name,
   'version': main_source.version,

--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -7,6 +7,7 @@ import time
 import traceback
 
 import ocm
+import ocm.util
 import github3.exceptions
 import github3.repos.repo
 
@@ -357,7 +358,7 @@ def _import_release_notes(
         )
         return None
 
-    main_source = cnudie.util.determine_main_source_for_component(component)
+    main_source = ocm.util.main_source(component)
     github_cfg = ccc.github.github_cfg_for_repo_url(main_source.access.repoUrl)
     org_name = main_source.access.org_name()
     repository_name = main_source.access.repository_name()

--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -14,13 +14,13 @@ import github3.issues.issue
 import github3.repos
 
 import ocm
+import ocm.util
 import requests
 
 import ccc.github
 import checkmarx.model
 import cfg_mgmt.model as cmm
 import ci.util
-import cnudie.util
 import concourse.model.traits.image_scan as image_scan
 import delivery.client
 import delivery.model
@@ -340,7 +340,7 @@ def _scanned_element_repository(
     scanned_element: gcm.Target,
 ) -> github3.repos.repo.Repository:
     if gcm.is_ocm_artefact_node(scanned_element):
-        source = cnudie.util.main_source(component=scanned_element.component)
+        source = ocm.util.main_source(component=scanned_element.component)
 
         if not source.access.type is ocm.AccessType.GITHUB:
             raise NotImplementedError(source)

--- a/mailutil.py
+++ b/mailutil.py
@@ -8,9 +8,8 @@ import smtplib
 import typing
 
 import ocm
+import ocm.util
 
-import cnudie.retrieve
-import cnudie.util
 from model.email import EmailConfig
 from ci.util import (
     existing_dir,
@@ -275,9 +274,9 @@ def _codeowners_parser_from_component(
     component: ocm.Component,
     branch_name: str='master',
 ):
-    main_source = cnudie.util.main_source(
+    main_source = ocm.util.main_source(
         component=component,
-        absent_ok=False,
+        no_source_ok=False,
     )
     if not main_source.access.type is ocm.AccessType.GITHUB:
         raise NotImplementedError(main_source.access.type)

--- a/ocm/util.py
+++ b/ocm/util.py
@@ -1,0 +1,46 @@
+import ocm
+
+
+def as_component(
+    component: ocm.Component | ocm.ComponentDescriptor,
+    /,
+) -> ocm.Component:
+    if isinstance(component, ocm.Component):
+        return component
+    if isinstance(component, ocm.ComponentDescriptor):
+        return component.component
+
+    raise ValueError(component)
+
+
+def main_source(
+    component: ocm.Component | ocm.ComponentDescriptor,
+    *,
+    no_source_ok: bool=True,
+    ambiguous_ok: bool=True,
+) -> ocm.Source | None:
+    '''
+    returns the "main source" of the given OCM Component. Typically, components will have exactly
+    one source, in which the applied logic is to return the sole source-artefact.
+
+    For other cases, behaviour can be controlled via kw-(only-)params:
+
+    no_source_ok: if component has _no_ sources, return None
+    ambiguous_ok: if component has more than one source, return first
+
+    In cases where no main-source can be determined, raises ValueError.
+    '''
+    component = as_component(component)
+
+    if len(component.sources) == 1:
+        return component.sources[0]
+    elif not component.sources:
+        if no_source_ok:
+            return None
+        else:
+            raise ValueError('no sources', component)
+
+    if ambiguous_ok:
+        return component.sources[0]
+
+    raise ValueError('could not umambiguously determine main-source', component)

--- a/release_notes/fetch.py
+++ b/release_notes/fetch.py
@@ -4,11 +4,11 @@ import datetime
 import enum
 
 import ocm
+import ocm.util
 import git
 import github3.repos
 
 import cnudie.retrieve
-import cnudie.util
 import gitutil
 import github.util
 import release_notes.model as rnm
@@ -257,7 +257,7 @@ def fetch_draft_release_notes(
         f'Creating draft-release notes from {previous_version} to current HEAD'
     )
 
-    source = cnudie.util.determine_main_source_for_component(component)
+    source = ocm.util.main_source(component)
     github_helper = rnu.github_helper_from_github_access(source.access)
     git_helper = rnu.git_helper_from_github_access(source.access, repo_path)
 
@@ -364,7 +364,7 @@ def fetch_release_notes(
         current_version or SpecialVersion.HEAD
     )
 
-    source = cnudie.util.determine_main_source_for_component(component)
+    source = ocm.util.main_source(component)
     github_helper = rnu.github_helper_from_github_access(source.access)
     git_helper = rnu.git_helper_from_github_access(source.access, repo_path)
 

--- a/release_notes/model.py
+++ b/release_notes/model.py
@@ -5,11 +5,10 @@ import traceback
 import typing
 
 import ocm
+import ocm.util
 import git
 import github3.pulls
 
-import cnudie.util
-import cnudie.retrieve
 import version
 
 logger = logging.getLogger(__name__)
@@ -326,14 +325,14 @@ def create_release_notes_obj(
         )
 
     # access
-    source_component_access = cnudie.util.determine_main_source_for_component(
+    source_component_access = ocm.util.main_source(
         component=source_component,
-        absent_ok=False
+        no_source_ok=False,
     ).access
 
-    current_src_access = cnudie.util.determine_main_source_for_component(
+    current_src_access = ocm.util.main_source(
         component=current_component,
-        absent_ok=False
+        no_source_ok=False,
     ).access
 
     from_same_github_instance = current_src_access.hostname() in source_component_access.hostname()


### PR DESCRIPTION
As another step towards discarding `cnudie` package, mv cnudie.util's main_source to ocm.util. Slightly overhaul while doing so (give callers more control about lookup/raising behaviour).

Replace usages within this repository (there outside usages, hence keeping legacies in cnudie.util for smooth migration). Also, rm some unused imports.
