### PR TITLE
refactor: pass authtoken-lookup to deliveryservice-client

### DIFF
--- a/ccc/delivery.py
+++ b/ccc/delivery.py
@@ -1,9 +1,11 @@
 import logging
 
+import ccc.github
 import ci.log
 import ci.util
 import ctx
 import delivery.client
+import model.base
 
 ci.log.configure_default_logging()
 logger = logging.getLogger(__name__)
@@ -19,6 +21,17 @@ def _current_cfg_set(
     cfg_set = cfg_factory.cfg_set(cfg_set_name)
 
     return cfg_set
+
+
+def auth_token_lookup(api_url: str, /):
+    '''
+    an implementation of delivery.client.AuthTokenLookup
+    '''
+    try:
+        github_cfg = ccc.github.github_cfg_for_repo_url(api_url)
+        return github_cfg.credentials().auth_token()
+    except model.base.ConfigElementNotFoundError:
+        return None
 
 
 def default_client_if_available(
@@ -51,7 +64,7 @@ def default_client_if_available(
     )
     return delivery.client.DeliveryServiceClient(
         routes=routes,
-        cfg_factory=cfg_factory,
+        auth_token_lookup=auth_token_lookup,
     )
 
 
@@ -74,7 +87,7 @@ def client(
 
     return delivery.client.DeliveryServiceClient(
         routes=routes,
-        cfg_factory=cfg_factory,
+        auth_token_lookup=auth_token_lookup,
     )
 
 

--- a/cli/gardener_ci/_oci.py
+++ b/cli/gardener_ci/_oci.py
@@ -11,6 +11,7 @@ import tempfile
 
 import requests
 
+import ccc.delivery
 import ccc.oci
 import ctx
 import delivery.client
@@ -502,7 +503,7 @@ def osinfo(
             routes=delivery.client.DeliveryServiceRoutes(
                 base_url=delivery_cfg.base_url(),
             ),
-            cfg_factory=cfg_factory,
+            auth_token_lookup=ccc.delivery.auth_token_lookup,
         )
     else:
         delivery_client = None


### PR DESCRIPTION
Remove dependency from deliveryservice-client towards Gardener-CICD / cfg-factory. Define authtoken-lookup, and pass it to deliveyservice-client, rather than cfg-factory.

