### PR TITLE
cleanup: do not unncecessarily configure logger

### DIFF
--- a/ccc/delivery.py
+++ b/ccc/delivery.py
@@ -7,7 +7,6 @@ import ctx
 import delivery.client
 import model.base
 
-ci.log.configure_default_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -15,7 +15,6 @@ import deprecated
 import github3.exceptions
 import yaml
 
-import ci.log
 import ctx
 
 import model.base
@@ -35,7 +34,6 @@ dc = dataclasses.dataclass
 empty_list = dataclasses.field(default_factory=list) # noqa:E3701
 empty_tuple = dataclasses.field(default_factory=tuple) # noqa:E3701
 
-ci.log.configure_default_logging()
 logger = logging.getLogger(__name__)
 
 '''


### PR DESCRIPTION
Configuring `logging` gear should be to leaf components. This does not apply to either ccc or model packages, hence drop corresponding calls.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
remove unnecessary invocations of ci.log.configure_default_logging in common imports (model + ccc) to avoid issues from multiple invocations, which may result in logger with broken cfg (which results in logging-outputs not to be emitted at all).

Note: this _may_ require leaf-scripts that previously relied on implicit calling of ci.log.configure_default_logging to now need to explicitly initialise logging-package.
```
