### PR TITLE
gardener-gha-libs installer action

### DIFF
--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -1,0 +1,16 @@
+name: Install Gardener-GHA-Libs
+description: |
+  Install Python3 and gardener-gha-libs
+
+runs:
+  using: composite
+  steps:
+    - name: install python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: install-gardener-gha-libs
+      shell: bash
+      run: |
+        python3 --version
+        pip install gardener-gha-libs


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
add a new github-action to conveniently install `gardener-gha-libs` package + its runtime requirements (python currently).
```
