### PR TITLE
Remove dead code

### DIFF
--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -618,22 +618,14 @@ def create_or_update_github_issues(
 
             if delivery_svc_client:
                 try:
-                    if not scan_result.severity:
-                        if not max_processing_days:
-                            max_processing_days = gcm.MaxProcessingTimesDays()
-                        max_days = max_processing_days.for_severity(
-                            criticality_classification,
-                        )
-                        latest_processing_date = datetime.date.today() + datetime.timedelta(
-                            days=max_days,
-                        )
-                    else:
-                        # do not pass delivery service client or repository here to avoid
-                        # determining milestone here because then we would lose track of
-                        # failed milestone assignments
-                        latest_processing_date = scan_result.calculate_latest_processing_date(
-                            max_processing_days=max_processing_days,
-                        )
+                    if not max_processing_days:
+                        max_processing_days = gcm.MaxProcessingTimesDays()
+                    max_days = max_processing_days.for_severity(
+                        criticality_classification,
+                    )
+                    latest_processing_date = datetime.date.today() + datetime.timedelta(
+                        days=max_days,
+                    )
 
                     target_sprints = gcmi.target_sprints(
                         delivery_svc_client=delivery_svc_client,


### PR DESCRIPTION
This code was used for finding-specific SLA tracking (i.e. for BDBA findings). However, said handling of findings was moved to delivery-service and does not rely on `ScanResultGroups` anymore.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
