### PR TITLE
Add flag to disable asset upload as github release asset

### DIFF
--- a/concourse/model/traits/release.py
+++ b/concourse/model/traits/release.py
@@ -116,6 +116,7 @@ class Asset:
     - step_name: pipelinestep-name of data-source
     - comment: unused
     - type: asset-type - overwritten by subclasses
+    - upload_as_github_asset: whether the asset should _also_ be published as github release asset
     - github_asset_name: name to use for github asset (must be unique per release)
 
     Purpose-labels will be added as OCM-Label `gardener.cloud/purposes`.
@@ -139,6 +140,7 @@ class Asset:
     artefact_extra_id: dict[str, str] = dataclasses.field(default_factory=dict)
     purposes: list[str] = dataclasses.field(default_factory=list)
     comment: str | None = None
+    upload_as_github_asset: bool = True
     github_asset_name: str | None = None
 
     def __post_init__(self):

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -342,12 +342,14 @@ component.resources.append(
     labels=${asset.ocm_labels},
   ),
 )
-blobfh.seek(0)
-github_assets.append({
-  'fh': blobfh,
-  'name': '${github_asset_name(asset)}',
-  'mimetype': blob_mimetype,
-})
+%  if asset.upload_as_github_asset:
+  blobfh.seek(0)
+  github_assets.append({
+    'fh': blobfh,
+    'name': '${github_asset_name(asset)}',
+    'mimetype': blob_mimetype,
+  })
+%  endif
 
 % else:
   <% raise ValueError(asset) %>


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add flag to disable build step asset upload as GitHub release asset
```
