### PR TITLE
GitHub-Action handling draft-release-notes

### DIFF
--- a/.github/actions/draft-release/action.yaml
+++ b/.github/actions/draft-release/action.yaml
@@ -1,0 +1,45 @@
+name: update draft-release
+description: |
+  Creates/Updates GitHub-Release-draft for upcoming release.
+
+inputs:
+  component-descriptor:
+    description: |
+      effective OCM component-descriptor. It is sufficient to pass a `base component-descriptor`,
+      as output by `base-component-descriptor` workflow. Its version must be set to next planned
+      version (e.g. `1.2.0-dev`, if greatest released version was `1.1.0`).
+    required: true
+  github-token:
+    description: |
+      the github-auth-token to use for authenticating against GitHub.
+      Use `secrets.GITHUB_TOKEN`. If not passed-on via input, env-var GITHUB_TOKEN will be
+      honoured
+
+runs:
+  using: composite
+  steps:
+    - name: install-gardener-gha-libs
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+    - name: Update draft-release
+      shell: sh
+      run: |
+        set -eu
+        echo "${{ inputs.component-descriptor }}" > component-descriptor.yaml
+
+        # XXX rm again after next release of cc-utils/gardener-gha-libs (containing cachetools as
+        # dependency)
+        pip install cachetools
+
+        echo 'Component-Descriptor:'
+        cat component-descriptor.yaml
+
+        auth_token="${{ inputs.github-token }}"
+
+        if [ -z "${auth_token:-}" ]; then
+          auth_token="${GITHUB_TOKEN}"
+        fi
+
+        echo 'Fetching release-notes and updating / creating draft-release'
+        "${GITHUB_ACTION_PATH}/update_draft_release.py" \
+          --component-descriptor component-descriptor.yaml \
+          --github-auth-token "${auth_token}"

--- a/.github/actions/draft-release/update_draft_release.py
+++ b/.github/actions/draft-release/update_draft_release.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import pprint
+import sys
+import tempfile
+
+import github3
+import yaml
+
+try:
+    import ocm
+except ImportError:
+    # make local development more comfortable
+    repo_root = os.path.join(os.path.dirname(__file__), '../../..')
+    sys.path.insert(1, repo_root)
+    print(f'note: added {repo_root} to python-path (sys.path)')
+    import ocm
+
+import cnudie.retrieve
+import github.util
+import gitutil
+import oci.auth
+import oci.client
+import release_notes.fetch
+import release_notes.markdown
+import version
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--component-descriptor',
+        default='component-descriptor.yaml',
+        help='path to component-descriptor file to read from',
+    )
+    parser.add_argument(
+        '--repo-url',
+        required=False,
+        default=None,
+        help='github-repo-url ({host}/{org}/{repo}). derived from GitHubActions-Env-Vars by default',
+    )
+    # TODO: needs to be extended in order to support authentication against multiple GH(E)-instances
+    # -> as cross-auth is not in scope for first version of this script, omitted this on purpose
+    parser.add_argument(
+        '--github-auth-token',
+        default=os.environ.get('GITHUB_TOKEN', None),
+        help='the github-auth-token to use (defaults to GitHub-Action\'s default',
+    )
+    parser.add_argument(
+        '--repo-worktree',
+        default=os.getcwd(),
+        help='path to root-component\'s worktree root',
+    )
+    parser.add_argument(
+        '--draftname-suffix',
+        default='-draft',
+    )
+
+    parsed = parser.parse_args()
+    pprint.pprint(parsed)
+
+    with open(parsed.component_descriptor) as f:
+        component_descriptor = ocm.ComponentDescriptor.from_dict(
+            yaml.safe_load(f)
+        )
+
+    component = component_descriptor.component
+    # effective component-descriptor will be default contain either "-next"-version, or
+    # effective version (which is suffixed w/ commit-digests). hardcode conversion to
+    # next final version (might make this configurable later, if needed)
+    component.version = version.process_version(
+        component.version,
+        operation='finalise',
+    )
+
+    oci_client = oci.client.Client(
+        credentials_lookup=oci.auth.docker_credentials_lookup(),
+    )
+    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(component.current_ocm_repo)
+
+    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm_repository_lookup,
+        oci_client=oci_client,
+        cache_dir=tempfile.TemporaryDirectory().name,
+    )
+    ocm_version_lookup = cnudie.retrieve.version_lookup(
+        ocm_repository_lookup=ocm_repository_lookup,
+        oci_client=oci_client,
+    )
+
+    if (repo_url := parsed.repo_url):
+        host, org, repo = repo_url.strip('/').split('/')
+    else:
+        host = os.environ['GITHUB_SERVER_URL'].removeprefix('https://')
+        org, repo = os.environ['GITHUB_REPOSITORY'].split('/')
+
+    if host == 'github.com':
+        github_api = github3.GitHub(token=parsed.github_auth_token)
+    else:
+        github_api = github3.GitHubEnterprise(
+            url=f'https://{host}', # yes, slightly hacky (but good enough for now)
+            token=parsed.github_auth_token,
+        )
+
+    github_helper = github.util.GitHubRepositoryHelper(
+        owner=org,
+        name=repo,
+        github_api=github_api,
+    )
+    git_helper = gitutil.GitHelper(
+        repo=parsed.repo_worktree,
+        git_cfg=gitutil.GitCfg(
+            repo_url=f'https://{host}/{org}/{repo}',
+            user_name='Gardener-CICD-GitHubAction-Bot',
+            user_email='no-reply@github.com',
+            auth=None,
+            auth_type=gitutil.AuthType.PRESET,
+        ),
+    )
+
+    def github_api_lookup(repo_url):
+        # XXX: needs to be extended for cross-github-support
+        return github_api
+
+    try:
+        release_notes_md = 'no release notes available'
+        release_note_blocks = release_notes.fetch.fetch_draft_release_notes(
+            current_version=component.version,
+            component=component,
+            component_descriptor_lookup=component_descriptor_lookup,
+            version_lookup=ocm_version_lookup,
+            git_helper=git_helper,
+            github_api_lookup=github_api_lookup,
+        )
+    except ValueError as ve:
+        print(f'Warning: error whilst fetch draft-release-notes: {ve=}')
+        import traceback
+        traceback.print_exc()
+        release_note_blocks = None
+
+    if release_note_blocks:
+        release_notes_md = '\n'.join(
+            str(rn) for rn
+            in release_notes.markdown.render(release_note_blocks)
+        )
+
+    draft_release_name = f'{component.version}{parsed.draftname_suffix}'
+    if not (draft_release := github_helper.draft_release_with_name(draft_release_name)):
+        print(f'Creating {draft_release_name=}')
+        github_helper.create_draft_release(
+            name=draft_release_name,
+            body=release_notes_md,
+            component_version=component.version,
+            component_name=component.name,
+        )
+    else:
+        if not draft_release.body == release_notes_md:
+            print(f'Updating {draft_release_name=}')
+            draft_release.edit(body=release_notes_md)
+
+    for release, deleted in github_helper.delete_outdated_draft_releases():
+        if deleted:
+            print('Deleted obsolete draft {release.name=}')
+        else:
+            print(f'Failed to delete draft {release.name=}')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -240,6 +240,22 @@ jobs:
             we use bandit (linter) for SAST scans
             see: https://bandit.readthedocs.io/en/latest/
 
+  update-draft-release:
+    name: Update / Create Draft-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - base-component-descriptor
+    if: ${{ ! inputs.release && github.ref_name == 'master' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: update-draft-release
+        uses: ./.github/actions/draft-release
+        with:
+          component-descriptor: ${{ needs.base-component-descriptor.outputs.component-descriptor }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   component_descriptor:
     name: Generate + Publish OCM-Component-Descriptor
     runs-on: ubuntu-latest

--- a/concourse/steps/draft_release.mako
+++ b/concourse/steps/draft_release.mako
@@ -57,18 +57,16 @@ processed_version = version.process_version(
 
 repo_dir = ci.util.existing_dir('${repo.resource_name()}')
 
-have_cd = os.path.exists(component_descriptor_path := '${component_descriptor_path}')
-
-if have_cd:
-    component = ocm.ComponentDescriptor.from_dict(
-            component_descriptor_dict=ci.util.parse_yaml_file(
-                component_descriptor_path,
-            ),
-            validation_mode=ocm.ValidationMode.WARN,
-    ).component
-else:
-   print('did not find component-descriptor')
+if not os.path.exists(component_descriptor_path := '${component_descriptor_path}'):
+   logger.error(f'did not find component-descriptor at {component_descriptor_path}')
    exit(1)
+
+component = ocm.ComponentDescriptor.from_dict(
+        component_descriptor_dict=ci.util.parse_yaml_file(
+            component_descriptor_path,
+        ),
+        validation_mode=ocm.ValidationMode.WARN,
+).component
 
 github_cfg = ccc.github.github_cfg_for_repo_url(
   ci.util.urljoin(

--- a/release_notes/fetch.py
+++ b/release_notes/fetch.py
@@ -242,7 +242,7 @@ def fetch_draft_release_notes(
     version_lookup: cnudie.retrieve.VersionLookupByComponent,
     git_helper: gitutil.GitHelper,
     github_api_lookup: rnu.GithubApiLookup,
-):
+) -> set[rnm.ReleaseNote]:
     known_versions: list[str] = list(version_lookup(component.identity()))
 
     previous_version = version.greatest_version_before(

--- a/setup.gha.py
+++ b/setup.gha.py
@@ -34,7 +34,6 @@ def requirements():
         'aliyun-python-sdk-ram',
         'brypt',
         'boto3',
-        'cachetools',
         'cryptography',
         'dockerfile-parse',
         'docutils',


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add new GitHub-Action `draft-release` (+ usage example on cc-util's pipeline) that will create / update draft-releases (typically upon head-updates).
```
