### PR TITLE
Refactor - drop unused parameters / lessen dependencies towards OCM (where not reasonable)

### DIFF
--- a/.github/actions/draft-release/update_draft_release.py
+++ b/.github/actions/draft-release/update_draft_release.py
@@ -152,8 +152,6 @@ def main():
         github_helper.create_draft_release(
             name=draft_release_name,
             body=release_notes_md,
-            component_version=component.version,
-            component_name=component.name,
         )
     else:
         if not draft_release.body == release_notes_md:

--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -13,4 +13,7 @@ runs:
       shell: sh
       run: |
         python3 --version
-        pip install gardener-gha-libs
+        if ! pip install gardener-gha-libs &> /tmp/pip-install.log; then
+          echo 'An error occured while tring to run pip install:'
+          cat /tmp/pip-install.log
+        fi

--- a/concourse/steps/draft_release.mako
+++ b/concourse/steps/draft_release.mako
@@ -130,8 +130,6 @@ if not draft_release:
     github_helper.create_draft_release(
         name=draft_name,
         body=release_notes_md,
-        component_version=processed_version,
-        component_name=component.name,
     )
 else:
     if not draft_release.body == release_notes_md:

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -541,7 +541,6 @@ try:
   github_helper.update_release_notes(
     tag_name=version_str,
     body=release_notes_md,
-    component_name=component.name,
   )
   git_helper.push('refs/notes/commits', 'refs/notes/commits')
 except:

--- a/concourse/steps/release.py
+++ b/concourse/steps/release.py
@@ -405,7 +405,6 @@ def github_release(
             draft_release=release,
             release_tag=release_tag,
             release_version=release_version,
-            component_name=component_name,
         )
     else:
         release = github_helper.create_release(
@@ -414,7 +413,6 @@ def github_release(
             draft=False,
             prerelease=False,
             name=release_version,
-            component_name=component_name,
         )
 
 

--- a/github/util.py
+++ b/github/util.py
@@ -462,8 +462,6 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         draft: bool=False,
         prerelease: bool=False,
         name: str=None,
-        component_name: str=None,
-        component_version: str=None,
     ):
         if len(body) < MAXIMUM_GITHUB_RELEASE_BODY_LENGTH:
             return self.repository.create_release(
@@ -511,16 +509,12 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         self,
         name: str,
         body: str,
-        component_name: str=None,
-        component_version: str=None,
     ):
         return self.create_release(
             tag_name='',
             name=name,
             body=body,
             draft=True,
-            component_name=component_name,
-            component_version=component_version,
         )
 
     def promote_draft_release(
@@ -528,7 +522,6 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
         draft_release,
         release_tag,
         release_version,
-        component_name: str=None,
     ):
         draft_release.edit(
             tag_name=release_tag,
@@ -554,7 +547,6 @@ class GitHubRepositoryHelper(RepositoryHelperBase):
     def update_release_notes(
         self,
         tag_name: str,
-        component_name: str,
         body: str,
     ) -> bool:
         ci.util.not_empty(tag_name)


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
drop obsolete ocm-related parameters for helpers
```
