### PR TITLE
refactor: split draft-release and release-notes

### DIFF
--- a/.github/actions/draft-release/action.yaml
+++ b/.github/actions/draft-release/action.yaml
@@ -3,11 +3,13 @@ description: |
   Creates/Updates GitHub-Release-draft for upcoming release.
 
 inputs:
-  component-descriptor:
+  release-notes:
     description: |
-      effective OCM component-descriptor. It is sufficient to pass a `base component-descriptor`,
-      as output by `base-component-descriptor` workflow. Its version must be set to next planned
-      version (e.g. `1.2.0-dev`, if greatest released version was `1.1.0`).
+      the release-notes to publish to draft-release
+    required: true
+  version:
+    description: |
+      the version to use as prefix for the release-name
     required: true
   github-token:
     description: |
@@ -20,27 +22,11 @@ runs:
   steps:
     - name: install-gardener-gha-libs
       uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
-    - name: install-git
-      run: |
-        set -eu
-        if which git &>/dev/null; then exit 0; fi
-        apt-get install -y git
-      shell: sh
     - name: Update draft-release
       shell: sh
       run: |
         set -eu
-        echo "${{ inputs.component-descriptor }}" > component-descriptor.yaml
-
-        # XXX rm again after next release of cc-utils/gardener-gha-libs (containing cachetools as
-        # dependency)
-        pip install cachetools
-
-        echo 'Component-Descriptor:'
-        cat component-descriptor.yaml
-
-        git config --global user.name 'Gardener GitHubActions-Bot'
-        git config --global user.email 'no-reply@github.com'
+        echo "${{ inputs.release-notes }}" > release-notes.md
 
         auth_token="${{ inputs.github-token }}"
 
@@ -48,7 +34,8 @@ runs:
           auth_token="${GITHUB_TOKEN}"
         fi
 
-        echo 'Fetching release-notes and updating / creating draft-release'
+        echo 'Updating / creating draft-release'
         "${GITHUB_ACTION_PATH}/update_draft_release.py" \
-          --component-descriptor component-descriptor.yaml \
+          --release-notes release-notes.md \
+          --version "${{ inputs.version }}" \
           --github-auth-token "${auth_token}"

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -9,6 +9,16 @@ inputs:
       as output by `base-component-descriptor` workflow. Its version must be set to next planned
       version (e.g. `1.2.0-dev`, if greatest released version was `1.1.0`).
     required: true
+  ocm-repositories:
+    description: |
+      a (commaseparated) list of ocm-repository-URLs where component-versions are to be looked up
+      (order is honoured).
+
+      Caveat: this action will only honour final versions. Hence, at least one ocm-repository
+      containing final/release versions must be passed.
+
+      If no ocm-repository is passed, this action will fallback to the current ocm-repository from
+      passed ocm-component-descriptor (see caveat above).
   github-token:
     description: |
       the github-auth-token to use for authenticating against GitHub.
@@ -62,11 +72,16 @@ runs:
           draft_arg='--draft'
         fi
 
+        if [ -n "${{ inputs.ocm-repositories }}" ]; then
+          ocm_repositories_arg="--ocm-repositories ${{ inputs.ocm-repositories }}"
+        fi
+
         echo 'Fetching release-notes'
         "${GITHUB_ACTION_PATH}/release_notes_cli.py" \
           --component-descriptor component-descriptor.yaml \
           --github-auth-token "${auth_token}" \
-         ${draft_arg:-} \
+          ${draft_arg:-} \
+          ${ocm_repositories_arg:-} \
           --outfile release-notes.md
 
         echo 'Release-notes written to `release-notes.md`'

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -1,0 +1,81 @@
+name: release-notes
+description: |
+  retrieves release-notes following conventions from Gardener-Project
+
+inputs:
+  component-descriptor:
+    description: |
+      effective OCM component-descriptor. It is sufficient to pass a `base component-descriptor`,
+      as output by `base-component-descriptor` workflow. Its version must be set to next planned
+      version (e.g. `1.2.0-dev`, if greatest released version was `1.1.0`).
+    required: true
+  github-token:
+    description: |
+      the github-auth-token to use for authenticating against GitHub.
+      Use `secrets.GITHUB_TOKEN`. If not passed-on via input, env-var GITHUB_TOKEN will be
+      honoured
+  draft:
+    type: boolean
+    default: false
+    description: |
+      if true, will collect draft-release-notes
+outputs:
+  release-notes:
+    description: |
+      the collected release-notes in markdown format
+
+runs:
+  using: composite
+  steps:
+    - name: install-gardener-gha-libs
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+    - name: install-git
+      run: |
+        set -eu
+        if which git &>/dev/null; then exit 0; fi
+        apt-get install -y git
+      shell: sh
+    - name: Update draft-release
+      shell: bash
+      run: |
+        set -eu
+        echo "${{ inputs.component-descriptor }}" > component-descriptor.yaml
+
+        # XXX rm again after next release of cc-utils/gardener-gha-libs (containing cachetools as
+        # dependency)
+        pip install cachetools
+
+        echo 'Component-Descriptor:'
+        cat component-descriptor.yaml
+
+        # todo: remove after next release of gardener-gha-libs (2025-01-16)
+        git config --global user.name 'Gardener GitHubActions-Bot'
+        git config --global user.email 'no-reply@github.com'
+
+        auth_token="${{ inputs.github-token }}"
+
+        if [ -z "${auth_token:-}" ]; then
+          auth_token="${GITHUB_TOKEN}"
+        fi
+
+        if [ "${{ inputs.draft }}" == 'true' ]; then
+          draft_arg='--draft'
+        fi
+
+        echo 'Fetching release-notes'
+        "${GITHUB_ACTION_PATH}/release_notes_cli.py" \
+          --component-descriptor component-descriptor.yaml \
+          --github-auth-token "${auth_token}" \
+         ${draft_arg:-} \
+          --outfile release-notes.md
+
+        echo 'Release-notes written to `release-notes.md`'
+
+        echo 'release-notes<<EOF' >> ${GITHUB_OUTPUT}
+        cat release-notes.md >> ${GITHUB_OUTPUT}
+        echo EOF >> ${GITHUB_OUTPUT}
+
+        cat << EOF > ${GITHUB_STEP_SUMMARY}
+        ## Release-Notes
+        $(cat release-notes.md)
+        EOF

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+# note: do not name this file `release_notes.py` to avoid conflicts w/ package of this name
+
+import argparse
+import os
+import pprint
+import sys
+import tempfile
+
+import github3
+import yaml
+
+try:
+    import ocm
+except ImportError:
+    # make local development more comfortable
+    repo_root = os.path.join(os.path.dirname(__file__), '../../..')
+    sys.path.insert(1, repo_root)
+    print(f'note: added {repo_root} to python-path (sys.path)', file=sys.stderr)
+    import ocm
+
+import cnudie.retrieve
+import gitutil
+import oci.auth
+import oci.client
+import release_notes.fetch
+import release_notes.markdown
+import version
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--component-descriptor',
+        default='component-descriptor.yaml',
+        help='path to component-descriptor file to read from',
+    )
+    parser.add_argument(
+        '--repo-url',
+        required=False,
+        default=None,
+        help='github-repo-url ({host}/{org}/{repo}). derived from GitHubActions-Env-Vars by default',
+    )
+    # TODO: needs to be extended in order to support authentication against multiple GH(E)-instances
+    # -> as cross-auth is not in scope for first version of this script, omitted this on purpose
+    parser.add_argument(
+        '--github-auth-token',
+        default=os.environ.get('GITHUB_TOKEN', None),
+        help='the github-auth-token to use (defaults to GitHub-Action\'s default',
+    )
+    parser.add_argument(
+        '--repo-worktree',
+        default=os.getcwd(),
+        help='path to root-component\'s worktree root',
+    )
+    parser.add_argument(
+        '--draft',
+        action='store_true',
+        default=False,
+        help='if set, will fetch draft-release-notes',
+    )
+    parser.add_argument(
+        '--outfile',
+        default='-',
+        help='output file to write to (`-` for stdout, which is the default)',
+    )
+
+    parsed = parser.parse_args()
+    print(pprint.pformat(parsed), file=sys.stderr)
+
+    with open(parsed.component_descriptor) as f:
+        component_descriptor = ocm.ComponentDescriptor.from_dict(
+            yaml.safe_load(f)
+        )
+
+    component = component_descriptor.component
+    # effective component-descriptor will be default contain either "-next"-version, or
+    # effective version (which is suffixed w/ commit-digests). hardcode conversion to
+    # next final version (might make this configurable later, if needed)
+    component.version = version.process_version(
+        component.version,
+        operation='finalise',
+    )
+
+    oci_client = oci.client.Client(
+        credentials_lookup=oci.auth.docker_credentials_lookup(),
+    )
+    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(component.current_ocm_repo)
+
+    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm_repository_lookup,
+        oci_client=oci_client,
+        cache_dir=tempfile.TemporaryDirectory().name,
+    )
+    ocm_version_lookup = cnudie.retrieve.version_lookup(
+        ocm_repository_lookup=ocm_repository_lookup,
+        oci_client=oci_client,
+    )
+
+    if (repo_url := parsed.repo_url):
+        host, org, repo = repo_url.strip('/').split('/')
+    else:
+        host = os.environ['GITHUB_SERVER_URL'].removeprefix('https://')
+        org, repo = os.environ['GITHUB_REPOSITORY'].split('/')
+
+    if host == 'github.com':
+        github_api = github3.GitHub(token=parsed.github_auth_token)
+    else:
+        github_api = github3.GitHubEnterprise(
+            url=f'https://{host}', # yes, slightly hacky (but good enough for now)
+            token=parsed.github_auth_token,
+        )
+
+    git_helper = gitutil.GitHelper(
+        repo=parsed.repo_worktree,
+        git_cfg=gitutil.GitCfg(
+            repo_url=f'https://{host}/{org}/{repo}',
+            user_name='Gardener-CICD-GitHubAction-Bot',
+            user_email='no-reply@github.com',
+            auth=None,
+            auth_type=gitutil.AuthType.PRESET,
+        ),
+    )
+
+    def github_api_lookup(repo_url):
+        # XXX: needs to be extended for cross-github-support
+        return github_api
+
+    try:
+        release_notes_md = 'no release notes available'
+        if parsed.draft:
+            release_note_blocks = release_notes.fetch.fetch_draft_release_notes(
+                current_version=component.version,
+                component=component,
+                component_descriptor_lookup=component_descriptor_lookup,
+                version_lookup=ocm_version_lookup,
+                git_helper=git_helper,
+                github_api_lookup=github_api_lookup,
+            )
+        else:
+            raise RuntimeError('not implemented')
+    except ValueError as ve:
+        print(f'Warning: error whilst fetch draft-release-notes: {ve=}')
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        release_note_blocks = None
+
+    if release_note_blocks:
+        release_notes_md = '\n'.join(
+            str(rn) for rn
+            in release_notes.markdown.render(release_note_blocks)
+        )
+
+    append_newline = not release_notes_md.endswith('\n')
+
+    if parsed.outfile == '-':
+        sys.stdout.write(release_notes_md)
+        if append_newline:
+            sys.stdout.write('\n')
+    else:
+        with open(parsed.outfile, 'w') as f:
+            f.write(release_notes_md)
+            if append_newline:
+                f.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -43,6 +43,12 @@ def main():
         help='path to component-descriptor file to read from',
     )
     parser.add_argument(
+        '--ocm-repositories',
+        action='extend',
+        type=lambda repo: repo.split(','),
+        default=[],
+    )
+    parser.add_argument(
         '--repo-url',
         required=False,
         default=None,
@@ -92,7 +98,10 @@ def main():
     oci_client = oci.client.Client(
         credentials_lookup=oci.auth.docker_credentials_lookup(),
     )
-    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(component.current_ocm_repo)
+    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(
+        *parsed.ocm_repositories,
+        component.current_ocm_repo,
+    )
 
     component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repository_lookup,

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -118,6 +118,13 @@ def main():
             token=parsed.github_auth_token,
         )
 
+    repository = github_api.repository(org, repo)
+    if repository.fork and not parsed.repo_url:
+        # if repo-url was not passed-in explicitly, rewrite org to "parent" (from where fork was
+        # created). In the majority of cases, this will likely be helpful (so release-notes will
+        # be calculated from fork's source)
+        org = repository.parent.full_name.split('/')[-1]
+
     git_helper = gitutil.GitHelper(
         repo=parsed.repo_worktree,
         git_cfg=gitutil.GitCfg(

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -3,6 +3,7 @@
 # note: do not name this file `release_notes.py` to avoid conflicts w/ package of this name
 
 import argparse
+import logging
 import os
 import pprint
 import sys
@@ -27,6 +28,11 @@ import oci.client
 import release_notes.fetch
 import release_notes.markdown
 import version
+
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stderr,
+)
 
 
 def main():

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ocm_repository: ${{ steps.params.outputs.ocm_repository }}
+      ocm_releases_repository: ${{ steps.params.outputs.ocm_releases_repository }}
       oci_repository: ${{ steps.params.outputs.oci_repository }}
       oci_platforms: ${{ steps.params.outputs.oci_platforms }}
     steps:
@@ -49,6 +50,7 @@ jobs:
             oci_repository=${snapshots_repo}
           fi
 
+          echo "ocm_releases_repository=${releases_repo}" >> "${GITHUB_OUTPUT}"
           echo "ocm_repository=${ocm_repository}" >> "${GITHUB_OUTPUT}"
           echo "oci_repository=${oci_repository}" >> "${GITHUB_OUTPUT}"
           echo "oci_platforms=linux/amd64,linux/arm64" >> "${GITHUB_OUTPUT}"
@@ -248,6 +250,7 @@ jobs:
       contents: write
     needs:
       - base-component-descriptor
+      - params
       - version
     if: ${{ ! inputs.release && github.ref_name == 'master' }}
     steps:
@@ -256,6 +259,7 @@ jobs:
         uses: ./.github/actions/release-notes
         with:
           component-descriptor: ${{ needs.base-component-descriptor.outputs.component-descriptor }}
+          ocm-repositories: ${{ needs.params.ocm_releases_repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
       - name: update-draft-release

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -247,13 +247,21 @@ jobs:
       contents: write
     needs:
       - base-component-descriptor
+      - version
     if: ${{ ! inputs.release && github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@v4
+      - name: draft-release-notes
+        uses: ./.github/actions/release-notes
+        with:
+          component-descriptor: ${{ needs.base-component-descriptor.outputs.component-descriptor }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
       - name: update-draft-release
         uses: ./.github/actions/draft-release
         with:
-          component-descriptor: ${{ needs.base-component-descriptor.outputs.component-descriptor }}
+          release-notes: ${{ steps.draft-release-notes.outputs.release-notes }}
+          version: ${{ needs.version.outputs.effective_version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   component_descriptor:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -221,6 +221,7 @@ jobs:
     uses: ./.github/workflows/base-component-descriptor.yaml
     with:
       version: ${{ needs.version.outputs.effective_version }}
+      component-name: 'github.com/gardener/cc-utils'
       ocm-repo: ${{ needs.params.outputs.ocm_repository }}
       commit-digest: ${{ needs.version.outputs.release-commit-digest }}
       labels: |


### PR DESCRIPTION
split code handling retrieval of release-notes into a separate github-action, re-use it in draft-release-action.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
split code handling retrieval of release-notes into a separate github-action (release-notes)
```
