### PR TITLE
fix: do not overwrite existing labels

### DIFF
--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -138,9 +138,9 @@ def append(parsed):
 
     def inject_labels(artefact: dict, labels):
         if not 'labels' in artefact:
-            artefact['labels'] = []
-
-        artefact['labels'] = labels
+            artefact['labels'] = labels
+        else:
+            artefact['labels'].extend(labels)
 
     if isinstance(obj, list):
         for o in obj:


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
fix a bug where `gardener-ocm resource|source add` would overwrite labels from passed artefact-fragments.
```
