### PR TITLE
Fix release notes-action some more

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -45,6 +45,11 @@ runs:
         if which git &>/dev/null; then exit 0; fi
         apt-get install -y git
       shell: sh
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # release-notes code needs full commit-history and tags
+        fetch-tags: 0
     - name: Retrieve Release-Notes
       shell: bash
       run: |

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -45,7 +45,7 @@ runs:
         if which git &>/dev/null; then exit 0; fi
         apt-get install -y git
       shell: sh
-    - name: Update draft-release
+    - name: Retrieve Release-Notes
       shell: bash
       run: |
         set -eu


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
have release-notes-action do a full checkout (it needs both full commit-history, as well as tags)
```
