### PR TITLE
Drop (now) unused input parameter `release-to-pypi`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,10 +7,6 @@ on:
         required: false
         type: boolean
         default: false
-      release-to-pypi:
-        required: false
-        type: boolean
-        default: false
     outputs:
       release-commit-objects:
         description: release-commit-objects (for importing release-commit)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
     uses: ./.github/workflows/build-and-test.yaml
     with:
       release: true
-      release-to-pypi: ${{ inputs.release-to-pypi }}
 
 
   publish-release-and-bump-commit:


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
