### PR TITLE
Drop `cfg_name` property from compliance snapshots

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -602,14 +602,13 @@ class ComplianceSnapshotState:
 
 @dataclasses.dataclass(frozen=True)
 class ComplianceSnapshot:
-    cfg_name: str
     latest_processing_date: datetime.date
     correlation_id: str
     state: list[ComplianceSnapshotState]
 
     @property
     def key(self) -> str:
-        return _as_key(self.cfg_name, self.correlation_id)
+        return self.correlation_id
 
     def current_state(
         self,


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Drop cfg_name property from compliance snapshots
```
