### PR TITLE
Fix install gha action

### DIFF
--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -20,7 +20,12 @@ runs:
       shell: bash
       run: |
         set -eu
-        cd cc-utils
+
+        # mv outside of $PWD to avoid leaving files in workdir
+        tmpdir="$(mktemp -d)"
+        mv cc-utils ${tmpdir}
+        cd "${tmpdir}/cc-utils"
+
         python3 --version
 
         pip install setuptools >/dev/null


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
install-gardener-gha-libs action will no longer leave copy of cc-utils in workdir
```
