### PR TITLE
Reduce K8S python client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ google-crc32c>1.1.4
 html2text
 jsonschema
 jsonpath-ng
-kubernetes>=26.0.0
+kubernetes<32.0.0,>=26.0.0
 msal<2
 openstacksdk
 oss2


### PR DESCRIPTION
In order to unblock the dev pipeline, currently affected by
https://github.com/kubernetes-client/python/issues/2344

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Restrict K8S python client version to <32.0.0
```
