### PR TITLE
Remove ruleset version from diki finding key

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -418,7 +418,7 @@ class DikiFinding(Finding):
 
     @property
     def key(self) -> str:
-        return _as_key(self.provider_id, f'{self.ruleset_id}:{self.ruleset_version}', self.rule_id)
+        return _as_key(self.provider_id, self.ruleset_id, self.rule_id)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
This PR removes the ruleset version from `DikiFinding`'s key property. The ruleset version is not needed for an identifier since all findings of a single scan are from the same ruleset version.

This change will cause a recreating of current GitHub issues and will prevent future recreations caused by using a newer ruleset version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Remove the ruleset version from `DikiFinding`'s key property.
```
