### PR TITLE
fix: expose release-notes as output m(((

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -33,6 +33,7 @@ outputs:
   release-notes:
     description: |
       the collected release-notes in markdown format
+  value: ${{ steps.release-notes.outputs.release-notes }}
 
 runs:
   using: composite
@@ -51,6 +52,7 @@ runs:
         fetch-depth: 0 # release-notes code needs full commit-history and tags
         fetch-tags: 0
     - name: Retrieve Release-Notes
+      id: release-notes
       shell: bash
       run: |
         set -eu


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
expose release-notes as output from release-notes action
```
