### PR TITLE
Rm ocm retention policy

### DIFF
--- a/cnudie/purge.py
+++ b/cnudie/purge.py
@@ -1,4 +1,3 @@
-import collections.abc
 import logging
 import traceback
 
@@ -9,29 +8,9 @@ import cnudie.retrieve
 import cnudie.util
 import oci.client as oc
 import oci.model as om
-import version
+
 
 logger = logging.getLogger(__name__)
-
-
-def iter_componentversions_to_purge(
-    component: ocm.Component | ocm.ComponentDescriptor,
-    policy: version.VersionRetentionPolicies,
-    oci_client: oc.Client,
-) -> collections.abc.Generator[ocm.ComponentIdentity, None, None]:
-    oci_ref = cnudie.util.oci_ref(component=component)
-    if isinstance(component, ocm.ComponentDescriptor):
-        component = component.component
-
-    for v in version.versions_to_purge(
-        versions=oci_client.tags(oci_ref.ref_without_tag),
-        reference_version=component.version,
-        policy=policy,
-    ):
-        yield ocm.ComponentIdentity(
-            name=component.name,
-            version=v,
-        )
 
 
 def remove_component_descriptor_and_referenced_artefacts(

--- a/doc/traits/component_descriptor.rst
+++ b/doc/traits/component_descriptor.rst
@@ -205,20 +205,6 @@ Gardener-Components have a name that is by convention the github-repo-url (w/o s
     - name: imagevector.gardener.cloud/source-repository
       value: github.com/gardener/gardener # github-repo
 
-
-Retention Policies (aka cleaning up old versions)
-=================================================
-
-The `retention_policies` attribute can be used to configure automated removal of
-component descriptors and referenced `resources` (mostly OCI Container Images).
-
-.. attention::
-   Removal of component descriptors and referenced resources is _permanent_. There is no
-   backup mechanism in place. Use with care. For example, if multiple component descriptors
-   share reference to the same OCI Artefact (using the same registry, repository, and tag)
-   removal of any of the referencing component descriptors will lead to stale references
-   in other component descriptors.
-
 Cleanup Semantics and Use-Case
 ------------------------------
 

--- a/version.py
+++ b/version.py
@@ -4,7 +4,6 @@
 
 
 import collections
-import dataclasses
 import enum
 import logging
 import semver
@@ -41,47 +40,6 @@ class VersionType(enum.Enum):
     ANY = 'any'
 
 
-@dataclasses.dataclass(frozen=True)
-class VersionRetentionPolicy:
-    name: str = None
-    keep: typing.Union[str, int] = 'all'
-    match: VersionType = VersionType.ANY
-    restrict: VersionRestriction = VersionRestriction.NONE
-    recursive: bool = False
-
-    def matches_version_restriction(self, version, ref_version) -> bool:
-        version = parse_to_semver(version)
-        final = is_final(version)
-
-        if self.match is VersionType.ANY:
-            pass
-        if self.match is VersionType.SNAPSHOT and final:
-            return False
-        if self.match is VersionType.RELEASE and not final:
-            return False
-
-        # if this line is reached, version-type matches
-
-        if self.restrict is VersionRestriction.NONE:
-            return True
-        elif self.restrict is VersionRestriction.SAME_MINOR:
-            ref_version = version.parse_to_semver(ref_version)
-            return ref_version.minor == version.minor
-        else:
-            raise RuntimeError(f'not implemented: {self.restrict}')
-
-    @property
-    def keep_all(self) -> bool:
-        return self.keep == 'all'
-
-
-@dataclasses.dataclass
-class VersionRetentionPolicies:
-    name: str
-    rules: list[VersionRetentionPolicy]
-    dry_run: bool = True
-
-
 T = typing.TypeVar('T')
 
 
@@ -93,46 +51,6 @@ def is_final(
         version = converter(version)
     version = parse_to_semver(version=version)
     return not version.build and not version.prerelease
-
-
-def versions_to_purge(
-    versions: typing.Iterable[T],
-    reference_version: Version,
-    policy: VersionRetentionPolicies,
-    converter: typing.Callable[[T], Version]=None,
-) -> typing.Generator[T, None, None]:
-    versions_by_policy = collections.defaultdict(list)
-
-    def to_version(v: T):
-        if converter:
-            v = converter(v)
-        return v
-
-    for v in versions:
-        converted_version = to_version(v)
-        for rule in policy.rules:
-            rule: VersionRetentionPolicy
-            if rule.matches_version_restriction(
-                version=converted_version,
-                ref_version=reference_version,
-            ):
-                versions_by_policy[rule].append(v)
-                break # first rule matches
-            else:
-                continue
-        else:
-            logger.info(f'no rule matched {converted_version}')
-
-    for policy, versions in versions_by_policy.items():
-        policy: VersionRetentionPolicy
-        if policy.keep_all:
-            continue
-
-        yield from smallest_versions(
-            versions=versions,
-            keep=policy.keep,
-            converter=converter,
-        )
 
 
 def parse_to_semver(


### PR DESCRIPTION
Google Artifact Registry has a built-in mechanism.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
OCM clean-up logic (based on version-policies) is removed (we use oci-registry built-ins instead).
```
