### PR TITLE
Drop `correlation_id` from snapshots and add utility function

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -507,12 +507,11 @@ class ComplianceSnapshotState:
 @dataclasses.dataclass(frozen=True)
 class ComplianceSnapshot:
     latest_processing_date: datetime.date
-    correlation_id: str
     state: list[ComplianceSnapshotState]
 
     @property
     def key(self) -> str:
-        return self.correlation_id
+        return self.latest_processing_date.isoformat()
 
     def current_state(
         self,

--- a/dso/model.py
+++ b/dso/model.py
@@ -129,6 +129,14 @@ class LocalArtefactId:
             self.normalised_artefact_extra_id,
         )
 
+    def as_dict_repr(self) -> dict:
+        return {
+            **({'Artefact': self.artefact_name} if self.artefact_name else {}),
+            **({'Artefact-Version': self.artefact_version} if self.artefact_version else {}),
+            **({'Artefact-Type': self.artefact_type} if self.artefact_type else {}),
+            **self.artefact_extra_id,
+        }
+
     def __hash__(self) -> int:
         return hash(self.key)
 
@@ -180,6 +188,14 @@ class ComponentArtefactId:
             self.artefact_kind,
             references_key,
         )
+
+    def as_dict_repr(self) -> dict:
+        return {
+            **({'Component': self.component_name} if self.component_name else {}),
+            **({'Component-Version': self.component_version} if self.component_version else {}),
+            **({'Artefact-Kind': self.artefact_kind} if self.artefact_kind else {}),
+            **(self.artefact.as_dict_repr() if self.artefact else {}),
+        }
 
     def __hash__(self) -> int:
         return hash(self.key)


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Dropped the `correlation_id` property from compliance snapshots (ODG)
```
