### PR TITLE
Improve release action

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -119,9 +119,10 @@ runs:
         import oci.auth
         import ocm
 
-        component_descriptor = ocm.ComponentDescriptor.from_dict(
-          yaml.safe_load('''${{ inputs.component-descriptor }}''')
-        )
+        with open('/tmp/component-descriptor') as f:
+          component_descriptor = ocm.ComponentDescriptor.from_dict(
+            yaml.safe_load(f.read())
+          )
         component = component_descriptor.component
         tgt_ocm_repo = component.current_ocm_repo
         tgt_oci_ref = tgt_ocm_repo.component_version_oci_ref(

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -106,6 +106,36 @@ runs:
         echo "tag-ref=${tag_ref}" >> $GITHUB_OUTPUT
         echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT
 
+    - name: read-target-oci-ref:
+      id: read-oci-ref
+      shell: python
+      run: |
+        import os
+
+        import yaml
+
+        import ocm
+
+        with open('/tmp/component-descriptor') as f:
+          component_descriptor = ocm.ComponentDescriptor.from_dict(
+            yaml.safe_load(f.read())
+          )
+        component = component_descriptor.component
+        tgt_ocm_repo = component.current_ocm_repo
+        tgt_oci_ref = tgt_ocm_repo.component_version_oci_ref(
+          name=component.name,
+          version=component.version,
+        )
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+          f.write(f'ocm-target-oci-ref={tgt_oci_ref}\n')
+
+
+    - name: authenticate-against-oci-registry
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
+      with:
+        oci-image-reference: ${{ steps.read-oci-ref.outputs.ocm-target-oci-ref }}
+        gh-token: ${{ inputs.github-token }}
+
     - name: attach-release-notes-to-component-descriptor
       if: ${{ inputs.release-notes }}
       shell: python
@@ -165,7 +195,6 @@ runs:
             Dumper=ocm.EnumValueYamlDumper,
             stream=f,
           )
-
 
     - name: publish OCM Component-Descriptor
       shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -265,7 +265,7 @@ jobs:
       ocm-repositories: ${{ needs.params.outputs.ocm_releases_repository }}
 
   component-descriptor:
-    name: Generate + Publish OCM-Component-Descriptor
+    name: Generate OCM-Component-Descriptor
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -362,10 +362,6 @@ jobs:
           echo "component-descriptor to be uploaded:"
           cat component-descriptor.yaml
 
-          echo "uploading component-descriptor"
-          python -m ocm upload \
-            --file component-descriptor.yaml \
-            --blobs-dir /tmp/dist/blobs.d
           echo 'component-descriptor<<EOF' >> ${GITHUB_OUTPUT}
           cat component-descriptor.yaml >> ${GITHUB_OUTPUT}
           echo EOF >> ${GITHUB_OUTPUT}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
- do not publish component-descriptor prior to release-job (cc-utils pipeline)
- improve robustness of loading YAML documents passed as input
- authenticate against target oci-registry prior to publishing ocm-component-descriptor from release-job
```
