### PR TITLE
cleanup: drop obsolete backwards-compatibility cruft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,24 +18,12 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 
-COPY --from=builder /pkgs/usr /usr
 COPY --from=ocm-cli /bin/ocm /bin/ocm
-COPY --from=builder /cc/utils/bin/component-cli /bin/component-cli
+
+COPY --from=builder /pkgs/usr /usr
+COPY --from=builder /cc/utils/bin /cc/utils/bin
 COPY --from=builder /usr/lib/libmagic.so.1 /usr/lib/libmagic.so.1
 COPY --from=builder /usr/lib/libmagic.so.1.0.0 /usr/lib/libmagic.so.1.0.0
 COPY --from=builder /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc
 
-# path is hardcoded in our trait
-COPY --from=builder /cc/utils/bin/launch-dockerd.sh /cc/utils/bin/launch-dockerd.sh
 ENV PATH=$PATH:/cc/utils/bin
-
-# place version file into container's filesystem to make it easier to
-# determine the image version during runtime
-COPY VERSION /metadata/VERSION
-
-ENV HELM_V3_VERSION=v3.12.2
-ENV HELM_ARCH="${TARGETARCH}"
-# copy to where helm is expected
-COPY --from=builder /cc/utils/bin/helm /usr/local/bin/helm
-# backwards-compatibility
-RUN ln -sf /usr/local/bin/helm /usr/local/bin/helm3

--- a/bin/helm
+++ b/bin/helm
@@ -3,13 +3,12 @@
 set -eu
 set -o pipefail
 
-HELM_ARCH="${HELM_ARCH:-amd64}"
-DOWNLOAD_URL="https://get.helm.sh/helm-${HELM_V3_VERSION}-linux-${HELM_ARCH}.tar.gz"
-HELM_PATH=/bin/helm_binary
+helm_path=/usr/local/bin/helm
 
-if [ ! -f "${HELM_PATH}" ]; then
-    tmp="$(mktemp -d)"
-    curl $DOWNLOAD_URL -L | tar -xz -C "${tmp}" && mv "${tmp}/linux-amd64/helm" "${HELM_PATH}"
+if [ ! -f "${helm_path}" ]; then
+    export VERIFY_CHECKSUM=false
+    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    unset VERIFY_CHECKSUM
 fi
 
-exec ${HELM_PATH} "$@"
+exec ${helm_path} "$@"


### PR DESCRIPTION
- cc-utils-versions is accessible either via
 - meta-step / job-image-tag
 - pip show gardener-cicd-libs # and friends
- HELM_V3_VERSION is outdated - nobody seems to care
- HELM_ARCH - no known usages
- placing helm into /cc/utils/bin: nobody should hardcode such paths
- helm3: let's see..



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
drop unused backwards-compatibility-cruft from cc-job-image:
- cc-utils-versions is accessible either via
 - meta-step / job-image-tag
 - pip show gardener-cicd-libs # and friends
- HELM_V3_VERSION is outdated - nobody seems to care
- HELM_ARCH - no known usages
- placing helm into /cc/utils/bin: nobody should hardcode such paths
```
