### PR TITLE
always declare `version` as extraIdentity for pipeline-built images

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -294,6 +294,9 @@ jobs:
             name='${{ inputs.name }}',
             version='${{ inputs.version }}',
             type=ocm.ArtefactType.OCI_IMAGE,
+            extraIdentity={
+              'version': '${{ inputs.version }}',
+            },
             access=ocm.OciAccess(
               imageReference=tgt_image_ref,
             ),

--- a/concourse/steps/component_descriptor.mako
+++ b/concourse/steps/component_descriptor.mako
@@ -174,6 +174,9 @@ component_v2.resources.append(
       imageReference='${target_spec.image}' + ':' + effective_version,
     ),
     labels=${image_descriptor.resource_labels()}
+    extraIdentity={
+      'version': effective_version,
+    }
   ),
 )
 %   endfor


### PR DESCRIPTION
OCM-spec demands that each resource within a componentversion features a unique identity. By default, this identity consists only of the `name` (for historical reasons, version was implicitly added if necessary to make identities unique, i.e. if more than one artefact w/ same name, but different versions are present).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
OCM-spec demands that each resource within a componentversion features a unique identity. By default, this identity consists only of the `name` (for historical reasons, version was implicitly added if necessary to make identities unique, i.e. if more than one artefact w/ same name, but different versions are present).

Future OCM-Component-Descriptors release from Concourse-Pipeline-Template with OCI-Image-Resources injected from Pipeline will feature `version` as part of their extraIdentity. The same holds true for future Component-Descriptors build from OCM-Resource-Fragments emitted by the `gardener/cc-utils/.github/workflows/oci-ocm.yaml`-workflow.
```
