### PR TITLE
dso: `normalise_artefact_extra_id` dict may have `any` values

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -125,7 +125,7 @@ class Datasource:
 
 
 def normalise_artefact_extra_id(
-    artefact_extra_id: dict[str, str],
+    artefact_extra_id: dict[str, any],
 ) -> str:
     '''
     generate stable representation of `artefact_extra_id`
@@ -133,7 +133,8 @@ def normalise_artefact_extra_id(
     sorted by key in alphabetical order and concatinated following pattern:
     key1:value1_key2:value2_ ...
     '''
-    s = sorted(artefact_extra_id.items(), key=lambda items: items[0])
+    items = [(k, str(v)) for k, v in artefact_extra_id.items()]
+    s = sorted(items, key=lambda items: items[0])
     return '_'.join([':'.join(values) for values in s])
 
 


### PR DESCRIPTION
Some models may have values other than `dict[str, str]`, which specify their extra identity.

This commit ensures that any values passed to `normalise_artefact_extra_id` are normalized as string values before generating the stable identity.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`normalise_artefact_extra_id` normalizes values as strings
```
