### PR TITLE
Add normalisation to OCM model

### DIFF
--- a/cnudie/access.py
+++ b/cnudie/access.py
@@ -1,6 +1,10 @@
+import hashlib
+
 import ocm
 
 import ioutil
+import oci.client
+import oci.model
 
 
 def s3_access_as_blob_descriptor(
@@ -22,3 +26,52 @@ def s3_access_as_blob_descriptor(
         size=size,
         name=name or f's3://{s3_access.bucketName}/{s3_access.objectKey}',
     )
+
+
+def access_to_digest_lookup(
+    access: ocm.Access,
+    oci_client: oci.client.Client=None,
+    s3_client: 'botocore.client.S3'=None,
+    chunk_size: int=4096,
+) -> ocm.DigestSpec:
+    if access.type is ocm.AccessType.OCI_REGISTRY:
+        image_reference = oci.model.OciImageReference(
+            image_reference=oci_client.to_digest_hash(
+                image_reference=access.imageReference,
+                accept=oci.model.MimeTypes.prefer_multiarch,
+            )
+        )
+
+        digest = image_reference.digest
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.OCI_ARTIFACT_DIGEST,
+            value=digest,
+        )
+
+    elif access.type is ocm.AccessType.LOCAL_BLOB:
+        reference = access.globalAccess.digest if access.globalAccess else access.localReference
+
+        digest = reference.lower().removeprefix('sha256:')
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
+            value=digest,
+        )
+
+    elif access.type is ocm.AccessType.S3:
+        blob = s3_client.get_object(Bucket=access.bucketName, Key=access.objectKey)['Body']
+
+        digest = hashlib.sha256()
+        for chunk in blob.iter_chunks(chunk_size=chunk_size):
+            digest.update(chunk)
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
+            value=digest.hexdigest(),
+        )
+
+    return ocm.ExcludeFromSignatureDigest()

--- a/ocm/ocm-component-descriptor-schema.yaml
+++ b/ocm/ocm-component-descriptor-schema.yaml
@@ -11,11 +11,28 @@ definitions:
       schemaVersion:
         type: 'string'
 
+  mergeSpec:
+    type: 'object'
+    properties:
+      algorithm:
+        pattern: '^[a-z][a-z0-9/_-]+$'
+      config: {}
+
   label:
     type: 'object'
     required:
       - 'name'
       - 'value'
+    properties:
+      name:
+        type: 'string'
+      value: {}
+      version:
+        pattern: '^v[0-9]+$'
+      signing:
+        type: 'boolean'
+      merge:
+        $ref: '#/definitions/mergeSpec'
 
   componentName:
     type: 'string'
@@ -152,6 +169,15 @@ definitions:
         description: 'The media type of the signature value'
         type: string
 
+  timestampSpec:
+    type: 'object'
+    properties:
+      value:
+        type: 'string'
+      time:
+        type: 'string'
+        format: 'date-time'
+
   signature:
     type: 'object'
     required:
@@ -165,6 +191,8 @@ definitions:
         $ref: '#/definitions/digestSpec'
       signature:
         $ref: '#/definitions/signatureSpec'
+      timestamp:
+        $ref: '#/definitions/timestampSpec'
 
   srcRef:
     type: 'object'
@@ -428,6 +456,37 @@ definitions:
 
     componentReferences: {}
 
+  nestedDigestSpec:
+    type: 'object'
+    required:
+      - 'name'
+    properties:
+      name:
+        type: 'string'
+      version:
+        type: 'string'
+      extraIdentity:
+        $ref: '#/definitions/identityAttribute'
+      digest:
+        $ref: '#/definitions/digestSpec'
+
+  nestedComponentDigests:
+    type: 'object'
+    required:
+      - 'name'
+      - 'version'
+    properties:
+      name:
+        $ref: '#/definitions/componentName'
+      version:
+        $ref: '#/definitions/relaxedSemver'
+      digest:
+        $ref: '#/definitions/digestSpec'
+      resourceDigests:
+        type: 'array'
+        items:
+          $ref: '#/definitions/nestedDigestSpec'
+
 
 type: 'object'
 required:
@@ -442,3 +501,7 @@ properties:
     type: 'array'
     items:
       $ref: '#/definitions/signature'
+  nestedDigests:
+    type: 'array'
+    items:
+      $ref: '#/definitions/nestedComponentDigests'

--- a/ocm/sign.py
+++ b/ocm/sign.py
@@ -1,0 +1,235 @@
+'''
+Functionality for normalising and hashing OCM-Component-Descriptors.
+'''
+
+import collections.abc
+import dataclasses
+import datetime
+import hashlib
+import json
+
+import ocm
+
+
+def normalise_obj(
+    obj: dict,
+) -> list[dict]:
+    '''
+    Recursively converts a dictionary `obj` to a list of objects with a single key/value-pair,
+    sorted by the keys, to create a stable representation of `obj`.
+    '''
+    return [
+        {
+            key: normalise_obj(value) if isinstance(value, dict) else value,
+        }
+        for key, value in sorted(
+            obj.items(),
+            key=lambda item: item[0],
+        )
+    ]
+
+
+def normalise_label(
+    label: ocm.Label,
+) -> list[dict]:
+    label_raw = dataclasses.asdict(label)
+
+    if not label.version:
+        del label_raw['version']
+    if not label.merge:
+        del label_raw['merge']
+
+    return normalise_obj(label_raw)
+
+
+def normalise_resource(
+    resource: ocm.Resource,
+    access_to_digest_lookup: collections.abc.Callable[[ocm.Access], ocm.DigestSpec],
+) -> list[dict]:
+    resource_raw = dataclasses.asdict(resource)
+
+    # drop properties not relevant for signing
+    del resource_raw['access']
+    del resource_raw['srcRefs']
+
+    if labels := [normalise_label(l) for l in resource.labels if l.signing]:
+        resource_raw['labels'] = labels
+    else:
+        del resource_raw['labels']
+
+    # digest is ignored in case no access is specified; otherwise, calculate digest if it is not
+    # existing yet
+    if resource.access and not resource.digest:
+        resource_raw['digest'] = dataclasses.asdict(access_to_digest_lookup(resource.access))
+    elif not resource.access:
+        del resource_raw['digest']
+
+    # extra-identity is expected to be null instead of an empty object by OCM-cli in case it does
+    # not contain any elements
+    if not resource.extraIdentity:
+        resource_raw['extraIdentity'] = None
+
+    return normalise_obj(resource_raw)
+
+
+def normalise_component_reference(
+    component_reference: ocm.ComponentReference,
+    component_descriptor_lookup: collections.abc.Callable[[ocm.ComponentIdentity], ocm.ComponentDescriptor], # noqa: E501
+    access_to_digest_lookup: collections.abc.Callable[[ocm.Access], ocm.DigestSpec],
+    normalisation: ocm.NormalisationAlgorithm=ocm.NormalisationAlgorithm.JSON_NORMALISATION,
+) -> list[dict]:
+    component_reference_raw = dataclasses.asdict(component_reference)
+
+    if labels := [normalise_label(l) for l in component_reference.labels if l.signing]:
+        component_reference_raw['labels'] = labels
+    else:
+        del component_reference_raw['labels']
+
+    if not component_reference.digest:
+        component_descriptor = component_descriptor_lookup(ocm.ComponentIdentity(
+            name=component_reference.componentName,
+            version=component_reference.version,
+        ))
+
+        digest = component_descriptor_digest(
+            component_descriptor=component_descriptor,
+            component_descriptor_lookup=component_descriptor_lookup,
+            access_to_digest_lookup=access_to_digest_lookup,
+            normalisation=normalisation,
+        )
+
+        component_reference_raw['digest'] = dataclasses.asdict(ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=normalisation,
+            value=digest,
+        ))
+
+    # extra-identity is expected to be null instead of an empty object by OCM-cli in case it does
+    # not contain any elements
+    if not component_reference.extraIdentity:
+        component_reference_raw['extraIdentity'] = None
+
+    return normalise_obj(component_reference_raw)
+
+
+def normalise_component(
+    component: ocm.Component,
+    component_descriptor_lookup: collections.abc.Callable[[ocm.ComponentIdentity], ocm.ComponentDescriptor], # noqa: E501
+    access_to_digest_lookup: collections.abc.Callable[[ocm.Access], ocm.DigestSpec],
+    normalisation: ocm.NormalisationAlgorithm=ocm.NormalisationAlgorithm.JSON_NORMALISATION,
+) -> list[dict]:
+    component_raw = dataclasses.asdict(component)
+
+    # drop properties not relevant for signing
+    del component_raw['repositoryContexts']
+    del component_raw['sources']
+
+    if labels := [normalise_label(l) for l in component.labels if l.signing]:
+        component_raw['labels'] = labels
+    else:
+        del component_raw['labels']
+
+    # calculate missing digests for component references
+    component_raw['componentReferences'] = [
+        normalise_component_reference(
+            component_reference=cref,
+            component_descriptor_lookup=component_descriptor_lookup,
+            access_to_digest_lookup=access_to_digest_lookup,
+            normalisation=normalisation,
+        ) for cref in component.componentReferences
+    ]
+
+    # calculate missing digests for resources; also, match OCM-cli's extra-identity handling by
+    # implicitly adding the version to the extra-identity if the resource is not unique by its name
+    # + existing extra-identity yet (not for the last resource as this is unique already if all
+    # other resources have the version added to their extra-identity)
+    resources = []
+    for idx, resource in enumerate(component.resources):
+        for peer in component.resources[idx+1:]:
+            if (
+                peer.identity(peers=()) == resource.identity(peers=())
+                and 'version' not in resource.extraIdentity
+            ):
+                resource = dataclasses.replace(resource) # create copy
+                resource.extraIdentity['version'] = resource.version
+
+        resources.append(normalise_resource(
+            resource=resource,
+            access_to_digest_lookup=access_to_digest_lookup,
+        ))
+    component_raw['resources'] = resources
+
+    # match OCM-cli's creation time normalisation by dropping the microseconds (round up if
+    # necessary) and match expected format %Y-%m-%dT%H:%M:%SZ
+    if component.creationTime:
+        creation_time = datetime.datetime.fromisoformat(component.creationTime)
+        if creation_time.microsecond >= 500000:
+            creation_time += datetime.timedelta(seconds=1)
+        component_raw['creationTime'] = creation_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+    else:
+        del component_raw['creationTime']
+
+    return normalise_obj(component_raw)
+
+
+def normalise_component_descriptor(
+    component_descriptor: ocm.ComponentDescriptor,
+    component_descriptor_lookup: collections.abc.Callable[[ocm.ComponentIdentity], ocm.ComponentDescriptor], # noqa: E501
+    access_to_digest_lookup: collections.abc.Callable[[ocm.Access], ocm.DigestSpec],
+    normalisation: ocm.NormalisationAlgorithm=ocm.NormalisationAlgorithm.JSON_NORMALISATION,
+) -> list[dict]:
+    '''
+    Returns a normalised version of the component descriptor by dropping signing-irrelevant
+    properties, calculating missing digests and converting properties to the format expected by the
+    OCM-cli (i.e. extra-identity handling and datetime-format).
+
+    @param component_descriptor_lookup:
+        lookup for component descriptors by their identity
+    @param image_ref_to_digest_lookup:
+        used to retrieve the digest of an oci-resource by its image reference
+    '''
+    component_descriptor_raw = dataclasses.asdict(component_descriptor)
+
+    # drop properties not relevant for signing
+    del component_descriptor_raw['signatures']
+    del component_descriptor_raw['nestedDigests']
+
+    component_descriptor_raw['component'] = normalise_component(
+        component=component_descriptor.component,
+        component_descriptor_lookup=component_descriptor_lookup,
+        access_to_digest_lookup=access_to_digest_lookup,
+        normalisation=normalisation,
+    )
+
+    return normalise_obj(component_descriptor_raw)
+
+
+def component_descriptor_digest(
+    component_descriptor: ocm.ComponentDescriptor,
+    component_descriptor_lookup: collections.abc.Callable[[ocm.ComponentIdentity], ocm.ComponentDescriptor], # noqa: E501
+    access_to_digest_lookup: collections.abc.Callable[[ocm.Access], ocm.DigestSpec],
+    normalisation: ocm.NormalisationAlgorithm=ocm.NormalisationAlgorithm.JSON_NORMALISATION,
+) -> str:
+    '''
+    Calculates the hexdigest of the recursively normalised component descriptor. If an already
+    existing digest for a component reference or resource is found, this is assumed to be valid and
+    no re-calculation is performed. This must be done as part of the validation though.
+
+    @param component_descriptor_lookup:
+        lookup for component descriptors by their identity
+    @param image_ref_to_digest_lookup:
+        used to retrieve the digest of an oci-resource by its image reference
+    '''
+    normalised_component_descriptor = normalise_component_descriptor(
+        component_descriptor=component_descriptor,
+        component_descriptor_lookup=component_descriptor_lookup,
+        access_to_digest_lookup=access_to_digest_lookup,
+        normalisation=normalisation,
+    )
+
+    serialised_component_descriptor = json.dumps(
+        obj=normalised_component_descriptor,
+        separators=(',', ':'), # remove spaces after separators (match OCM-cli)
+    )
+
+    return hashlib.sha256(serialised_component_descriptor.encode()).hexdigest()


### PR DESCRIPTION
Adds utilities to create a normalised version of a component descriptor matching the `jsonNormalisation/v1` of the OCM-cli.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Added implementation of the `jsonNormalisation/v1` algorithm to the OCM model.
```
