### PR TITLE
Drop OCM cli from job-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,9 @@ RUN cat /cc/utils/gardener-cicd-libs.apk-packages \
   gardener-cicd-cli==$(cat /metadata/VERSION) \
   pycryptodome
 
-FROM ghcr.io/open-component-model/ocm/ocm.software/ocmcli/ocmcli-image:0.18.0 AS ocm-cli
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
-
-COPY --from=ocm-cli /bin/ocm /bin/ocm
 
 COPY --from=builder /pkgs/usr /usr
 COPY --from=builder /cc/utils/bin /cc/utils/bin


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed OCM cli from cc-utils' job-image
```
