### PR TITLE
Use `alpine:edge` for alpine-sap-image

### DIFF
--- a/Dockerfile.alpine-sap
+++ b/Dockerfile.alpine-sap
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:edge
 
 RUN --mount=type=bind,source=ALPINE_SAP_VERSION,target=/ALPINE_SAP_VERSION \
     apk add --no-cache \


### PR DESCRIPTION
Following edge allows use to consume patches earlier, especially relevant for security related patches which have not been ported back to alpine release branches.

open-delivery-gear is the only known consumer. If this changes in future and following edge is not possible anymore, consider creating dedicated odg-alpine-(base-)image.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
