### PR TITLE
allow passing-in different auth-token for pushing commits

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -77,9 +77,14 @@ inputs:
     required: false
   github-token:
     description: |
-      the github-auth-token to use for authenticating against GitHub.
+      the github-auth-token to use for authenticating against GitHub and OCI-Registry.
       Use `secrets.GITHUB_TOKEN`
     required: true
+  git-push-token:
+    description: |
+      an auth-token to use for pushing release- and bump-commits. Must grant the privilege to
+      bypass branch-protection-rules, if present.
+    required: false
 
 defaults:
   run:
@@ -91,6 +96,8 @@ runs:
     - name: install-gardener-gha-libs
       uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - uses: actions/checkout@v4
+      with:
+        token: ${{ git-push-token || github-token }}
     - name: import-release-commit
       uses: gardener/cc-utils/.github/actions/import-commit@master
       with:


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
allow passing-in different auth-token to release-action for pushing commits bypassing branch-protections
```
