### PR TITLE
Also add `allowed_processing_time` (+ `due_date`) to findings + rescorings model

### DIFF
--- a/dso/model.py
+++ b/dso/model.py
@@ -695,6 +695,12 @@ class MetaRescoringRules(enum.StrEnum):
 
 @dataclasses.dataclass(frozen=True)
 class CustomRescoring:
+    '''
+    The `allowed_processing_time` is stored relatively to allow the rescoring to apply to findings
+    with different discovery dates, i.e. in case the rescoring is of scope "global" or "component".
+    Alternatively, the explicit `due_date` can be set in case the `due_date` is independent of the
+    individual discovery dates (for example, this might be the case if exceptions apply).
+    '''
     finding: (
         RescoringVulnerabilityFinding
         | RescoringLicenseFinding
@@ -712,6 +718,8 @@ class CustomRescoring:
     )
     matching_rules: list[str] = dataclasses.field(default_factory=list)
     comment: str | None = None
+    allowed_processing_time: str | None = None
+    due_date: datetime.date | None = None
 
     @property
     def key(self) -> str:
@@ -721,6 +729,8 @@ class CustomRescoring:
             self.user.key,
             self.comment,
             self.finding.key,
+            self.allowed_processing_time,
+            self.due_date.strftime('%Y-%m-%d') if self.due_date else None,
         )
 
 
@@ -922,6 +932,7 @@ class ArtefactMetadata:
         | dict # fallback, there should be a type
     )
     discovery_date: datetime.date | None = None # required for finding specific SLA tracking
+    allowed_processing_time: str | None = None
 
     @staticmethod
     def from_dict(raw: dict):

--- a/dso/model.py
+++ b/dso/model.py
@@ -738,12 +738,12 @@ class ComplianceSnapshotState:
 
 @dataclasses.dataclass(frozen=True)
 class ComplianceSnapshot:
-    latest_processing_date: datetime.date
+    due_date: datetime.date
     state: list[ComplianceSnapshotState]
 
     @property
     def key(self) -> str:
-        return self.latest_processing_date.isoformat()
+        return self.due_date.isoformat()
 
     def current_state(
         self,

--- a/github/compliance/issue.py
+++ b/github/compliance/issue.py
@@ -157,7 +157,7 @@ def _create_issue(
     assignees_statuses: set[delivery.model.Status] = set(),
     milestone: github3.issues.milestone.Milestone=None,
     failed_milestones: list[github3.issues.milestone.Milestone]=[],
-    latest_processing_date: datetime.date|datetime.datetime=None,
+    due_date: datetime.date|datetime.datetime=None,
 ) -> github3.issues.issue.ShortIssue:
     assignees = tuple(assignees)
 
@@ -176,9 +176,9 @@ def _create_issue(
             labels=sorted(labels),
         )
 
-        if latest_processing_date:
-            latest_processing_date = latest_processing_date.isoformat()
-            issue.create_comment(f'{latest_processing_date=}')
+        if due_date:
+            due_date = due_date.isoformat()
+            issue.create_comment(f'{due_date=}')
 
         if assignees_statuses:
             comment_body = textwrap.dedent('''\
@@ -294,7 +294,7 @@ def create_or_update_issue(
     assignees_statuses: set[delivery.model.Status] = set(),
     milestone: github3.issues.milestone.Milestone=None,
     failed_milestones: list[github3.issues.milestone.Milestone]=[],
-    latest_processing_date: datetime.date=None,
+    due_date: datetime.date=None,
     extra_labels: typing.Iterable[str]=None,
     preserve_labels_regexes: typing.Iterable[str]=(),
     ctx_labels: typing.Iterable[str]=(),
@@ -341,7 +341,7 @@ def create_or_update_issue(
             assignees_statuses=assignees_statuses,
             milestone=milestone,
             failed_milestones=failed_milestones,
-            latest_processing_date=latest_processing_date,
+            due_date=due_date,
         )
     elif issues_count == 1:
 

--- a/github/compliance/milestone.py
+++ b/github/compliance/milestone.py
@@ -127,7 +127,7 @@ def _sprints(
 
 def target_sprints(
     delivery_svc_client: delivery.client.DeliveryServiceClient,
-    latest_processing_date: datetime.date,
+    due_date: datetime.date,
     sprints_count: int=-1,
 ) -> tuple[dm.Sprint]:
     sprints = _sprints(
@@ -142,13 +142,13 @@ def target_sprints(
             break
 
         end_date = sprint.find_sprint_date(name='end_date').value.date()
-        if end_date >= latest_processing_date:
+        if end_date >= due_date:
             targets_sprints.append(sprint)
 
     if len(targets_sprints) < sprints_count:
         logger.warning(
             f'did not find {sprints_count} sprints starting from ' +
-            f'{latest_processing_date}, only found {len(targets_sprints)} sprints'
+            f'{due_date}, only found {len(targets_sprints)} sprints'
         )
 
     return tuple(targets_sprints)

--- a/github/compliance/report.py
+++ b/github/compliance/report.py
@@ -516,7 +516,7 @@ def create_or_update_github_issues(
                     f'issue. Remaining assignees: {assignees}'
                 )
 
-            latest_processing_date = None
+            due_date = None
             target_milestone = None
             failed_milestones = []
 
@@ -524,16 +524,12 @@ def create_or_update_github_issues(
                 try:
                     if not max_processing_days:
                         max_processing_days = gcm.MaxProcessingTimesDays()
-                    max_days = max_processing_days.for_severity(
-                        criticality_classification,
-                    )
-                    latest_processing_date = datetime.date.today() + datetime.timedelta(
-                        days=max_days,
-                    )
+                    max_days = max_processing_days.for_severity(criticality_classification)
+                    due_date = datetime.date.today() + datetime.timedelta(days=max_days)
 
                     target_sprints = gcmi.target_sprints(
                         delivery_svc_client=delivery_svc_client,
-                        latest_processing_date=latest_processing_date,
+                        due_date=due_date,
                         sprints_count=2,
                     )
                     target_milestone, failed_milestones = gcmi.find_or_create_sprint_milestone(
@@ -542,7 +538,7 @@ def create_or_update_github_issues(
                     )
 
                     if target_milestone:
-                        latest_processing_date = target_milestone.due_on.date()
+                        due_date = target_milestone.due_on.date()
                 except Exception as e:
                     import traceback
                     traceback.print_exc()
@@ -581,7 +577,7 @@ def create_or_update_github_issues(
                     assignees_statuses=assignees_statuses,
                     milestone=target_milestone,
                     failed_milestones=failed_milestones,
-                    latest_processing_date=latest_processing_date,
+                    due_date=due_date,
                     ctx_labels=ctx_labels,
                     preserve_labels_regexes=preserve_labels_regexes,
                     known_issues=known_issues,


### PR DESCRIPTION
To not honour already existing findings + rescorings in case existing allowed processing times change, also store the `allowed_processing_time` (+ `due_date`) which is valid upon creation time. This is also a prerequisite to allow rescorings with a manual `due_date` input (e.g. in case of exceptions).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
