### PR TITLE
refactor: pass (by default) base-component-descriptor as artefact

### DIFF
--- a/.github/actions/base-component-descriptor/action.yaml
+++ b/.github/actions/base-component-descriptor/action.yaml
@@ -24,6 +24,10 @@ description: |
         value: 42
   ```
 
+  The resulting base-component-descriptor is exposed both as an output (`component-descriptor`), and
+  as an artefact (named `base-component-descriptor`). The latter consists of a single TARchive
+  named `component-descriptor.tar.gz`, containing a single file `component-descriptor.yaml`.
+
 inputs:
   base-component:
     required: false
@@ -77,6 +81,7 @@ runs:
         sys.path.insert(1, os.environ['GITHUB_ACTION_PATH'])
 
         import datetime
+        import tarfile
         import textwrap
         import urllib.parse
 
@@ -140,6 +145,13 @@ runs:
             Dumper=ocm.EnumValueYamlDumper,
         )
 
+        with open('component-descriptor.yaml', 'w') as f:
+          f.write(component_descriptor_str)
+        with tarfile.open(name='component-descriptor.tar.gz', mode='w:gz') as tf:
+          tf.add(
+            name='component-descriptor.yaml',
+          )
+
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
           f.write('component-descriptor<<EOF\n')
           f.write(component_descriptor_str)
@@ -153,3 +165,7 @@ runs:
             {textwrap.indent(component_descriptor_str, '  ')}
             ```
           '''))
+    - uses: actions/upload-artifact@v4
+      with:
+        name: base-component-descriptor
+        path: component-descriptor.tar.gz

--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -35,6 +35,12 @@ inputs:
     required: true
     description: |
       a filepath pointing to a file that was created before the head-commit
+  to-artefact:
+    required: false
+    description: |
+      if specified, the captured commits will also be uploaded as an artefact of the specified
+      name. The artefact will contain a single TARchive w/ the same contents as the `commit-objects`
+      output. Its name will be `commit-objects.tar.gz`
 
 outputs:
   commit-digest:
@@ -78,5 +84,10 @@ runs:
         commit-message:
         $(git show)
         EOF
-        git clean -dfx
+        gzip commit-objects.tar
       shell: bash
+    - uses: actions/upload-artifact@v4
+      if: ${{ inputs.to-artefact != '' }}
+      with:
+        name: ${{ inputs.to-artefact }}
+        path: commit-objects.tar.gz

--- a/.github/actions/import-commit/action.yaml
+++ b/.github/actions/import-commit/action.yaml
@@ -12,10 +12,17 @@ description: |
 
 inputs:
   commit-objects:
-    required: true
+    required: false
     description: |
       a base64-encoded tarfile containing the objects to import into git-repository. The expected
       format matches the one output from `capture-commit` action.
+
+      Either this input, or `commit-objects-artefact` must be passed.
+  commit-objects-artefact:
+    required: false
+    description: |
+      name of artefact to use as alternative to directly passing objects as input via the
+      `commit-objects` input.
   commit-digest:
     required: false
     description: |
@@ -60,10 +67,25 @@ runs:
         if which git &>/dev/null; then exit 0; fi
         apt-get install -y git
       shell: bash
+    - name: import-commit-objects-from-input
+      if: ${{ inputs.commit-objects != '' }}
+      run: |
+        set -eu
+        echo "${{ inputs.commit-objects }}" | base64 -d | tar x
+    - name: import-commit-objects-from-artefact
+      if: ${{ inputs.commit-objects-artefact != '' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.commit-objects-artefact }}
+    - name: extract-commit-objects-from-artefact
+      if: ${{ inputs.commit-objects-artefact != '' }}
+      run: |
+        set -eu
+        tar xf commit-objects.tar.gz
+        unlink commit-objects.tar.gz
     - name: import-commit
       run: |
         echo 'importing objects into .git-dir'
-        echo "${{ inputs.commit-objects }}" | base64 -d | tar x
         if [ -n "${{ inputs.commit-digest }}" ]; then
           commit_digest="${{ inputs.commit-digest }}"
         else

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -21,6 +21,17 @@ inputs:
     description: |
       The (base) component-descriptor to merge ocm-fragments into. If it is not passed, a minimal
       one will be created.
+  component-descriptor-artefact:
+    required: false
+    type: string
+    description: |
+      If passed, the passed name is assumed to refer to an (existing) artefact of this name,
+      containing a (base) component-descriptor, as output by the `base-component-descriptor`
+      action.
+
+      I.e. it must contain (at least) a file named `component-descriptor.tar.gz`, which in turn
+      must (at least) contain a file `component-descriptor.yaml`, which is used as base
+      component-descriptor.
   ctx:
     required: false
     type: string
@@ -66,6 +77,29 @@ runs:
         cat <<EOF > "${{ inputs.outdir }}/base-component-descriptor.yaml"
         ${{ inputs.component-descriptor }}
         EOF
+    - name: import-component-descriptor-artefact
+      if: ${{ inputs.component-descriptor-artefact }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.component-descriptor-artefact }}
+    - name: extract-component-descriptor-artefact
+      if: ${{ inputs.component-descriptor-artefact }}
+      shell: bash
+      run: |
+        archive=component-descriptor.tar.gz
+        if [ ! -f "${archive}" ]; then
+          echo "Error: expected file not present: ${archive}"
+          exit 1
+        fi
+        tar xf ${archive}
+        component_descriptor_path='component-descriptor.yaml'
+        if [ ! -f "${component_descriptor_path}" ]; then
+          echo "Error: archive did not contain expected ${component_descriptor_path} file"
+          exit 1
+        fi
+        echo "<<EOF" >> "${GITHUB_OUTPUT}"
+        cat "${component_descriptor_path}" >> ${GITHUB_OUTPUT}
+        echo EOF >> "${GITHUB_OUTPUT}"
     - name: prepare-component-descriptor
       shell: bash
       run: |

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -27,7 +27,13 @@ inputs:
   release-commit-objects:
     description: |
       release-commit in serialised form (as output by `capture-commit` action)
-    required: true
+
+      Either this input, or `release-commit-objects-artefact` must be passed.
+    required: false
+  release-commit-objects-artefact:
+    description: |
+      name of artefact (as published from capture-commit action) to use.
+    required: false
   release-commit-digest:
     description: |
       release-commit-digest (necessary, unless capture-commit's special-ref is not present)
@@ -101,6 +107,7 @@ runs:
     - name: import-release-commit
       uses: gardener/cc-utils/.github/actions/import-commit@master
       with:
+        commit-objects-artefact: ${{ inputs.release-commit-objects-artefact }}
         commit-objects: ${{ inputs.release-commit-objects }}
         commit-digest: ${{ inputs.release-commit-digest }}
         after-import: rebase

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -83,6 +83,12 @@ inputs:
 
       If `noop` is set as `version-operation`, passed values are ignored.
       Setting prerelease to the empty string (which is the default) will "finalise" version.
+  commit-objects-artefact:
+    required: false
+    type: string
+    description: |
+      if passed, captured commit (as output by `capture-commit` action) will (also) be uploaded
+      as an artefat of the passed name.
 
   repository-operation:
     required: true
@@ -183,6 +189,7 @@ runs:
       uses: gardener/cc-utils/.github/actions/capture-commit@master
       with:
         timestamp-reference: /tmp/timestamp-ref
+        to-artefact: ${{ inputs.commit-objects-artefact }}
     - name: reset-repository
       if: ${{ inputs.repository-operation == 'capture-commit' }}
       shell: bash

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -16,5 +16,4 @@ jobs:
       - name: collect-component-descriptor
         uses: ./.github/actions/merge-ocm-fragments
         with:
-          component-descriptor: ${{ needs.build-and-test.outputs.base-component-descriptor }}
           outdir: /tmp/ocm

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -102,9 +102,11 @@ jobs:
           echo "commit-message=${commit_msg}" >> ${GITHUB_OUTPUT}
       - uses: gardener/cc-utils/.github/actions/version@master
         id: version
+        name: create-release-commit
         with:
           prerelease: ${{ steps.pre.outputs.prerelease }}
           commit-message: ${{ steps.pre.outputs.commit-message }}
+          commit-objects-artefact: release-commit-objects
       - uses: gardener/cc-utils/.github/actions/base-component-descriptor@master
         id: component-descriptor
         with:

--- a/.github/workflows/release-cc-utils.yaml
+++ b/.github/workflows/release-cc-utils.yaml
@@ -25,7 +25,6 @@ jobs:
     secrets:
       github-app-secret-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
     with:
-      release-commit-objects: ${{ needs.build.outputs.version-commit-objects }}
       release-commit-target: branch
       next-version: bump-minor
 

--- a/.github/workflows/release-cc-utils.yaml
+++ b/.github/workflows/release-cc-utils.yaml
@@ -25,7 +25,6 @@ jobs:
     secrets:
       github-app-secret-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
     with:
-      component-descriptor: ${{ needs.build.outputs.base-component-descriptor }}
       release-commit-objects: ${{ needs.build.outputs.version-commit-objects }}
       release-commit-target: branch
       next-version: bump-minor

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,13 +35,17 @@ on:
           If not passed, an artefact named `base-component-descriptor` will be assumed to
           exist, and used as default / fallback.
       release-commit-objects:
-        required: true
+        required: false
         type: string
         description: |
           The release-commit (created from build-job) to publish. The expected format matches the
           one emitted by the `capture-commit` action; i.e. the value is expected to be a base64
           encoded TARchive containing all objects belonging to the commit, as taken from `.git`
           directory after commit was created.
+
+          If not passed, the action will fallback to expecting the commit-objects having been
+          uploaded into an artefact named `release-commit-objects` (which the `prepare.yaml`)
+          workflow does by default.
       release-commit-target:
         required: false
         default: branch
@@ -92,6 +96,7 @@ jobs:
           component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
           component-descriptor-blobs-dir: /tmp/ocm/blobs.d
           release-commit-objects: ${{ inputs.release-commit-objects }}
+          release-commit-objects-artefact: release-commit-objects
           release-commit-target: ${{ inputs.release-commit-target }}
           next-version: ${{ inputs.next-version }}
           next-version-commit-message: "next version: ${version}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,15 @@ on:
           Pass-in `secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY`.
     inputs:
       component-descriptor:
-        required: true
+        required: false
         type: string
         description: |
           A base-component-descriptor, as output from `base-component-descriptor` action.
           Additional Component-Descriptor-Fragments as exported from the `export-ocm-fragments`
           action will be merged into it (i.e. callers do not need to take care of this).
+
+          If not passed, an artefact named `base-component-descriptor` will be assumed to
+          exist, and used as default / fallback.
       release-commit-objects:
         required: true
         type: string


### PR DESCRIPTION
Avoid some more boilerplate: Let `merge-ocm-fragments`-action by default fallback to retrieve base-component-descriptor from artefact (also, let base-component-descriptor-action publish such artefacts), effectively allowing to drop explicit passing of base-component-descriptor from build-action to callers.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Let `merge-ocm-fragments`-action by default fallback to retrieve base-component-descriptor from artefact (also, let base-component-descriptor-action publish such artefacts), effectively allowing to drop explicit passing of base-component-descriptor from build-action to callers.
```
