### PR TITLE
Keep `v` version prefix (if specified)

### DIFF
--- a/.github/actions/version/version_cli.py
+++ b/.github/actions/version/version_cli.py
@@ -183,29 +183,30 @@ def process_version(
 ):
     if operation is VersionOperation.NOOP:
         return version
-    parsed_version = version_mod.parse_to_semver(version)
+    parsed_version, prefix = version_mod._parse_to_semver_and_prefix(version)
+    prefix = prefix or ''
     parsed_version = parsed_version.replace(
         prerelease=prerelease,
     )
 
     if operation is VersionOperation.SET_PRERELEASE:
-        return str(parsed_version)
+        return f'{prefix}{parsed_version}'
 
     if operation is VersionOperation.BUMP_MAJOR:
         bumped = parsed_version.bump_major()
         if prerelease:
             bumped = f'{bumped}-{prerelease}'
-        return bumped
+        return f'{prefix}{bumped}'
     if operation is VersionOperation.BUMP_MINOR:
         bumped = parsed_version.bump_minor()
         if prerelease:
             bumped = f'{bumped}-{prerelease}'
-        return bumped
+        return f'{prefix}{bumped}'
     if operation is VersionOperation.BUMP_PATCH:
         bumped = parsed_version.bump_patch()
         if prerelease:
             bumped = f'{bumped}-{prerelease}'
-        return bumped
+        return f'{prefix}{bumped}'
 
     raise ValueError('unexpected version-operation', operation)
 

--- a/version.py
+++ b/version.py
@@ -180,7 +180,7 @@ def parse_to_semver(
     return semver_version_info
 
 
-def _parse_to_semver_and_prefix(version: str) -> semver.VersionInfo:
+def _parse_to_semver_and_prefix(version: str) -> tuple[semver.VersionInfo, str | None]:
     def raise_invalid():
         raise ValueError(f'not a valid (semver) version: `{version}`')
 


### PR DESCRIPTION
Required for go packages.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
