### PR TITLE
Don't raise upon 404 on DELETE manifest operations per default

### DIFF
--- a/cnudie/purge.py
+++ b/cnudie/purge.py
@@ -40,6 +40,7 @@ def remove_component_descriptor_and_referenced_artefacts(
     lookup: cnudie.retrieve.ComponentDescriptorLookupById=None,
     recursive: bool=False,
     on_error: str='abort', # todo: implement, e.g. patch-component-descriptor-and-abort
+    absent_ok: bool=False,
 ):
     if isinstance(component, ocm.ComponentDescriptor):
         component = component.component
@@ -63,6 +64,7 @@ def remove_component_descriptor_and_referenced_artefacts(
                 _remove_component_descriptor(
                     component=current_component,
                     oci_client=oci_client,
+                    absent_ok=absent_ok,
                 )
             current_component = node.component
             continue
@@ -78,6 +80,7 @@ def remove_component_descriptor_and_referenced_artefacts(
                 did_remove = _remove_resource(
                     node=node,
                     oci_client=oci_client,
+                    absent_ok=absent_ok,
                 )
                 if not did_remove:
                     logger.info(f'do not know how to remove {node.resource=}')
@@ -97,12 +100,14 @@ def remove_component_descriptor_and_referenced_artefacts(
         _remove_component_descriptor(
             component=component,
             oci_client=oci_client,
+            absent_ok=absent_ok,
         )
 
 
 def _remove_component_descriptor(
     component: ocm.Component,
     oci_client: oc.Client,
+    absent_ok: bool=False,
 ):
     oci_ref = cnudie.util.oci_ref(
         component=component,
@@ -111,12 +116,14 @@ def _remove_component_descriptor(
     oci_client.delete_manifest(
         image_reference=oci_ref,
         purge=True,
+        absent_ok=absent_ok,
     )
 
 
 def _remove_resource(
     node: cnudie.iter.ResourceNode,
     oci_client: oc.Client,
+    absent_ok: bool=False,
 ) -> bool:
     resource = node.resource
     if not resource.type in (ocm.ArtefactType.OCI_IMAGE, 'ociImage'):
@@ -151,6 +158,7 @@ def _remove_resource(
         image_reference=image_reference,
         purge=purge,
         accept=om.MimeTypes.prefer_multiarch,
+        absent_ok=absent_ok,
     )
 
     if isinstance(manifest, om.OciImageManifest):
@@ -181,6 +189,7 @@ def _remove_resource(
         oci_client.delete_manifest(
             image_reference=ref,
             purge=True,
+            absent_ok=absent_ok,
         )
 
     return True

--- a/oci/client_async.py
+++ b/oci/client_async.py
@@ -560,6 +560,7 @@ class Client:
         image_reference: om.OciImageReference | str,
         purge: bool=False,
         accept: str=om.MimeTypes.prefer_multiarch,
+        absent_ok: bool=False,
     ):
         '''
         deletes the specified manifest. Depending on whether the passed image_reference contains
@@ -585,7 +586,7 @@ class Client:
             else:
                 headers = {}
 
-            return await self._request(
+            res = await self._request(
                 url=self.routes.manifest_url(
                     image_reference=image_reference,
                     tag_preprocessing_callback=self.tag_preprocessing_callback,
@@ -594,7 +595,15 @@ class Client:
                 scope=scope,
                 headers=headers,
                 method='DELETE',
+                raise_for_status=False,
             )
+
+            if absent_ok and res.status_code == 404:
+                return res
+
+            res.raise_for_status()
+
+            return res
         elif image_reference.has_symbolical_tag:
             manifest_raw = await self.manifest_raw(
                 image_reference=image_reference,
@@ -607,11 +616,13 @@ class Client:
                 image_reference=image_reference,
                 purge=False,
                 accept=accept,
+                absent_ok=absent_ok,
             )
             res.raise_for_status()
             return await self.delete_manifest(
                 image_reference=f'{image_reference.ref_without_tag}@{manifest_digest}',
                 purge=False,
+                absent_ok=absent_ok,
             )
         else:
             raise RuntimeError('this case should not occur (this is a bug)')


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
OCI client does not raise upon 404 per default for DELETE manifest operations
```
