### PR TITLE
Allow oci-client without credential-lookup (anonymous auth)

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -251,10 +251,17 @@ def _scope(image_reference: str | om.OciImageReference, action: str):
     return scope
 
 
+def no_credentials_lookup(**kwargs) -> None:
+    '''
+    useful to pass to oci-client when working with public images
+    '''
+    return None
+
+
 class Client:
     def __init__(
         self,
-        credentials_lookup: collections.abc.Callable,
+        credentials_lookup: collections.abc.Callable=no_credentials_lookup,
         routes: OciRoutes=OciRoutes(),
         disable_tls_validation: bool=False,
         timeout_seconds: int=None,
@@ -264,6 +271,7 @@ class Client:
     ):
         '''
         @param credentials_lookup <Callable>
+            defaults to no credentials, leading to anonymous-auth attempt
         @param routes <OciRoutes>
         @param disable_tls_validation <bool>
         @param timeout_seconds <int>


### PR DESCRIPTION
Useful when working with public images, as credential handling boilerplate can be omitted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
gardener-cicd-libs oci-client will not use credentials by default (useful for public images)
```
