### PR TITLE
default to org-secret

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,11 @@ on:
   workflow_call:
     secrets:
       github-app-secret-key:
-        required: true
+        required: false
         description: |
           The secret-key for the `Gardener-GitHub-App` (`vars.GARDENER_GITHUB_ACTIONS_APP_ID`)
-          Pass-in `secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY`.
+          If not passed (in which case calling workflows need to set `secrets: inherit`), defaults
+          to `secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY`.
     inputs:
       component-descriptor:
         required: false
@@ -91,7 +92,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
-          private-key: ${{ secrets.github-app-secret-key }}
+          private-key: ${{ secrets.github-app-secret-key || secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
       - uses: gardener/cc-utils/.github/actions/release@master
         with:
           component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}


### PR DESCRIPTION
Do not require calling workflows to explicitly pass-in org-secret to release-workflow. Instead, have it default to reading org-secret. This will make usage of additional secrets more convenient.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
reusable `release.yaml` workflow now no longer needs to be passed org-secrets explicitly, if using `secrets: inherit`.
```
