### PR TITLE
Resolve reference to `cnudie` package in `ocm download` command

### DIFF
--- a/cnudie/retrieve.py
+++ b/cnudie/retrieve.py
@@ -376,7 +376,6 @@ def _raw_component_descriptor_from_oci(
     for ocm_repo in ocm_repos:
         if isinstance(ocm_repo, str):
             ocm_repo = ocm.OciOcmRepository(
-                type=ocm.OciAccess,
                 baseUrl=ocm_repo,
             )
 

--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -236,6 +236,10 @@ def upload(parsed):
 
 
 def download(parsed):
+    if not _have_oci:
+        print('ERROR: `oci`-package is not available - cannot download')
+        exit(1)
+
     cname, cversion = parsed.component.split(':')
     oci_client = oci.client.Client(
         credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),

--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -2,14 +2,15 @@ import argparse
 import collections.abc
 import dataclasses
 import datetime
+import io
 import json
 import os
 import sys
 
 import dacite
 
-import cnudie.retrieve
 import ocm
+import ocm.oci
 import ocm.upload
 
 
@@ -244,13 +245,52 @@ def download(parsed):
     oci_client = oci.client.Client(
         credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
     )
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(
-            parsed.ocm_repository,
-        ),
-        oci_client=oci_client,
+
+    ocm_repo = ocm.OciOcmRepository(
+        baseUrl=parsed.ocm_repository,
     )
-    component_descriptor = component_descriptor_lookup((cname, cversion))
+
+    target_ref = ocm_repo.component_version_oci_ref(
+        name=cname,
+        version=cversion,
+    )
+
+    manifest = oci_client.manifest(
+        image_reference=target_ref,
+    )
+
+    try:
+        cfg_blob = oci_client.blob(
+            image_reference=target_ref,
+            digest=manifest.config.digest,
+        )
+        cfg_raw = json.loads(cfg_blob.text)
+        cfg = dacite.from_dict(
+            data_class=ocm.oci.ComponentDescriptorOciCfg,
+            data=cfg_raw,
+        )
+        layer_digest = cfg.componentDescriptorLayer.digest
+        layer_mimetype = cfg.componentDescriptorLayer.mediaType
+    except Exception as e:
+        print(f'Failed to retrieve component-descriptor-cfg: {e=}, falling back to first layer')
+
+        # by contract, the first layer must always be a tar w/ component-descriptor
+        layer_digest = manifest.layers[0].digest
+        layer_mimetype = manifest.layers[0].mediaType
+
+    if not layer_mimetype in ocm.oci.component_descriptor_mimetypes:
+        print(f'Error: {target_ref=} {layer_mimetype=} was unexpected')
+        exit(1)
+
+    raw = oci_client.blob(
+        image_reference=target_ref,
+        digest=layer_digest,
+        stream=False, # manifests are typically small - do not bother w/ streaming
+    ).content
+
+    component_descriptor = ocm.oci.component_descriptor_from_tarfileobj(
+        fileobj=io.BytesIO(raw),
+    )
     component = component_descriptor.component
 
     if parsed.outfile == '-':


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `gardener-ocm` Python package no longer requires the `cnudie` package to be installed
```
