### PR TITLE
fix: do not overwrite (patched) OCI manifest

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -159,7 +159,6 @@ def replicate_artifact(
         need_uncompressed_layer_digests = True
         uncompressed_layer_digests = []
     elif schema_version == 2:
-        manifest = json.loads(raw_manifest)
         media_type = manifest.get('mediaType', om.DOCKER_MANIFEST_SCHEMA_V2_MIME)
 
         if media_type in (


### PR DESCRIPTION
For OCI-Manifests of type Image-List, or OCI-Image-Index, that lack a `mediaType`-attribute, we patch-in media-type from `Content-Type` HTTP-Header (if present).

Rm redundant deserilisation that would overwrite said patching.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix: do not overwrite (patched) OCI manifest
```
