### PR TITLE
fix: utf-8-encode component-descriptor

### DIFF
--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -258,6 +258,7 @@ def download(parsed):
         yaml.dump(
             data=dataclasses.asdict(component_descriptor),
             stream=outfh,
+            encoding='utf-8',
             Dumper=ocm.EnumValueYamlDumper,
         )
         exit(0)


### PR DESCRIPTION
`ocm`'s `download`-command opens target fileobjects in binary-mode (which is a reasonable match for retrieveing artefact-contents). Utf-8-encode component-descriptor if used to dump component-descriptor.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
fix: utf-8-encode component-descriptor
```
