### PR TITLE
add `component-descriptor` workflow

### DIFF
--- a/.github/workflows/component-descriptor.yaml
+++ b/.github/workflows/component-descriptor.yaml
@@ -1,0 +1,54 @@
+name: OCM Component-Descriptor
+description: |
+  A reusable workflow for retrieving and uploading the OCM Component-Descriptor that as created
+  by a build using `prepare.yaml` and `export-ocm-fragment` action(s).
+
+  Counterpart to `release.yaml` for non-release-jobs. Callers must ensure it is run only after
+  build-job(s) emitted OCM-Fragments are finished prior to running this workflow.
+
+on:
+  workflow_call:
+
+jobs:
+  component-descriptor:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: collect-component-descriptor
+        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@master
+        with:
+          component-descriptor-artefact: base-component-descriptor
+          outdir: /tmp/ocm
+      - name: read-target-oci-ref
+        id: read-oci-ref
+        shell: python
+        run: |
+          import os
+          import yaml
+          import ocm
+
+          with open('/tmp/ocm/component-descriptor.yaml') as f:
+            component_descriptor = ocm.ComponentDescriptor.from_dict(
+              yaml.safe_load(f.read())
+            )
+          component = component_descriptor.component
+          tgt_ocm_repo = component.current_ocm_repo
+          tgt_oci_ref = tgt_ocm_repo.component_version_oci_ref(
+            name=component.name,
+            version=component.version,
+          )
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f'ocm-target-oci-ref={tgt_oci_ref}\n')
+
+      - name: authenticate-against-oci-registry
+        uses: gardener/cc-utils/.github/actions/oci-auth@master
+        with:
+          oci-image-reference: ${{ steps.read-oci-ref.outputs.ocm-target-oci-ref }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: upload-component-descriptor
+        run: |
+          python -m ocm upload \
+            --file /tmp/ocm/component-descriptor.yaml \
+            --blobs-dir /tmp/ocm/blobs.d

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -8,12 +8,6 @@ jobs:
     with:
       mode: snapshot
   component-descriptor:
-    runs-on: ubuntu-latest
     needs:
       - build-and-test
-    steps:
-      - uses: actions/checkout@v4
-      - name: collect-component-descriptor
-        uses: ./.github/actions/merge-ocm-fragments
-        with:
-          outdir: /tmp/ocm
+    uses: ./.github/workflows/component-descriptor.yaml


### PR DESCRIPTION
non-release pipelines should also have a means to create (e.g. for validation) and publish effective component-descriptor. Hence, add `component-descriptor.yaml` workflow, as counterpart to `release.yaml` for non-release pipelines.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
add `component-descriptor` workflow
```
