### PR TITLE
limit size of commit-objects output from capture-commit action

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -86,9 +86,16 @@ runs:
             ${commit_out}
 
         tar tf ${objects_out}
+        objects_size=$(stat --format=%s ${objects_out})
+        objects_max_size=65536 # 64 KiB
 
         echo "commit-digest=$(cat ${commit_out})" >> ${GITHUB_OUTPUT}
-        echo "commit-objects=$(cat ${objects_out} | base64 -w0)" >> ${GITHUB_OUTPUT}
+        if [ ${objects_size} -lt ${objects_max_size} ]; then
+          echo "commit-objects=$(cat ${objects_out} | base64 -w0)" >> ${GITHUB_OUTPUT}
+        else
+          echo "Warning: captured objects were too large (${objects_size} octets)"
+          echo "commit-objects output will not be set"
+        fi
 
         summary_kind="${{ inputs.commit-summary }}"
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,9 +11,6 @@ on:
           the "mode" to use. passed to `prepare` (currently for selecting  target-registries)
 
     outputs:
-      version-commit-objects:
-        description: commit-objects (for importing commit changing to effective version)
-        value: ${{ jobs.prepare.outputs.version-commit-objects }}
       version-commit-digest:
         description: commit-digest for version-commit
         value: ${{ jobs.prepare.outputs.version-commit-digest }}

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -63,11 +63,6 @@ on:
       version:
         description: the effective version
         value: ${{ jobs.version-and-ocm.outputs.version }}
-
-      version-commit-objects:
-        description: |
-          The created version-change-commit in serialised form as output by `capture-commit`.
-        value: ${{ jobs.version-and-ocm.outputs.commit-objects }}
       version-commit-digest:
         description: |
           The commit-digest of the version-change-commit.
@@ -100,7 +95,6 @@ jobs:
       - params
     outputs:
       version: ${{ steps.version.outputs.version }}
-      commit-objects: ${{ steps.version.outputs.commit-objects }}
       commit-digest: ${{ steps.version.outputs.commit-digest }}
       component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
     steps:
@@ -158,7 +152,6 @@ jobs:
 
           # version-and-ocm
           echo "${{ needs.version-and-ocm.outputs.version }}" > $p/version
-          echo "${{ needs.version-and-ocm.outputs.commit-objects }}" > $p/commit-objects
           echo "${{ needs.version-and-ocm.outputs.commit-digest }}" > $p/commit-digest
           cat <<EOF > $p/component-descriptor
           ${{ needs.version-and-ocm.outputs.component-descriptor }}


### PR DESCRIPTION
release-commit is captured as part of `prepare.yaml` action such as to already be able to include reference to it in base-component-descriptor w/o pushing it (and of course to use it for release-action).

The captured commit objects are already consumed via GitHub-Artefact, hence outputting it as base64-encoded string is not strictly necessary; keep it for now, but limit it to 64 KiB (otherwise emit a warning, but do not output it) to avoid errors due to limitation of total output-size.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
limit size of commit-objects output from capture-commit action
```
