### PR TITLE
Guard delivery-service-client against missing authentication feature

### DIFF
--- a/delivery/client.py
+++ b/delivery/client.py
@@ -239,7 +239,14 @@ class DeliveryServiceClient:
         headers: dict=None,
         **kwargs,
     ):
-        self._authenticate()
+        try:
+            self._authenticate()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code != 400:
+                raise
+            if e.response.json().get('error_id') != 'feature-inactive':
+                raise
+            logger.info('delivery-service authentication feature is inactive')
 
         headers = headers or {}
 


### PR DESCRIPTION
To ease local consumption, allow the delivery-service-client to connect to a local delivery-service instance which has no authentication feature configured.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
