### PR TITLE
Upgrade pullrequest action

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -18,6 +18,23 @@ inputs:
       auth-token used for pushing upgrade-pullrequest-commit and for creating PullRequests.
     type: string
     required: true
+  merge-policy:
+    description: |
+      Controls what should happen to newly created upgrade-pullrequests.
+    type: choice
+    default: manual
+    options:
+      - automerge
+      - manual
+  merge-method:
+    description: |
+      Sets the merge-method (only used if merge-policy is set to automerge)
+    type: choice
+    default: merge
+    options:
+      - rebase
+      - merge
+      - squash
 
 runs:
   using: composite
@@ -58,7 +75,7 @@ runs:
 
         import ocm_upgrade
 
-        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+        logging.basicConfig(stream=sys.stderr, level=logging.INFO)
         logger = logging.getLogger('ugrade-ocm')
 
         # silence annoying loggers
@@ -76,9 +93,18 @@ runs:
 
         logger.info(f'{ocm_repositories=}')
 
-        component_descriptor_lookup, version_lookup = ocm_upgrade.create_ocm_lookups(
+        oci_client, component_descriptor_lookup, version_lookup = ocm_upgrade.create_ocm_lookups(
           ocm_repositories=ocm_repositories,
         )
+
+        merge_method = '${{ inputs.merge-method }}'
+        merge_policy = '${{ inputs.merge-policy }}'
+        if merge_policy == 'automerge':
+          auto_merge = True
+        elif merge_policy == 'manual':
+          auto_merge = False
+        else:
+          raise ValueError(f'unspected {merge_policy=}')
 
         with open('/tmp/github-token') as f:
           github_token = f.read().strip()
@@ -86,6 +112,10 @@ runs:
         host, org, repo = github.host_org_and_repo()
         github_api = github.github_api(token=github_token)
         repository = github_api.repository(org, repo)
+
+        def github_api_lookup(repo_url):
+          # XXX needs to be extended for cross-github-support
+          return github_api
 
         repo_dir = os.getcwd()
 
@@ -100,29 +130,19 @@ runs:
 
         logger.info(f'found {len(upgrade_pullrequests)=}')
 
-        for cref in ocm.gardener.iter_component_references(
+        ocm_upgrade.create_upgrade_pullrequests(
           component=component,
-        ):
-          logger.info(f'processing {cref=}')
-
-          upgrade_vector = ocm.gardener.find_upgrade_vector(
-            component_id=cref.component_id,
-            version_lookup=version_lookup,
-            ignore_prerelease_versions=True,
-            ignore_invalid_semver_versions=True,
-          )
-
-          if not upgrade_vector:
-            logger.info(f'did not find an upgrade-proposal for {cref=}')
-            continue
-
-          logger.info(f'found {upgrade_vector=}')
-          ocm_upgrade.create_upgrade_pullrequest_diff(
-            upgrade_vector=upgrade_vector,
-            repo_dir=repo_dir,
-          )
-
-          # todo: create upgrade-pullrequest + reset repo
+          component_descriptor_lookup=component_descriptor_lookup,
+          version_lookup=version_lookup,
+          github_api_lookup=github_api_lookup,
+          repo_dir=repo_dir,
+          repo_url=f'https://{host}/{org}/{repo}',
+          repository=repository,
+          auto_merge=auto_merge,
+          merge_method=merge_method,
+          branch='${{ github.ref_name }}',
+          oci_client=oci_client,
+        )
 
         summary = f'''\
         ## Upgrade-Dependencies-Summary

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -170,6 +170,7 @@ runs:
 
         import yaml
 
+        import release_notes.ocm
         import oci.client
         import oci.auth
         import ocm
@@ -202,7 +203,7 @@ runs:
 
         component.resources.append(
           ocm.Resource(
-            name='release-notes',
+            name=release_notes.ocm.release_notes_resource_name,
             version=component.version,
             type='text/markdown.release-notes',
             access=ocm.LocalBlobAccess(

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -126,6 +126,7 @@ import concourse.util
 import ocm
 import ocm.upload
 import ocm.util
+import release_notes.ocm
 import github.release
 import github.util
 import gitutil
@@ -483,7 +484,7 @@ if release_notes_md:
 
   component.resources.append(
     ocm.Resource(
-      name='release-notes',
+      name=release_notes.ocm.release_notes_resource_name,
       version=component.version,
       type='text/markdown.release-notes',
       access=ocm.LocalBlobAccess(

--- a/release_notes/ocm.py
+++ b/release_notes/ocm.py
@@ -4,12 +4,15 @@ OCM-Component-Descriptors
 '''
 
 import collections.abc
+import logging
 import zlib
 
 import oci.client
 import ocm
 import ocm.gardener
 import version as version_mod
+
+logger = logging.getLogger(__name__)
 
 
 def release_notes(
@@ -85,6 +88,7 @@ def release_notes_range(
             name=version_vector.component_name,
             version=version,
         )
+        logger.info(f'retrieving release-notes for {component_id=}')
         notes = release_notes(
            component=component_id,
            oci_client=oci_client,
@@ -93,6 +97,8 @@ def release_notes_range(
         )
 
         if not notes: # previous call would already have failed, if absent_ok were falsy
+            logger.info(f'did not find release-notes for {component_id=}')
             continue
 
+        logger.info(f'found {len(notes)=} characters of release-notes for {component_id=}')
         yield component_id, notes

--- a/release_notes/ocm.py
+++ b/release_notes/ocm.py
@@ -1,0 +1,98 @@
+'''
+another opinionated / gardener-specific module for managing release-notes in
+OCM-Component-Descriptors
+'''
+
+import collections.abc
+import zlib
+
+import oci.client
+import ocm
+import ocm.gardener
+import version as version_mod
+
+
+def release_notes(
+    component: ocm.ComponentIdentity | ocm.Component,
+    oci_client: oci.client.Client,
+    component_descriptor_lookup: ocm.ComponentDescriptorLookup | None=None,
+    absent_ok: bool=True,
+) -> str | None:
+    '''
+    retrieves (raw, i.e. in markdown / text fmt) release-notes for the given component version.
+
+    The release-notes are expected to be stored as a local-blob, and referenced from a resource
+    named `release-notes`.
+
+    If a full ocm.Component is passed-in, component_descriptor_lookup can be omitted (it is
+    otherwise used to retrieve component-descriptor). Either way, the component-descriptor is
+    expected to be stored in an OCI-Registry (hence the need for passing-in an oci-client).
+    '''
+    if not isinstance(component, ocm.Component):
+        component = component_descriptor_lookup(component).component
+
+    for resource in component.resources:
+        if resource.name == 'release-notes':
+            break
+    else:
+        if absent_ok:
+            return None
+        raise ValueError(f'{component=} has no resource named `release-notes`')
+
+    access = resource.access
+    if not access.type is ocm.AccessType.LOCAL_BLOB:
+        raise ValueError(f'do not know how to handle {access.type=} ({component=})')
+    access: ocm.LocalBlobAccess
+
+    oci_ref = component.current_ocm_repo.component_version_oci_ref(
+        name=component.name,
+        version=component.version,
+    )
+
+    release_notes_blob = oci_client.blob(
+        image_reference=oci_ref,
+        digest=access.localReference,
+    )
+
+    if access.mediaType.endswith('/gzip'):
+        release_notes_bytes = zlib.decompress(release_notes_blob.content, wbits=31)
+    else:
+        release_notes_bytes = release_notes_blob.content
+
+    return release_notes_bytes.decode('utf-8')
+
+
+def release_notes_range(
+    version_vector: ocm.gardener.UpgradeVector,
+    versions: collections.abc.Iterable[version_mod.Version],
+    oci_client: oci.client.Client,
+    component_descriptor_lookup: ocm.ComponentDescriptorLookup | None=None,
+    absent_ok: bool=True,
+) -> collections.abc.Iterable[tuple[ocm.ComponentIdentity, str]]:
+    '''
+    yields pairs of component-id and release-notes in specified range,
+    excluding release-notes for `whence`-version,
+    including release-notes for `whither`-version.
+    '''
+    versions_in_range = version_mod.iter_upgrade_path(
+        whence=version_vector.whence.version,
+        whither=version_vector.whither.version,
+        versions=versions,
+    )
+
+    for version in versions_in_range:
+        component_id = ocm.ComponentIdentity(
+            name=version_vector.component_name,
+            version=version,
+        )
+        notes = release_notes(
+           component=component_id,
+           oci_client=oci_client,
+           component_descriptor_lookup=component_descriptor_lookup,
+           absent_ok=absent_ok,
+        )
+
+        if not notes: # previous call would already have failed, if absent_ok were falsy
+            continue
+
+        yield component_id, notes

--- a/release_notes/ocm.py
+++ b/release_notes/ocm.py
@@ -15,6 +15,9 @@ import version as version_mod
 logger = logging.getLogger(__name__)
 
 
+release_notes_resource_name = 'release-notes'
+
+
 def release_notes(
     component: ocm.ComponentIdentity | ocm.Component,
     oci_client: oci.client.Client,
@@ -35,7 +38,7 @@ def release_notes(
         component = component_descriptor_lookup(component).component
 
     for resource in component.resources:
-        if resource.name == 'release-notes':
+        if resource.name == release_notes_resource_name:
             break
     else:
         if absent_ok:

--- a/test/github/pullrequest_test.py
+++ b/test/github/pullrequest_test.py
@@ -1,0 +1,17 @@
+import github.pullrequest as gpr
+
+
+def test_split_chunks_if_too_long():
+    assert gpr.split_into_chunks_if_too_long(
+        string='abcd',
+        split_hint='does-not-matter',
+        max_leng=100,
+        max_chunk_leng=100,
+    ) == ('abcd', ())
+
+    assert gpr.split_into_chunks_if_too_long(
+        string='12345678',
+        split_hint='X',
+        max_leng=2,
+        max_chunk_leng=3,
+    ) == ('1X', ('234', '567', '8'))

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -199,3 +199,49 @@ def test_smallest_versions():
 
     # keep greatest (returned versions are intended to be removed)
     assert set(version.smallest_versions({'1.2.3', '2.3.4', '3.0'}, keep=1)) == {'1.2.3', '2.3.4'}
+
+
+def test_iter_upgrade_path():
+    versions = (
+        '0.1.0',
+        'v1.0.0', # original values should be retained
+        '1.0.1',
+        '1.1.0',
+        '1.1.1',
+        '1.1.2',
+        '1.2.0',
+        '1.2.1',
+        '1.3.2',
+        '1.4.0',
+        '1.4.1',
+        '1.4.2',
+        'v2.0.0',
+        '2.2.2',
+        '3.0.1',
+        '3.0.2',
+        '4.0.0',
+    )
+
+    # different major version (minor / patch-versions should be ignored)
+    path = tuple(v for v in version.iter_upgrade_path(
+        whence='1.0.0',
+        whither='3.0.2',
+        versions=versions,
+    ))
+    assert path == ('v2.0.0', '3.0.1', '3.0.2')
+
+    # different minor-version (patch-versions should be ignored)
+    path = tuple(v for v in version.iter_upgrade_path(
+        whence='1.1.0',
+        whither='1.4.2',
+        versions=versions,
+    ))
+    assert path == ('1.2.0', '1.3.2', '1.4.0', '1.4.1', '1.4.2')
+
+    # equal major and minor version (only patch-versions should be yielded)
+    path = tuple(v for v in version.iter_upgrade_path(
+        whence='1.4.0',
+        whither='1.4.2',
+        versions=versions,
+    ))
+    assert path == ('1.4.1', '1.4.2')

--- a/version.py
+++ b/version.py
@@ -472,10 +472,6 @@ def greatest_version_with_matching_minor(
     return latest_candidate
 
 
-# alias for backwards-compatibility
-find_latest_version_with_matching_minor = greatest_version_with_matching_minor
-
-
 def find_smallest_version_with_matching_minor(
     reference_version: Union[semver.VersionInfo, str],
     versions: Iterable[Union[semver.VersionInfo, str]],


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
- enable github-action `ocm-upgrade` to create upgrade-pullrequests for referened ocm-components
- refactor pullrequest-body-splitting
- re-implement retrieval of release-notes-ranges (use OCM rather than git/github)
```
