### PR TITLE
fix: Ensure `bom_diff_markdown` is always initialised

### DIFF
--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -416,6 +416,7 @@ def create_upgrade_pr(
 
     to_component = to_component_descriptor.component
 
+    bom_diff_markdown = None
     if include_bom_diff:
         bom_diff_markdown = github.pullrequest.bom_diff(
             delivery_dashboard_url=delivery_dashboard_url,


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
