### PR TITLE
upload component-descriptor as release-asset (again)

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -322,7 +322,7 @@ runs:
           repository=repository,
           name=draft_tag_name,
         )):
-          repository.create_release(
+          gh_release = repository.create_release(
             tag_name=release_tag_name,
             body=release_notes_markdown or 'no release-notes available',
             draft=False,
@@ -336,6 +336,14 @@ runs:
             draft=False,
             prerelease=False,
           )
+
+        # application/yaml is (since 2024) a registered mimetype
+        # https://www.iana.org/assignments/media-types/media-types.xhtml
+        gh_release.upload_asset(
+          content_type='application/yaml',
+          name='component-descriptor.yaml',
+          asset=open('/tmp/component-descriptor.yaml'),
+        )
 
     - name: prepare-push-bump-commit
       shell: bash


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`release`-action now uploads `component-descriptor` as (github-)release-asset (again)
```
