### PR TITLE
allow (re-)setting of extra-tags for OCI-OCM-Workflow

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -37,6 +37,12 @@ on:
         type: string
         default: '{version}'
         required: false
+      extra-tags:
+        type: string
+        required: false
+        description: |
+          A comma-separated list of additional tags to set. Existing tags will be updated.
+          Commonly used to reset `latest`-tag.
       push:
         description: |
           Whether or not to push the built image. Allowed values:
@@ -336,6 +342,7 @@ jobs:
               src_image_refs=src_image_refs,
               tgt_image_ref=tgt_image_ref,
               oci_client=oci_client,
+              extra_tags='${{ inputs.extra-tags }}'.strip().split(','),
             )
 
             print(f'published to {tgt_image_ref=}')


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
oci-ocm reusable workflow allows to (re-)set extra-tags
```
