### PR TITLE
Allow configuration of GitHub release and tag in release workflow

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -96,6 +96,12 @@ inputs:
       an auth-token to use for pushing release- and bump-commits. Must grant the privilege to
       bypass branch-protection-rules, if present.
     required: false
+  release-on-github:
+    default: true
+    type: boolean
+    description: |
+      If set to `true`, the action will create a new GitHub release (or convert an existing draft
+      release to an actual release).
 
 defaults:
   run:
@@ -288,6 +294,7 @@ runs:
         fi
 
     - name: create github-release
+      if: ${{ inputs.release-on-github }}
       shell: python
       run: |
         import os

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -102,6 +102,12 @@ inputs:
     description: |
       If set to `true`, the action will create a new GitHub release (or convert an existing draft
       release to an actual release).
+  github-tag-template:
+    default: '${version}'
+    type: string
+    description: |
+      GitHub tag template to use for the created release tag. Currently only supported template-var:
+      ${version} (bash-syntax).
 
 defaults:
   run:
@@ -131,7 +137,7 @@ runs:
         echo "${{ inputs.component-descriptor }}" > /tmp/component-descriptor.yaml
         version=$(yq .component.version /tmp/component-descriptor.yaml)
         echo "version=${version}" >> $GITHUB_OUTPUT
-        tag_name="${version}"
+        tag_name="${{ inputs.github-tag-template }}"
         tag_ref="refs/tags/${tag_name}"
         echo "tag-ref=${tag_ref}" >> $GITHUB_OUTPUT
         echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,12 @@ on:
         description: |
           If set to `true`, the workflow will create a new GitHub release (or convert an existing
           draft release to an actual release).
+      github-tag-template:
+        default: '${version}'
+        type: string
+        description: |
+          GitHub tag template to use for the created release tag. Currently only supported
+          template-var: ${version} (bash-syntax).
 
     outputs:
       release-notes:
@@ -147,6 +153,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-push-token: ${{ steps.app-token.outputs.token }}
           release-on-github: ${{ inputs.release-on-github }}
+          github-tag-template: ${{ inputs.github-tag-template }}
 
       - name: write-release-notes-to-file
         if: ${{ inputs.slack-channel-id != '' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,12 @@ on:
           The auth-token to use to authenticate against slack. Only needed if `slack-channel-id` is
           passed. For convenience, defaults to `secrets.SLACK_APP_TOKEN_GARDENER_CICD` (calling
           workflows must set `secrets: inherit` for this to work.
+      release-on-github:
+        default: true
+        type: boolean
+        description: |
+          If set to `true`, the workflow will create a new GitHub release (or convert an existing
+          draft release to an actual release).
 
     outputs:
       release-notes:
@@ -140,6 +146,7 @@ jobs:
           release-notes: ${{ steps.release-notes.outputs.release-notes }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-push-token: ${{ steps.app-token.outputs.token }}
+          release-on-github: ${{ inputs.release-on-github }}
 
       - name: write-release-notes-to-file
         if: ${{ inputs.slack-channel-id != '' }}


### PR DESCRIPTION
Useful if multiple OCM components should be released from the same GitHub repository.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
