### PR TITLE
Consistently use Git config from `setup-git-identity` GitHub Action

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -197,13 +197,7 @@ def create_upgrade_pullrequest(
     logger.info(f'found {upgrade_vector=}')
     git_helper = gitutil.GitHelper(
         repo=repo_dir,
-        git_cfg=gitutil.GitCfg(
-            repo_url=repo_url,
-            user_name='Gardener-CICD-GitHubAction-Bot',
-            user_email='no-reply@github.com',
-            auth=None,
-            auth_type=gitutil.AuthType.PRESET,
-        ),
+        git_cfg=gitutil.GitCfg(repo_url=repo_url),
     )
     from_component_descriptor = component_descriptor_lookup(
         upgrade_vector.whence,

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -46,6 +46,7 @@ runs:
         if which git &>/dev/null; then exit 0; fi
         apt-get install -y git
       shell: sh
+    - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
     - name: checkout
       uses: actions/checkout@v4
       with:

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -124,13 +124,7 @@ def main():
 
     git_helper = gitutil.GitHelper(
         repo=parsed.repo_worktree,
-        git_cfg=gitutil.GitCfg(
-            repo_url=f'https://{host}/{org}/{repo}',
-            user_name='Gardener-CICD-GitHubAction-Bot',
-            user_email='no-reply@github.com',
-            auth=None,
-            auth_type=gitutil.AuthType.PRESET,
-        ),
+        git_cfg=gitutil.GitCfg(repo_url=f'https://{host}/{org}/{repo}'),
     )
 
     # pass current head as ref-commit. This avoids release-tag to exist in remote while


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
