### PR TITLE
Fix max_level logic for linting

### DIFF
--- a/ci/util.py
+++ b/ci/util.py
@@ -70,7 +70,7 @@ class LintingResult:
 
     def max_level(self):
         if self.problems:
-            max(self.problems_dict.keys())
+            return max(self.problems_dict.keys())
         return 0
 
     def __str__(self):


### PR DESCRIPTION
Regardless of whether `self.problems` is truthy or not, the function always returns 0 because the result of `max(self.problems_dict.keys())` is not stored or returned.

This had to be corrected. The function does not return the maximum key from `self.problems_dict` even if `self.problems` is truthy. It should return the result of `max(self.problems_dict.keys())` when `self.problems` is truthy. 

Validated that this fix does break linting, when errors are found. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix linting behavior with regards to how max_level of errors / warnings is being implemented.
```
