### PR TITLE
allow specification of additional release-assets

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -102,6 +102,40 @@ inputs:
     description: |
       If set to `true`, the action will create a new GitHub release (or convert an existing draft
       release to an actual release).
+  assets:
+    type: string
+    required: false
+    description: |
+      An optional list of release-assets in YAML-format that will be added to the GitHub-Release.
+      If creation of github-release is suppressed (via `release-on-github` input), this value
+      will be ignored.
+
+      Each element is expected to have the following form:
+
+      ```
+      name: <name, as it should be set for the release-asset>, required
+      mime-type: # optional (will be determined using libmagic, if absent)
+      type: ocm-resource # mandatory; only `ocm-resource` is supported; for future extensions
+      id:
+        name: <ocm-resource-name>, required
+        type: <ocm-resource-type>, optional
+        <extra-id-attr>: <value> # optional - any attributes from extraIdentity
+      ```
+
+      `id` must be specified such that a resource is identified unambiguously. Only resources
+      that are stored as a localBlob (access-type) are supported.
+
+      Example (assuming pipeline builds `helm` for multiple platforms):
+      ```
+      assets: |
+       - name: helm-linux-x86-64
+         mime-type: application/x-pie-executable
+         type: ocm-resource
+         id:
+          name: helm
+          os: linux
+          arch: x86_64
+      ```
   github-tag-template:
     default: '${version}'
     type: string
@@ -142,6 +176,9 @@ runs:
         tag_ref="refs/tags/${tag_name}"
         echo "tag-ref=${tag_ref}" >> $GITHUB_OUTPUT
         echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT
+        cat <<EOF > /tmp/assets.yaml
+        ${{ inputs.assets }}
+        EOF
 
     - name: read-target-oci-ref
       id: read-oci-ref
@@ -305,10 +342,16 @@ runs:
       shell: python
       run: |
         import os
+        import sys
+        sys.path.insert(1, os.environ['GITHUB_ACTION_PATH'])
 
         import github3
+        import yaml
 
         import github.release
+        import ocm
+
+        import release
 
         host = os.environ['GITHUB_SERVER_URL'].removeprefix('https://')
         org, repo = os.environ['GITHUB_REPOSITORY'].split('/')
@@ -358,6 +401,32 @@ runs:
           name='component-descriptor.yaml',
           asset=open('/tmp/component-descriptor.yaml'),
         )
+
+        with open('/tmp/component-descriptor.yaml') as f:
+          component_descriptor = ocm.ComponentDescriptor.from_dict(
+            yaml.safe_load(f)
+          )
+
+        for asset in release.iter_assets(path='/tmp/assets.yaml'):
+          path, access = release.find_blob(
+            blobs_dir='${{ inputs.component-descriptor-blobs-dir }}',
+            asset=asset,
+            component=component_descriptor.component,
+          )
+
+          if asset.mime_type:
+            mime_type = asset.mime_type
+          else:
+            mime_type = access.mediaType
+
+          print(f'Uploading {asset=} as github-release-asset')
+          fh = open(path)
+          gh_release.upload_asset(
+            content_type=mime_type,
+            name=asset.name,
+            asset=fh,
+          )
+          fh.close() # as execution will end on errors, it should be okay to not guard against that
 
     - name: prepare-push-bump-commit
       shell: bash

--- a/.github/actions/release/release.py
+++ b/.github/actions/release/release.py
@@ -1,0 +1,114 @@
+import collections.abc
+import dataclasses
+import enum
+import os
+
+import dacite
+import yaml
+
+import ocm
+
+
+@dataclasses.dataclass(kw_only=True)
+class Asset:
+    '''
+    Model-Class for deserialising entries from `inputs.asset` input.
+    '''
+    name: str
+    mime_type: str | None = None
+    type: str
+    id: dict[str, str]
+
+    def matches(self, resource: ocm.Resource):
+        # special-handling for version, name, and type (as those are defined on toplevel)
+        for k,v in self.id.items():
+            if k in ('name', 'version', 'type'):
+                resource_value = getattr(resource, k)
+            else:
+                resource_value = resource.extraIdentity.get(k)
+
+            if isinstance(resource_value, enum.Enum):
+                resource_value = resource_value.value
+
+            if not resource_value == v:
+                return False
+
+        return True
+
+    def __post_init__(self):
+        # basic validation: id.name must be present and non-empty
+        if not self.id.get('name'):
+            print('Error: asset.id.name must not be empty:')
+            print(self)
+            exit(1)
+
+
+def iter_assets(
+    path: str,
+) -> collections.abc.Iterable[Asset]:
+    with open(path) as f:
+        assets = yaml.safe_load(f)
+
+    if not assets:
+        return
+
+    if isinstance(assets, dict):
+        # it is okay-ish if user only gave us a single element
+        assets = [assets]
+
+    for asset in assets:
+        # kebap -> camel
+        asset['mime_type'] = asset.pop('mime-type', None)
+
+        yield dacite.from_dict(
+            data_class=Asset,
+            data=asset,
+        )
+
+
+def find_blob(
+    blobs_dir: str,
+    asset: Asset,
+    component: ocm.Component,
+) -> tuple[str, ocm.LocalBlobAccess]:
+    '''
+    lookup OCM-resource selected by given `asset`. The resource is assume to have an access of
+    type localBlob, with the blob being expected to reside below `blobs_dir`, as is the case
+    after running `merge-ocm-fragments` action.
+
+    returns both the found path, and access as a two-tuple (the latter contains mime-type, which
+    makes it useful for uploading as a github-release-asset).
+    '''
+    matching_resources = (res for res in component.resources if asset.matches(res))
+
+    try:
+        resource = next(matching_resources)
+    except StopIteration:
+        print(f'Error: did not find matching ocm-resource for {asset=}')
+        exit(1)
+
+    try:
+        next(matching_resources)
+        print(f'Error: {asset=} is ambiguous (more than one matching OCM-Resource)')
+        exit(1)
+    except StopIteration:
+        pass # okay, we _want_ to have only one match
+
+    # for now, we only allow localBlobs
+    access = resource.access
+    if not access.type is ocm.AccessType.LOCAL_BLOB:
+        print(f'Error: {resource=} has unsupported access-type (only localBlob is allowed)')
+        exit(1)
+
+    # format: sha256:<digest> - as output by `merge-ocm-fragments` action
+    alg_and_hexdigest = access.localReference
+    path = os.path.join(
+        blobs_dir,
+        alg_and_hexdigest,
+    )
+
+    if not os.path.isfile(path):
+        print(f'Error: {path=} does not exist (but was referenced by {resource=} / {asset=}')
+        exit(1)
+
+    return path, access

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,40 @@ on:
         description: |
           GitHub tag template to use for the created release tag. Currently only supported
           template-var: ${version} (bash-syntax).
+      assets:
+        type: string
+        required: false
+        description: |
+          An optional list of release-assets in YAML-format that will be added to the GitHub-Release.
+          If creation of github-release is suppressed (via `release-on-github` input), this value
+          will be ignored.
+
+          Each element is expected to have the following form:
+
+          ```
+          name: <name, as it should be set for the release-asset>, required
+          mime-type: # optional (will be determined using libmagic, if absent)
+          type: ocm-resource # mandatory; only `ocm-resource` is supported; for future extensions
+          id:
+            name: <ocm-resource-name>, required
+            type: <ocm-resource-type>, optional
+            <extra-id-attr>: <value> # optional - any attributes from extraIdentity
+          ```
+
+          `id` must be specified such that a resource is identified unambiguously. Only resources
+          that are stored as a localBlob (access-type) are supported.
+
+          Example (assuming pipeline builds `helm` for multiple platforms):
+          ```
+          assets: |
+           - name: helm-linux-x86-64
+             mime-type: application/x-pie-executable
+             type: ocm-resource
+             id:
+              name: helm
+              os: linux
+              arch: x86_64
+          ```
 
     outputs:
       release-notes:
@@ -154,6 +188,7 @@ jobs:
           git-push-token: ${{ steps.app-token.outputs.token }}
           release-on-github: ${{ inputs.release-on-github }}
           github-tag-template: ${{ inputs.github-tag-template }}
+          assets: ${{ inputs.assets }}
 
       - name: write-release-notes-to-file
         if: ${{ inputs.slack-channel-id != '' }}


### PR DESCRIPTION
Add input `assets` to both `release`-action and `release.yaml` workflow. Said input allows users to specify a list of assets that should be added to github-release.

Those assets specify the target-name and (optionally) mime-type, and an OCM-Resource-Reference (which defines the content to be uploaded).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
allow specification of additional release-assets
```
