### PR TITLE
Guard against `TypeError` in GitHub releases iterator

### DIFF
--- a/github/release.py
+++ b/github/release.py
@@ -54,11 +54,17 @@ def find_draft_release(
     # are uncommon), this should be okay to hardcode. Todo: check whether this limit is still
     # valid.
     max_releases = 1020
-    for release in repository.releases(number=max_releases):
-        if not release.draft:
-            continue
-        if release.name == name:
-            return release
+    try:
+        for release in repository.releases(number=max_releases):
+            if not release.draft:
+                continue
+            if release.name == name:
+                return release
+    except TypeError:
+        # `github3.py` raises if one of the release authors is unknown (i.e. a deleted account)
+        import traceback
+        traceback.print_exc()
+        logger.info('ignoring error and continuing with already found releases')
 
 
 def delete_outdated_draft_releases(


### PR DESCRIPTION
`github3.py` raises in case the release author is unknown (i.e. because the user account has been deleted). In that case, ignore the error and continue processing with the releases which were already retrieved.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
