### PR TITLE
make writing of release-notes more robust

### DIFF
--- a/.github/actions/draft-release/action.yaml
+++ b/.github/actions/draft-release/action.yaml
@@ -26,8 +26,14 @@ runs:
       shell: sh
       run: |
         set -eu
-        if [ -n '${{ inputs.release-notes }}' ]; then
-          echo '${{ inputs.release-notes }}' > release-notes.md
+
+        if ${{ inputs.release-notes != '' }}; then
+
+        # do not indent to avoid prepending whitespace
+        cat <<'EOF' > release-notes.md
+        ${{ inputs.release-notes }}
+        EOF
+
         fi
         # if not passed via input, expect file `release-notes.md`
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
