### PR TITLE
Fix: Include BoM-Diff in UPR if there is space left (not vice-versa)

### DIFF
--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -297,10 +297,7 @@ def upgrade_pullrequest_body(
         total_length = len(bom_diff_markdown)
         if release_notes:
             total_length += len(release_notes)
-        if total_length > github.limits.pullrequest_body:
-            include_bom_diff = True
-        else:
-            include_bom_diff = False
+        include_bom_diff = total_length <= github.limits.pullrequest_body
     else:
         include_bom_diff = False
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The BoM-Diff is now added to the upgrade-PR body again if there is space left (not vice-versa...)
```
