### PR TITLE
Add `RegionsTarget` to CTT model

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -665,7 +665,10 @@ def process_images(
     # only replicated to the respectively configured targets
     tgt_oci_registries = set()
     for target_cfg in processing_cfg['targets'].values():
-        tgt_oci_registries.update(target_cfg['kwargs']['registries'])
+        if 'registry' in target_cfg['kwargs']:
+            tgt_oci_registries.add(target_cfg['kwargs']['registry'])
+        elif 'registries' in target_cfg['kwargs']:
+            tgt_oci_registries.update(target_cfg['kwargs']['registries'])
 
     replication_plan = ctt.model.ReplicationPlan()
 

--- a/ctt/targets.py
+++ b/ctt/targets.py
@@ -27,3 +27,21 @@ class RegistriesTarget(TargetBase):
         tgt_oci_registry: str,
     ) -> bool:
         return tgt_oci_registry in self._registries
+
+
+class RegionsTarget(TargetBase):
+    def __init__(
+        self,
+        registry: str,
+        provider: str,
+        regions: list[str],
+    ):
+        self.registry = registry
+        self.provider = provider
+        self.regions = regions
+
+    def filter(
+        self,
+        tgt_oci_registry: str,
+    ) -> bool:
+        return tgt_oci_registry == self.registry


### PR DESCRIPTION
Used to provide a mapping between a target registry (e.g. `europe-docker.pkg.dev`), the respective provider (e.g. `gcp`), and the regions where this registry should be used (e.g. `eu-central1`).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Added the CTT target `RegionsTarget` to specify mappings between OCI registries, providers and regions
```
