### PR TITLE
export testresults as inlined ocm-resource

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -254,8 +254,26 @@ jobs:
         mkdir /tmp/fake-cfg.d
         touch /tmp/fake-cfg.d/config_types.yaml
         export CC_CONFIG_DIR=/tmp/fake-cfg.d
-        .ci/test
 
+        mkdir /tmp/blobs.d
+
+        .ci/test |& tee /tmp/blobs.d/test-log.txt
+
+        tar czf /tmp/blobs.d/test-log.tar.gz -C/tmp/blobs.d test-log.txt
+    - name: add-unittests-results-to-component-descriptor
+      uses: ./.github/actions/export-ocm-fragments
+      with:
+        blobs-directory: /tmp/blobs.d
+        ocm-resources: |
+          - name: test-results
+            relation: local
+            access:
+              type: localBlob
+              localReference: test-log.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - test
   images:
     name: Build Job-Image
     needs:


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
export testresults as inlined ocm-resource
```
