### PR TITLE
split oci-image-building and -pushing into two steps

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -330,12 +330,12 @@ jobs:
           extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
 
       - name: 'push ${{ inputs.name }} / ${{ matrix.args.platform-name }}'
-        uses: docker/build-push-action@v6
         if: ${{ needs.preprocess.outputs.push == 'true' }}
+        shell: bash
         id: push
-        with:
-          push: ${{ needs.preprocess.outputs.push }}
-          tags: ${{ matrix.args.image-reference }}
+        run: |
+          set -eu
+          docker push ${{ matrix.args.image-reference }}
 
   collect-images:
     needs:

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -314,13 +314,28 @@ jobs:
         uses: docker/build-push-action@v6
         id: build
         with:
-          push: ${{ needs.preprocess.outputs.push }}
+          outputs: type=docker
           tags: ${{ matrix.args.image-reference }}
           context: '.'
           platforms: ${{ matrix.args.platform-name }}
           target: ${{ inputs.target }}
           file: ${{ inputs.dockerfile }}
           build-args: ${{ inputs.build-args }}
+
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
+        if: ${{ needs.preprocess.outputs.push == 'true' }}
+        with:
+          oci-image-reference: ${{ matrix.args.image-reference }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
+
+      - name: 'push ${{ inputs.name }} / ${{ matrix.args.platform-name }}'
+        uses: docker/build-push-action@v6
+        if: ${{ needs.preprocess.outputs.push == 'true' }}
+        id: push
+        with:
+          push: ${{ needs.preprocess.outputs.push }}
+          tags: ${{ matrix.args.image-reference }}
 
   collect-images:
     needs:


### PR DESCRIPTION
For long-running builds, it may happen that auth-token retrieved via OIDC expires during build, leading to failing attempts for uploading built images.

Hence, split building and pushing into two steps, and perform another oidc-authentication after build, before attempting to push. Keep initial authorisation such that read-access (for base-images) during build is possible, if authentication is required.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
split oci-image-building and -pushing into two steps
```
