### PR TITLE
fail if localBlob's file is not present

### DIFF
--- a/.github/actions/export-ocm-fragments/action.yaml
+++ b/.github/actions/export-ocm-fragments/action.yaml
@@ -226,7 +226,8 @@ runs:
           if local_ref.startswith('sha256:'):
             continue
           if not (local_fpath := find_local_blobfile(local_ref)):
-            continue
+            print(f'ERROR: did not find blobfile for {artefact=}')
+            exit(1)
           # local file exists, and it does not meet content-addresssing scheme (
           # <alg>:<hexdigest>). We should find it from previous step where we calculated
           # digests, and created symlinks.


### PR DESCRIPTION
If export-ocm-fragment action is used to export a resource using local-blob from a file, signal it as an error if referenced file does not exist (as this typically indicates a user error).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
fail if localBlob's file is not present
```
