### PR TITLE
let trusted-checkout honour "ok-to-test"-label

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -25,6 +25,19 @@ inputs:
       passed to `actions/checkout`'s as `fetch-depth` input.
 
       useful for cases where longer history is required.
+  trusted-label:
+    type: string
+    default: 'reviewed/ok-to-test'
+    description: |
+      a label, that can be used to mark pullrequests as trusted, regarless of author's association.
+
+      For security-reasons, this action will remove the label, such that it will have to be
+      added again (adding the label will work as trigger).
+  needs-trusted-label:
+    type: string
+    default: 'needs/ok-to-test'
+    description: |
+      a label that is added as a marker in order to notify lack of "trusted-label"
 
 runs:
   using: composite
@@ -48,6 +61,16 @@ runs:
         )
         author_association = '${{ github.event.pull_request.author_association }}'
         allowed_to_checkout = author_association in allowed_author_associations
+
+        # if pullrequest is labelled, it is also considered trusted, regardless of
+        # author's association (rationale: only codeowners can add labels)
+        trusted_label = '${{ inputs.trusted-label }}'
+
+        if '${{ github.event.action }}' == 'labeled':
+          if '${{ github.event.label.name }}' == trusted_label:
+            allowed_to_checkout = True
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'remove-label={trusted_label}\n')
 
         if not allowed_to_checkout:
           summary = textwrap.dedent(f'''\
@@ -75,3 +98,26 @@ runs:
           ),
           check=True,
         )
+    - if: ${{ steps.calc.outputs.remove-label }}
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+    - name: remove-trusted-and-add-needs-label
+      if: ${{ steps.calc.outputs.remove-label }}
+      shell: python
+      run: |
+        import github3.exceptions
+        import github
+        gh_api = github.github_api(token='${{ github.token }}')
+        _, org, repo = github.host_org_and_repo()
+        gh_repo = gh_api.repository(org, repo)
+
+        # we need issue-api to rm label (id is equal for pr and issue)
+        pull_request = gh_repo.issue(${{ github.event.number }})
+
+        try:
+          pull_request.remove_label('${{ steps.calc.outputs.remove-label }}')
+        except github3.exceptions.NotFoundError:
+          # trusted-checkout typically runs multiple times, so the label already being absent
+          # is an expected, and of course, acceptable case
+          exit(0)
+
+        pull_request.add_labels('${{ inputs.needs-trusted-label }}')


### PR DESCRIPTION
For security-reasons, pullrequests from untrusted sources (such as forked repositories) are either run with limited permissions (if using `on.pull_request` as event-source), or will by default not checkout changes from pullrequest.

Trusted-Checkout-Action was introduced to allow acceptably secure privileged runs for pullreqeust from trusted authors.

However, this does not work well in cases of e.g. new contributors. Hence, implement (again, as in place for concourse) a label `reviewed/ok-to-test`, which, if set, will have the same effect (trust the pullrequest).

For this option to work reasonably well, event-trigger should be changed like so:

```
on:
  pull_request_target:
    types:
      - labeled
```

This will restrict triggering to labelling-events. In order to avoid runs being triggered from labels different than `reviewed/ok-to-test`, jobs need to be fitted w/ a filtering-condition, in addition (this cannot be handled on event-trigger-level, unfortunately).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
let trusted-checkout honour "ok-to-test"-label
```
