### PR TITLE
additionally upload component-descriptor as artifact

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -294,6 +294,14 @@ runs:
           --blobs-dir '${{ inputs.component-descriptor-blobs-dir }}' \
           --on-exist ${{ inputs.on-existing-component-descriptor }}
 
+        tar czf /tmp/component-descriptor.tar.gz -C/tmp component-descriptor.yaml
+
+    - name: upload OCM Component-Descriptor as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: /tmp/component-descriptor.tar.gz
+        name: component-descriptor
+
     - name: push release-tag
       shell: bash
       run: |

--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -85,13 +85,19 @@ jobs:
         with:
           oci-image-reference: ${{ steps.read-oci-ref.outputs.ocm-target-oci-ref }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: upload-component-descriptor
+      - name: upload-component-descriptor-to-ocm-repository
         if: ${{ steps.prep.outputs.can-push == 'true' }}
         run: |
           python -m ocm upload \
             --file /tmp/ocm/component-descriptor.yaml \
             --blobs-dir /tmp/ocm/blobs.d \
             --on-exist ${{ inputs.on-existing-component-descriptor }}
+          tar czf component-descriptor.tar.gz -C /tmp/ocm component-descriptor.yaml
+      - name: upload-component-descriptor-as-artefact
+        uses: actions/upload-artifact@v4
+        with:
+          path: component-descriptor.tar.gz
+          name: component-descriptor
 
   repo-metadata:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes, publishing of component-descriptor to OCM-repository might fail. Upload component-descriptor as artifact to allow for easier investigation / manual intervention.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
additionally upload component-descriptor as gha-artifact
```
