### PR TITLE
fix trusted-checkout

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -29,7 +29,7 @@ inputs:
     type: string
     default: 'reviewed/ok-to-test'
     description: |
-      a label, that can be used to mark pullrequests as trusted, regarless of author's association.
+      a label, that can be used to mark pullrequests as trusted, regardless of author's association.
 
       For security-reasons, this action will remove the label, such that it will have to be
       added again (adding the label will work as trigger).


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
fix: trusted-checkout must honour path to git-repository, if passed, also for running git-fetch/checkout commands
```
