### PR TITLE
Fix detection of outdated upgrade-PRs (once again)

### DIFF
--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -62,8 +62,8 @@ class UpgradePullRequest:
         greatest_reference_version = version.parse_to_semver(reference_refs[-1].version)
         whence_version = self.upgrade_vector.whence_version
 
-        # PR is obsolete if same or greater component version is already configured in reference
-        return greatest_reference_version >= whence_version
+        # PR is obsolete if greater component version is already configured in reference
+        return greatest_reference_version > whence_version
 
     def purge(self):
         self.pull_request.close()


### PR DESCRIPTION
We don't want to consider an upgrade-PR as obsolete if the `whence_version` of the PR is equal to the current reference version of the component.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix detection of "obsolete" upgrade pull requests
```
