### PR TITLE
expose published component-descriptor as output

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -157,6 +157,12 @@ inputs:
       - skip
       - overwrite
       - fail
+outputs:
+  component-descriptor:
+    description: |
+      the Component-Descriptor as it was published (which may contain modifications compared
+      to the component-descriptor that was passed-in as input).
+    value: ${{ steps.publish-component-descriptor.outputs.component-descriptor }}
 
 defaults:
   run:
@@ -290,6 +296,7 @@ runs:
 
     - name: publish OCM Component-Descriptor
       shell: bash
+      id: publish-component-descriptor
       run: |
         python -m ocm upload \
           --file /tmp/component-descriptor.yaml \
@@ -297,6 +304,10 @@ runs:
           --on-exist ${{ inputs.on-existing-component-descriptor }}
 
         tar czf /tmp/component-descriptor.tar.gz -C/tmp component-descriptor.yaml
+
+        echo "component-descriptor<<EOF" >> "${GITHUB_OUTPUT}"
+        cat /tmp/component-descriptor.yaml >> "${GITHUB_OUTPUT}"
+        echo EOF >> "${GITHUB_OUTPUT}"
 
     - name: upload OCM Component-Descriptor as artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,6 +143,10 @@ on:
           published as part of component-descriptor, as well as via slack, if `slack-channel-id`
           input is specified).
         value: ${{ jobs.release-and-bump.outputs.release-notes }}
+      component-descriptor:
+        description: |
+          The component-descriptor document, as it was uploaded during release
+        value: ${{ jobs.release-and-bump.outputs.component-descriptor }}
 jobs:
   release-and-bump:
     runs-on: ubuntu-latest
@@ -153,6 +157,7 @@ jobs:
 
     outputs:
       release-notes: ${{ steps.release-notes.outputs.release-notes }}
+      component-descriptor: ${{ steps.release.outputs.component-descriptor }}
 
     steps:
       - name: collect-component-descriptor
@@ -174,6 +179,7 @@ jobs:
           app-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
           private-key: ${{ secrets.github-app-secret-key || secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
       - uses: gardener/cc-utils/.github/actions/release@master
+        id: release
         with:
           component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
           component-descriptor-blobs-dir: /tmp/ocm/blobs.d


### PR DESCRIPTION
needed (/helpful) for gardenlogin and gardenctl-v2, where additional publishing-steps are to be done (which will be easiest to be done in separate jobs/workflows).


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
expose published component-descriptor as output
```
