### PR TITLE
also expose component-descriptor from post-build-workflow

### DIFF
--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -37,6 +37,13 @@ on:
           - none
 
           Defines how component-descriptor should be post-processed.
+    outputs:
+      component-descriptor:
+        type: string
+        description: |
+          the final component-descriptor after base-component-descriptor and any emitted
+          fragments from other jobs.
+      value: ${{ jobs.component-descriptor.outputs.component-descriptor }}
 
 jobs:
   component-descriptor:


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
also expose component-descriptor from post-build-workflow
```
