### PR TITLE
fix: do not attempt to remove label if absent

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -163,8 +163,16 @@ runs:
         # we need issue-api to rm label (id is equal for pr and issue)
         pull_request = gh_repo.issue(${{ github.event.number }})
 
+        label_to_rm = '${{ steps.calc.outputs.remove-label }}'
+        for label in pull_request.labels():
+          if label.name == label_to_rm:
+            break
+        else:
+          # label not present - hence do not need to attempt removal
+          exit(0)
+
         try:
-          pull_request.remove_label('${{ steps.calc.outputs.remove-label }}')
+          pull_request.remove_label(label_to_rm)
         except github3.exceptions.NotFoundError:
           # trusted-checkout typically runs multiple times, so the label already being absent
           # is an expected, and of course, acceptable case


### PR DESCRIPTION
trusted-checkout will attempt to remove "trusted-label". However, removal requires pull-requests:write-permission. Avoid requiring each caller to grant this permission in cases where label was already removed (by an earlier job).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
