### PR TITLE
pass "commit-kind" to called version-callback-actions

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -520,6 +520,7 @@ runs:
         prerelease: 'dev'
         commit-message: ${{ inputs.next-version-commit-message }}
         repository-operation: commit-to-head
+        commit-kind: bump
 
     - name: reset-release-notes-directory
       if: ${{ inputs.release-notes-path }}

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -124,6 +124,23 @@ inputs:
       - capture-commit
       - commit-to-head
 
+  commit-kind:
+    required: false
+    type: choice
+    description: |
+      the semantical kind the created version-change-commit has. passed as `commit-kind` input to
+      action specified via `callback-action-path`, if any. If no such callback is passed, this
+      value is ignored.
+
+      bump: the commit increments the version
+      release: the commit sets a release-version (typically a final semver-version)
+      build: the commit sets a build-version (e.g. including a commit-digest)
+
+    options:
+      - bump
+      - release
+      - build
+
 outputs:
   version:
     description: |
@@ -183,6 +200,7 @@ runs:
       uses: ./../version-callback-action
       with:
         effective-version: ${{ steps.calc-version.outputs.effective-version }}
+        commit-kind: ${{ inputs.commit-kind }}
 
     - name: version
       id: version

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -181,6 +181,7 @@ jobs:
           callback-action-path: ${{ inputs.version-commit-callback-action-path }}
           versionfile: ${{ inputs.versionfile }}
           version-operation: ${{ inputs.version-operation }}
+          commit-kind: ${{ inputs.mode == 'release' && 'release' || 'build' }}
       - uses: gardener/cc-utils/.github/actions/base-component-descriptor@master
         id: component-descriptor
         with:


### PR DESCRIPTION
Convey semantics of commits (to-be) created w/ version-action to callbacks, to give them a hook to behave differently, depending on for which commit they were called.

A concrete use-case for behaving differently between bumping / releasing being the maintenance of a "LATEST"-file, which should be incremented upon release, but not be bumped after release.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
pass "commit-kind" to called version-callback-actions
```
