### PR TITLE
Allow cfg of full vs. local release-notes for Slack posting on Concourse

### DIFF
--- a/concourse/model/traits/slack.py
+++ b/concourse/model/traits/slack.py
@@ -26,6 +26,16 @@ CHANNEL_CFG_ATTRS = (
         doc='slack_cfg name (see cc-config)',
         type=str,
     ),
+    AttributeSpec.optional(
+        name='post_full_release_notes',
+        default=False,
+        doc='''
+        if the slack trait is used in conjunction with the release trait, specifies whether full
+        release notes (containing sub-components' release notes and OCI resources as well) or only
+        local release notes should be posted
+        ''',
+        type=bool,
+    ),
 )
 
 
@@ -39,6 +49,9 @@ class ChannelConfig(ModelBase):
 
     def slack_cfg_name(self):
         return self.raw.get('slack_cfg_name')
+
+    def post_full_release_notes(self):
+        return self.raw.get('post_full_release_notes')
 
     def _required_attributes(self):
         return {
@@ -57,7 +70,7 @@ ATTRIBUTES = (
         name='default_channel',
         doc='**deprecated**',
         type=str,
-    )
+    ),
 )
 
 
@@ -77,7 +90,7 @@ class SlackTrait(Trait):
         if isinstance(channel_cfgs, list):
             return [ChannelConfig(raw_dict=v) for v in channel_cfgs]
         else:
-            return [ChannelConfig(raw_dict=v) for _, v in channel_cfgs.items()]
+            return [ChannelConfig(raw_dict=v) for v in channel_cfgs.values()]
 
     def transformer(self):
         return SlackTraitTransformer()

--- a/concourse/steps/release.mako
+++ b/concourse/steps/release.mako
@@ -677,9 +677,14 @@ create_and_push_bump_commit(
 % if has_slack_trait:
   % for slack_channel_cfg in slack_channel_cfgs:
 try:
-  if release_notes_md:
+  if ${slack_channel_cfg.get('post_full_release_notes')}:
+    slack_release_notes_md = full_release_notes_md
+  else:
+    slack_release_notes_md = release_notes_md
+
+  if slack_release_notes_md:
     post_to_slack(
-      release_notes_markdown=release_notes_md,
+      release_notes_markdown=slack_release_notes_md,
       component=component,
       slack_cfg_name='${slack_channel_cfg["slack_cfg_name"]}',
       slack_channel='${slack_channel_cfg["channel_name"]}',

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -141,3 +141,4 @@ Example:
                 channel_cfg: # channel config name
                   channel_name: 'my_slack_channel_name' # you can specify the channel name or channel id
                   slack_cfg_name: 'example_slack_workspace' # Specifies the slack configuration that holds the slack api key (which is bound to a slack workspace)
+                  post_full_release_notes: False


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Allow configuration of full vs. local release-notes for Slack posting on Concourse
```
