### PR TITLE
Adapt linter to fail if warning or higher levels are found

### DIFF
--- a/ci/util.py
+++ b/ci/util.py
@@ -298,7 +298,7 @@ def _count_elements(value, count=0, max_elements_count=100000):
     return leng
 
 
-def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}):
+def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}, threshold: str = 'error'):
     if not _have_yamllint:
         raise RuntimeError('need to install yamllint in order to use')
 
@@ -313,8 +313,13 @@ def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}):
 
     _print_linting_findings(linting_result)
 
-    if linting_result.max_level() >= yamllint.linter.PROBLEM_LEVELS['warning']:
-        raise LintingError('Found some Warnings/Errors while linting. See above.')
+    # Convert the threshold string to the corresponding problem level
+    threshold_level = yamllint.linter.PROBLEM_LEVELS.get(threshold, yamllint.linter.PROBLEM_LEVELS['warning'])
+
+    # Check for problems at or above the threshold level
+    if linting_result.max_level() >= threshold_level:
+        raise LintingError(f'Found issues at or above the {threshold} level during linting. See above for details.')
+    
 
 
 def _print_linting_findings(linting_result: LintingResult):

--- a/ci/util.py
+++ b/ci/util.py
@@ -313,15 +313,15 @@ def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}):
 
     _print_linting_findings(linting_result)
 
-    if linting_result.max_level() >= yamllint.linter.PROBLEM_LEVELS['error']:
-        raise LintingError('Found some Errors while linting. See above.')
+    if linting_result.max_level() >= yamllint.linter.PROBLEM_LEVELS['warning']:
+        raise LintingError('Found some Warnings/Errors while linting. See above.')
 
 
 def _print_linting_findings(linting_result: LintingResult):
     if not _have_yamllint:
         raise RuntimeError('need to install yamllint in order to use')
     for level, problems in linting_result.problems():
-        if level < yamllint.linter.PROBLEM_LEVELS['error']:
+        if level < yamllint.linter.PROBLEM_LEVELS['warning']:
             for p in problems:
                 warning(p)
         else:

--- a/ci/util.py
+++ b/ci/util.py
@@ -314,11 +314,15 @@ def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}, threshold: 
     _print_linting_findings(linting_result)
 
     # Convert the threshold string to the corresponding problem level
-    threshold_level = yamllint.linter.PROBLEM_LEVELS.get(threshold, yamllint.linter.PROBLEM_LEVELS['warning'])
+    threshold_level = yamllint.linter.PROBLEM_LEVELS.get(
+        threshold, yamllint.linter.PROBLEM_LEVELS['warning']
+    )
 
     # Check for problems at or above the threshold level
     if linting_result.max_level() >= threshold_level:
-        raise LintingError(f'Found issues at or above the {threshold} level during linting. See above for details.')
+        raise LintingError(
+            f'Found issues at or above the {threshold} level during linting. See above for details.'
+        )
 
 
 def _print_linting_findings(linting_result: LintingResult):

--- a/ci/util.py
+++ b/ci/util.py
@@ -319,7 +319,6 @@ def lint_yaml_file(path, linter_config: dict={'extends': 'relaxed'}, threshold: 
     # Check for problems at or above the threshold level
     if linting_result.max_level() >= threshold_level:
         raise LintingError(f'Found issues at or above the {threshold} level during linting. See above for details.')
-    
 
 
 def _print_linting_findings(linting_result: LintingResult):


### PR DESCRIPTION
We would like to harden the linter behavior and make it fail whenever there are warnings or higher problems found during linting. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
