### PR TITLE
Always try OCI-Auth prior to OCI image build

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -299,7 +299,7 @@ jobs:
           EOF
           echo EOF >> "${GITHUB_OUTPUT}"
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
-        if: ${{ needs.preprocess.outputs.push == 'true' }}
+        continue-on-error: true # successful auth might not be required
         with:
           oci-image-reference: ${{ matrix.args.image-reference }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
