### PR TITLE
pass whither-component-descriptor to set-dependency-version callback

### DIFF
--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -303,6 +303,7 @@ def set_dependency_cmd_env(
     upgrade_vector: ocm.gardener.UpgradeVector,
     repo_dir: str,
     github_cfg_name: str=None,
+    whither_component_descriptor_path: str=None,
 ) -> dict[str, str]:
     '''
     returns a cmd-env-block (in form of a dict) to pass to `set_depedency_version` callbacks.
@@ -315,6 +316,9 @@ def set_dependency_cmd_env(
     cmd_env['DEPENDENCY_NAME'] = upgrade_vector.component_name
     cmd_env['DEPENDENCY_VERSION'] = upgrade_vector.whither.version
     cmd_env['REPO_DIR'] = repo_dir
+
+    if whither_component_descriptor_path: # github-actions only
+        cmd_env['WHITHER_COMPONENT_DESCRIPTOR'] = whither_component_descriptor_path
 
     if github_cfg_name: # concourse-only
         cmd_env['GITHUB_CFG_NAME'] = github_cfg_name


### PR DESCRIPTION
set_dependency_version callback scripts sometimes need to inspect whither-component-descriptor. Retrieve whither-component-descriptor for callback-script such as to make implementation of such scripts easier (do not require them to retrieve component-descriptors themselves).



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
pass whither-component-descriptor to set-dependency-version callback
```
