### PR TITLE
fix: Always retrieve patched root component descriptor in CTT

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -919,11 +919,11 @@ def process_replication_plan_step(
     # retrieve component descriptor from the target registry as local descriptor might not contain
     # patched image references (if it was already existing the the target registry and thus patching
     # has been skipped)
-    if not skip_component_upload or not skip_component_upload(root_component_descriptor.component):
-        root_component_descriptor = tgt_component_descriptor_lookup(ocm.ComponentIdentity(
-            name=root_component_descriptor.component.name,
-            version=root_component_descriptor.component.version,
-        ))
+    if patched_root_component_descriptor := tgt_component_descriptor_lookup(
+        root_component_descriptor.component.identity(),
+        absent_ok=True,
+    ):
+        root_component_descriptor = patched_root_component_descriptor
 
     for node in cnudie.iter.iter(
         component=root_component_descriptor,


### PR DESCRIPTION
In case the root component descriptor already exists in the target OCM repository, the patched component descriptor had not been retrieved and thus caused following steps to fail because of unpatched image refs.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix CTT replication in case the root OCM component descriptor already existed in the target OCM repository
```
