### PR TITLE
Allow overwriting of resource version in imagevector via resource-id

### DIFF
--- a/ocm/gardener.py
+++ b/ocm/gardener.py
@@ -183,6 +183,7 @@ def add_resources_from_imagevector(
         extra_identity = image_dict.get('extraIdentity', {})
         labels = copy.copy(image_dict.get('labels', []))
         tag = image_dict.get('tag', None)
+        version = resource_id.get('version', tag) if resource_id else tag
         target_version = image_dict.get('targetVersion', None)
 
         for prefix in (component_prefixes or ()):
@@ -279,7 +280,7 @@ def add_resources_from_imagevector(
 
         img_resource = ocm.Resource(
             name=resource_name or name,
-            version=tag,
+            version=version,
             extraIdentity=extra_identity,
             labels=labels,
             relation=relation,


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
