### PR TITLE
Fix `ocm-upgrade` GHA behaviour in case of multiple componentversions + upgrades

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -156,10 +156,6 @@ runs:
         github_api = github.github_api(token=github_token)
         repository = github_api.repository(org, repo)
 
-        def github_api_lookup(repo_url):
-          # XXX needs to be extended for cross-github-support
-          return github_api
-
         repo_dir = os.getcwd()
 
         logger.info('retrieving existing upgrade-pull-requests')
@@ -179,7 +175,6 @@ runs:
             component_descriptor_lookup=component_descriptor_lookup,
             version_lookup=version_lookup,
             upgrade_pullrequests=upgrade_pullrequests,
-            github_api_lookup=github_api_lookup,
             repo_dir=repo_dir,
             repo_url=f'https://{host}/{org}/{repo}',
             repository=repository,

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -320,18 +320,10 @@ def create_upgrade_pullrequests(
     branch: str,
     oci_client: oci.client.Client,
 ) -> collections.abc.Iterable[github.pullrequest.UpgradePullRequest]:
-    seen_component_ids = set()
-    for cref in ocm.gardener.iter_component_references(
-        component=component,
+    for cref in ocm.gardener.iter_greatest_component_references(
+        references=ocm.gardener.iter_component_references(component=component),
     ):
         logger.info(f'processing {cref=}')
-        if cref.component_id in seen_component_ids:
-            logger.warn(f'skipping {cref=} - already seen')
-            logger.warn('hint: there are multiple crefs, likely with different name or version')
-            logger.warn('-> handling for this case is not implemented, hence skipping')
-            continue
-
-        seen_component_ids.add(cref.component_id)
 
         upgrade_vector = ocm.gardener.find_upgrade_vector(
             component_id=cref.component_id,

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -355,6 +355,10 @@ def create_upgrade_pullrequests(
             branch=branch,
             oci_client=oci_client,
         )
+        # early-exit after first created upgrade PR as a workaround (for now) to prevent unintended
+        # sideeffects (e.g. dirty worktree, git conflicts)
+        # -> possible upgrade PRs for other components will be created upon the next execution
+        return
 
 
 def main():

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -203,10 +203,8 @@ def retrieve_release_notes(
 
 def create_upgrade_pullrequest(
     upgrade_vector: ocm.gardener.UpgradeVector,
-    component: ocm.Component,
     component_descriptor_lookup: ocm.ComponentDescriptorLookup,
     version_lookup: ocm.VersionLookup,
-    github_api_lookup,
     repo_dir: str,
     repo_url: str,
     repository: github3.repos.Repository,
@@ -313,7 +311,6 @@ def create_upgrade_pullrequests(
     component: ocm.Component,
     component_descriptor_lookup: ocm.ComponentDescriptorLookup,
     version_lookup: ocm.VersionLookup,
-    github_api_lookup,
     upgrade_pullrequests: collections.abc.Collection[github.pullrequest.UpgradePullRequest],
     repo_dir: str,
     repo_url: str,
@@ -356,10 +353,8 @@ def create_upgrade_pullrequests(
 
         yield create_upgrade_pullrequest(
             upgrade_vector=upgrade_vector,
-            component=component,
             component_descriptor_lookup=component_descriptor_lookup,
             version_lookup=version_lookup,
-            github_api_lookup=github_api_lookup,
             repo_dir=repo_dir,
             repo_url=repo_url,
             repository=repository,


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
