### PR TITLE
Exchange GH token for a K8s service account token

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -46,18 +46,16 @@ inputs:
       no kubeconfig will be written.
   service-account-name:
     type: string
-    default: testrunner
     description: |
       the service account in the target-cluster to authenticate request a token for.
       It should be used by the testrunner invocation at a later stage.
   service-account-namespace:
     type: string
-    default: default
     description: |
       the namespace in which the service account resides.
   service-account-token-expiration:
     type: number
-    default: 10800
+    default: 3600
     description: |
       the requested expiration (in seconds) of the service account token.
       Note that the actual expiration might differ, depending on the cluster's configuration.
@@ -128,26 +126,34 @@ runs:
           echo 'successfully retrieved an gh-auth-token'
         fi
 
-        testmachinery_token_request_url="${server}/api/v1/namespaces/${{ inputs.service-account-namespace}}/serviceaccounts/${{ inputs.service-account-name}}/token"
-        echo $server_ca | base64 -d > ca.pem
-        token_request_body='{"apiVersion":"authentication.k8s.io/v1","kind":"TokenRequest","spec":{"audiences":["kubernetes","gardener"],"expirationSeconds":${{ inputs.service-account-token-expiration}}}}'
+        auth_token="${gh_auth_token}"
 
-        auth_token=$(
-          curl -sLS -XPOST \
-            --cacert ca.pem \
-            -H "Authorization: Bearer ${gh_auth_token}" \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/json" \
-            -d '${token_request_body}' \
-            "${testmachinery_token_request_url}" \
-          | jq -r .status.token
-        )
+        if [ -n "${{ inputs.service-account-name }}" && -n "${{ inputs.service-account-namespace }}" ]; then
+          echo 'service-account details specified, requesting a service-account-token'
 
-        if [ -z "${auth_token}" ]; then
-          echo 'failed to retrieve an auth-token'
-          exit 1
-        else
-          echo 'successfully retrieved an auth-token'
+          echo $server_ca | base64 -d > ca.pem
+          kubernetes_token_request_url="${server}/api/v1/namespaces/${{ inputs.service-account-namespace}}/serviceaccounts/${{ inputs.service-account-name}}/token"
+          token_request_body='{"apiVersion":"authentication.k8s.io/v1","kind":"TokenRequest","spec":{"audiences":["kubernetes","gardener"],"expirationSeconds":${{ inputs.service-account-token-expiration}}}}'
+
+          sa_auth_token=$(
+            curl -sLS -XPOST \
+              --cacert ca.pem \
+              -H "Authorization: Bearer ${gh_auth_token}" \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json" \
+              -d '${token_request_body}' \
+              "${kubernetes_token_request_url}" \
+            | jq -r .status.token
+          )
+
+          if [ -z "${sa_auth_token}" ]; then
+            echo 'failed to retrieve an service account auth-token'
+            exit 1
+          else
+            echo 'successfully retrieved an service account auth-token'
+          fi
+
+          auth_token="${sa_auth_token}"
         fi
 
         cat <<EOF > kubeconfig.yaml

--- a/.github/workflows/run-testmachinery-tests.yaml
+++ b/.github/workflows/run-testmachinery-tests.yaml
@@ -49,6 +49,26 @@ on:
         description: |
           The path to which the generated kubeconfig will be generated (this needs to be passed
           to `testrunner`).
+      service-account-name:
+        required: false
+        type: string
+        default: testrunner
+        description: |
+          the service account in the target-cluster to authenticate request a token for.
+          It should be used by the testrunner invocation at a later stage.
+      service-account-namespace:
+        required: false
+        type: string
+        default: default
+        description: |
+          the namespace in which the service account resides.
+      service-account-token-expiration:
+        required: false
+        type: number
+        default: 10800
+        description: |
+          the requested expiration (in seconds) of the service account token.
+          Note that the actual expiration might differ, depending on the cluster's configuration.
       test-command:
         required: true
         type: string
@@ -89,6 +109,9 @@ jobs:
           server-ca: ${{ inputs.k8s-api-ca }}
           cluster-cfg: ${{ inputs.cluster-cfg }}
           kubeconfig-path: ${{ inputs.kubeconfig-path }}
+          service-account-name: ${{ inputs.service-account-name }}
+          service-account-namespace: ${{ inputs.service-account-namespace }}
+          service-account-token-expiration: ${{ inputs.service-account-token-expiration }}
       - name: trigger-testmachinery-tests
         shell: bash
         run: |


### PR DESCRIPTION
To avoid unintended/early expiration of a token used by testrunner, the action will use the GH token to request a K8s service account token with a custom expiration time.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`kubernetes-auth` action exchanges GH token for a K8s service account token
```
