### PR TITLE
Use -a operator to fix syntax error

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -128,7 +128,7 @@ runs:
 
         auth_token="${gh_auth_token}"
 
-        if [ -n "${{ inputs.service-account-name }}" && -n "${{ inputs.service-account-namespace }}" ]; then
+        if [ -n "${{ inputs.service-account-name }}" -a -n "${{ inputs.service-account-namespace }}" ]; then
           echo 'service-account details specified, requesting a service-account-token'
 
           echo $server_ca | base64 -d > ca.pem


### PR DESCRIPTION
Use `-a` operator instead of `&&` to fix a syntax error and avoid using `[[ ]]` for query.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an syntax error with the kuberentes-auth action.
```
