### PR TITLE
Ensure correct PR body size in case `pullrequest_body_suffix` is specified

### DIFF
--- a/concourse/steps/update_component_deps.py
+++ b/concourse/steps/update_component_deps.py
@@ -385,15 +385,13 @@ def create_upgrade_pr(
     pr_body, additional_notes = github.pullrequest.upgrade_pullrequest_body(
         release_notes=release_notes_markdown,
         bom_diff_markdown=bom_diff_markdown,
+        pullrequest_body_suffix=pullrequest_body_suffix,
     )
 
     rnt.release_notes_docs_into_files(
         release_notes_docs=grouped_release_notes_docs,
         repo_dir=repo_dir,
     )
-
-    if pullrequest_body_suffix:
-        pr_body += f'\n{pullrequest_body_suffix}'
 
     if merge_policy is ucd.MergePolicy.MANUAL:
         delete_on_exit = False

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -274,6 +274,7 @@ def split_into_chunks_if_too_long(
 def upgrade_pullrequest_body(
     release_notes: str | None,
     bom_diff_markdown: str | None,
+    pullrequest_body_suffix: str | None=None,
 ) -> tuple[str, list[str]]:
     pr_body = ''
 
@@ -281,6 +282,8 @@ def upgrade_pullrequest_body(
         total_length = len(bom_diff_markdown)
         if release_notes:
             total_length += len(release_notes)
+        if pullrequest_body_suffix:
+            total_length += len(pullrequest_body_suffix)
         include_bom_diff = total_length <= github.limits.issue_body
     else:
         include_bom_diff = False
@@ -290,6 +293,9 @@ def upgrade_pullrequest_body(
 
     if include_bom_diff:
         pr_body = f'{pr_body}\n\n{bom_diff_markdown}'
+
+    if pullrequest_body_suffix:
+        pr_body = f'{pr_body}\n\n{pullrequest_body_suffix}'
 
     return split_into_chunks_if_too_long(
         string=pr_body,


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The upgrade-PR body size is now correctly determined in case `pullrequest_body_suffix` is specified (for max PR body size check)
```
