### PR TITLE
Checkout Submodules using github-app-authtoken

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -30,6 +30,30 @@ inputs:
     default: false
     description: |
       passed to `actions/checkout` as `submodules` input.
+  auth-app-client-id:
+    type: string
+    default: ''
+    description: |
+      if used in conjuction to setting `submodules` to `recursive`, pass the client-id of a
+      GitHub-App that should be used to retrieve access-token(s) for checking out submodules.
+
+      if passed, must also pass `auth-app-private-key`. The app must be authorised to
+      (read-)access all git-repositories referenced as submodules.
+
+      If there are no submodules, or `submodules` is not set to `recursive`, this input will be
+      ignored.
+  auth-app-private-key:
+    type: string
+    default: ''
+    description: |
+      if used in conjuction to setting `submodules` to `recursive`, pass the private-key of a
+      GitHub-App that should be used to retrieve access-token(s) for checking out submodules.
+
+      if passed, must also pass `auth-app-client-id`. The app must be authorised to
+      (read-)access all git-repositories referenced as submodules.
+
+      If there are no submodules, or `submodules` is not set to `recursive`, this input will be
+      ignored.
   token:
     type: string
     default: ''
@@ -68,14 +92,27 @@ runs:
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         path: ${{ inputs.path }}
-        submodules: ${{ inputs.submodules }}
     - uses: actions/checkout@v4
       if: ${{ inputs.token != '' }}
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         path: ${{ inputs.path }}
-        submodules: ${{ inputs.submodules }}
         token: ${{ inputs.token }}
+
+    - name: checkout-submodules
+      if: ${{ inputs.submodules == 'recursive' }}
+      shell: bash
+      run: |
+        set -euo
+
+        echo "checking out submodules.."
+        set +x
+        APP_ID="${{ inputs.auth-app-client-id }}" \
+        APP_KEY="${{ inputs.auth-app-private-key }}" \
+        GIT_DIR=$PWD/.git \
+        GIT_WORK_TREE=$PWD \
+          "${{ github.action_path }}/checkout-submodules.sh"
+
     - name: checkout-pullrequest
       if: ${{ github.event_name == 'pull_request_target' }}
       id: calc

--- a/.github/actions/trusted-checkout/checkout-submodules.sh
+++ b/.github/actions/trusted-checkout/checkout-submodules.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# a (slightly hacky) script to be used as a workaround for allowing to checkout submodules
+# referenced with an SSH-URL with GitHub-Action's checkout-Action (using https / token-auth).
+#
+# Will only work for submodules on same GitHub-Instance. Only needed on GHE (checkout-action
+# does have special-handling for github.com in place - or so they claim).
+#
+# This script is intended to be run after actions/checkout (which should be run w/o telling it
+# to checkout submodules). This script assumes checkout's token is still present as
+# http.<github-api>.extraHeader, and furthermore assumes this token is valid to retrieve each
+# submodule (i.e.: no support for cross-github-submodules, and (obviously) no support for
+# submodules not hosted in github).
+
+set -euo pipefail
+
+own_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+git --version
+git submodule init
+github_host=$(echo ${GITHUB_SERVER_URL:-https://github.com} | cut -d/ -f3)
+
+if [ -z "${APP_ID:-}" -a -n "${APP_KEY:-}" ]; then
+  echo "Error: APP_ID and APP_KEY must both be set or not set"
+  exit 1
+elif [ -n "${APP_ID:-}" -a -z "${APP_KEY:-}" ]; then
+  echo "Error: APP_ID and APP_KEY must both be set or not set"
+  exit 1
+elif [ -n "${APP_ID:-}" ]; then
+  # we checked both are (un)set above
+  have_app=true
+else
+  have_app=false
+fi
+
+function token() {
+  org=$1
+
+  "$own_dir/create_app_token.py" \
+    --client-id "$APP_ID" \
+    --private-key "$APP_KEY" \
+    --github-org $org
+}
+
+git submodule status | while read -r s; do
+  path=$(echo $s | cut -d' ' -f2-)
+  cdig=$(echo $s | cut -d' ' -f1 | cut -d- -f2)
+
+  echo "path: $path, digest: $cdig"
+
+  echo "git-cmd to run: git config get submodule.$path.url"
+  sm_url=$(git config submodule.$path.url)
+  if [[ $sm_url == http* ]]; then
+    echo "submodule at $path not configured to use SSH"
+    continue
+  fi
+  echo "submodule at $path configured to use SSH - will reconfigure to https"
+
+  if ! $have_app; then
+    git submodule update $path
+    continue
+  fi
+
+  # XXX: assume submodules-URL is of SSH-Type. Also assume submodule resides on same GH-Instance
+  # strip prefixes (allow either of long/short form (ssh://git@ or just git@)
+  sm_repo=${sm_url#ssh://}
+  # strip git@-prefix
+  sm_repo=${sm_repo#git@}
+  # strip hostname (we do not know where we have long or short form, yet)
+  sm_repo=${sm_repo#$github_host}
+  # strip either / or : (depends on ssh-url-type)
+  sm_repo=${sm_repo#:}
+  sm_repo=${sm_repo#/}
+
+  # git does not seem to honour http.<url>.extraheaders, so we have to jump through some (more)
+  # hoops
+  org=$(echo $sm_repo | cut -d/ -f1)
+  auth=$(echo -n x-access-token:$(token $org) | base64)
+  (
+    unset GIT_DIR
+    unset GIT_WORK_TREE
+    cd $path
+    git init
+    git config http.https://$github_host/$sm_repo.extraHeader "AUTHORIZATION: basic $auth"
+    git remote add origin https://$github_host/$sm_repo
+    echo "will try to fetch submodule $sm_repo into $path"
+    git fetch origin $cdig
+    echo "fetched successfully"
+    git checkout $cdig
+  )
+
+done
+
+echo "done with initialisation of submodules"

--- a/.github/actions/trusted-checkout/create_app_token.py
+++ b/.github/actions/trusted-checkout/create_app_token.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import time
+
+import jwt
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--client-id',
+        required=True,
+        help="GitHub-App's client-id (or app-id)",
+    )
+    parser.add_argument(
+        '--private-key',
+        required=True,
+        help="GitHub-App's private-key in PEM-format",
+    )
+    parser.add_argument(
+        '--github-api',
+        required=False,
+        default=os.environ.get('GITHUB_API_URL', None),
+    )
+    parser.add_argument(
+        '--github-org',
+        required=True,
+    )
+
+    p = parser.parse_args()
+
+    now = int(time.time())
+    payload = {
+        'iat': now,
+        'exp': now + 600, # 10m
+        'iss': p.client_id,
+    }
+
+    encoded_jwt = jwt.encode(payload, p.private_key, algorithm='RS256')
+
+    sess = requests.Session()
+    sess.headers['Authorization'] = f'Bearer {encoded_jwt}'
+    sess.headers['Accept'] = 'application/vnd.github+json'
+
+    def api_url(suffix):
+        return f'{p.github_api}/{suffix}'
+
+    installation = sess.get(api_url(f'orgs/{p.github_org}/installation')).json()
+    installation_id = installation.get('id')
+
+    access_token = sess.post(
+        api_url(f'app/installations/{installation_id}/access_tokens')
+    )
+    access_token.raise_for_status()
+
+    print(access_token.json()['token'])
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -204,7 +204,8 @@ jobs:
         with:
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
           submodules: ${{ inputs.checkout-submodules }}
-          token: ${{ inputs.checkout-token || secrets.GITHUB_TOKEN }}
+          auth-app-client-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
+          auth-app-private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
       - name: preprocess-params
         id: pre
         run: |


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Allow checking-out of submodules from repositories on same github(-enterprise)-instance, also if authentication is required, using default Github-App-issued auth-tokens.
```
