### PR TITLE
Omit "null" properties from OCI manifest during replication

### DIFF
--- a/ctt/replicate.py
+++ b/ctt/replicate.py
@@ -86,7 +86,7 @@ def replicate_oci_artifact_with_patched_component_descriptor(
         },
     )
 
-    target_manifest_dict = dataclasses.asdict(target_manifest)
+    target_manifest_dict = target_manifest.as_dict()
     target_manifest_bytes = json.dumps(target_manifest_dict).encode('utf-8')
 
     oci_client.put_manifest(


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
