### PR TITLE
GHA release workflow supports multiple tags via `github-tag-templates` input field

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -140,13 +140,14 @@ inputs:
           os: linux
           arch: x86_64
       ```
-  github-tag-template:
+  github-tag-templates:
     default: '${version}'
     type: string
     description: |
-      GitHub tag template to use for the created release tag. Currently only supported template-var:
+      Comma-separated list of GitHub tag templates to use for the created release tags. Each template can use
       ${version} (bash-syntax): Version read from local component descriptor (i.e. previous version
       operations are honoured).
+      The first tag in the list will be used to create the GitHub release.
   on-existing-component-descriptor:
     default: fail
     type: choice
@@ -201,10 +202,42 @@ runs:
         EOF
         version=$(yq .component.version /tmp/component-descriptor.yaml)
         echo "version=${version}" >> $GITHUB_OUTPUT
-        tag_name="${{ inputs.github-tag-template }}"
-        tag_ref="refs/tags/${tag_name}"
-        echo "tag-ref=${tag_ref}" >> $GITHUB_OUTPUT
-        echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT
+        # Parse github-tag-templates string into array
+        IFS=',' read -ra tag_templates <<< "${{ inputs.github-tag-templates }}"
+        tag_names=()
+        tag_refs=()
+        for template in "${tag_templates[@]}"; do
+          template=$(echo "$template" | xargs) # trim whitespace
+          tag_name=$(echo "$template" | sed "s/\\${version}/$version/g")
+          tag_names+=("$tag_name")
+          tag_refs+=("refs/tags/$tag_name")
+        done
+        if [ "${#tag_names[@]}" -eq 0 ]; then
+          echo "Error: github-tag-templates must contain at least one item." >&2
+          exit 1
+        fi
+        # Validate uniqueness
+        unique_tags=$(printf "%s\n" "${tag_names[@]}" | sort | uniq)
+        if [ $(printf "%s\n" "${tag_names[@]}" | wc -l) -ne $(printf "%s\n" "$unique_tags" | wc -l) ]; then
+          echo "Error: Duplicate tag names found in github-tag-templates: ${tag_names[*]}" >&2
+          exit 1
+        fi
+        # Validate tag names (must not be empty, must match valid git tag pattern)
+        for tag in "${tag_names[@]}"; do
+          if [[ -z "$tag" ]]; then
+            echo "Error: Tag name must not be empty." >&2
+            exit 1
+          fi
+          # Git tag name rules: no spaces, no ASCII control chars, no ~^:?*[\, must not start with -
+          if [[ "$tag" =~ [~^:?*\\[\]@\s] || "$tag" =~ ^- ]]; then
+            echo "Error: Invalid tag name '$tag'." >&2
+            exit 1
+          fi
+        done
+        echo "tag-names=${tag_names[*]}" >> $GITHUB_OUTPUT
+        echo "tag-refs=${tag_refs[*]}" >> $GITHUB_OUTPUT
+        # Set first tag as main release tag
+        echo "release-tag-name=${tag_names[0]}" >> $GITHUB_OUTPUT
         cat <<"EOF" > /tmp/assets.yaml
         ${{ inputs.assets }}
         EOF
@@ -352,16 +385,21 @@ runs:
         path: /tmp/component-descriptor.tar.gz
         name: component-descriptor
 
-    - name: push release-tag
+    - name: push tag-refs
       shell: bash
       run: |
         set -eu
+        for tag_ref in ${{ steps.preprocess.outputs.tag-refs }}; do
+          push_spec="@:$$tag_ref"
+          echo "pushing release-commit using ${push_spec}"
+          git push origin "${push_spec}"
+        done
 
+    - name: push release-commit
+      shell: bash
+      run: |
+        set -eu
         orig_ref="$(git rev-parse @)"
-        push_spec="@:${{ steps.preprocess.outputs.tag-ref }}"
-        echo "pushing release-commit using ${push_spec}"
-        git push origin "${push_spec}"
-
         case "${{ inputs.release-commit-target }}" in
           tag)
           echo "chose to not push tag to source-branch: exiting now"
@@ -440,12 +478,11 @@ runs:
 
         repository = github_api.repository(org, repo)
 
-
         release_notes_markdown = '''\
         ${{ inputs.full-release-notes }}
         '''
 
-        release_tag_name = '${{ steps.preprocess.outputs.tag-name }}'
+        release_tag_name = '${{ steps.preprocess.outputs.release-tag-name }}'
         draft_tag_name = f'{release_tag_name}-draft'
 
         if not (gh_release := github.release.find_draft_release(

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,12 +96,14 @@ on:
         description: |
           If set to `true`, the workflow will create a new GitHub release (or convert an existing
           draft release to an actual release).
-      github-tag-template:
+      github-tag-templates:
         default: '${version}'
         type: string
         description: |
-          GitHub tag template to use for the created release tag. Currently only supported
-          template-var: ${version} (bash-syntax).
+          Comma-separated list of GitHub tag templates to use for the created release tags. Each template can use
+          ${version} (bash-syntax): Version read from local component descriptor (i.e. previous version
+          operations are honoured).
+          The first tag in the list will be used to create the GitHub release.
       assets:
         type: string
         required: false
@@ -214,7 +216,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-push-token: ${{ steps.app-token.outputs.token }}
           release-on-github: ${{ inputs.release-on-github }}
-          github-tag-template: ${{ inputs.github-tag-template }}
+          github-tag-templates: ${{ inputs.github-tag-templates }}
           assets: ${{ inputs.assets }}
 
       - name: write-release-notes-to-file


### PR DESCRIPTION
GHA release workflow supports multiple tags via `github-tag-templates` input field. I have replaced the previous `github-tag-template` field with `github-tag-templates`, since I nobody is using `github-tag-template` in gardener org yet, and I wanted to avoid the complexity of handling the same input from multiple input fields and deprecation overhead.

Also, this field is technically a string (comma-separated values validated in `release/action.yaml`), since the schema does not allow `array` or `list` type in reusable workflows - [ref discussion](https://github.com/orgs/community/discussions/11692).

I also split `push release-tag` step in release action into `push tag-refs` and `push release-commit` for clear separation of responsibilities.

Please let me know if the approach is correct. Also, majority of the changes are AI generated, so please let me know if there's anything I need to correct here as well.

Fixes #1381 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
GHA `release` workflow now supports multiple tags via `github-tag-templates` input field which takes comma-separated values of target ref templates.
```
```breaking developer
GHA `release` workflow input field `github-tag-template` has now been replaced by `github-tag-templates` which takes comma-separated values of target ref templates. While the input name needs to be adapted, no change is needed to the existing value.
```
