### PR TITLE
Remove default `cluster-cfg` input for `kubernetes-auth` action

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -17,7 +17,6 @@ inputs:
       the base64-encoded certificate-bundle for the server-endpoint.
   cluster-cfg:
     type: string
-    default: gardener/clusters/testmachinery-canary.yaml
     description: |
       Refers to a file located in a GitHub repository containing the k8s-api-endpoint as well as
       the k8s-api-ca. If the `server` _and_ `server-ca` inputs are specified as well, those will


### PR DESCRIPTION
As the `kubernetes-auth` action is intended to be used in more generic scenarios, drop this specific default value which is used for integrationtests only. Instead, users should consider using the `run-testmachinery-tests.yaml` workflow to run integrationtests which already defines reasonable defaults.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
