### PR TITLE
fix(ci): Use trusted-checkout also for job-image-base

### DIFF
--- a/.github/workflows/cc-job-image-base.yaml
+++ b/.github/workflows/cc-job-image-base.yaml
@@ -14,8 +14,14 @@ jobs:
     env:
       platforms: linux/amd64,linux/arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        id: checkout
+        with:
+          auth-app-client-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
+          auth-app-private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
+
+      - name: Setup Git Identity
+        uses: gardener/cc-utils/.github/actions/setup-git-identity@master
 
       - name: Setup Docker-Buildx
         uses: docker/setup-buildx-action@v3
@@ -29,7 +35,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.checkout.outputs.token }}
           registry: ghcr.io
 
       - name: Read Version
@@ -55,11 +61,14 @@ jobs:
       new_version: ${{ steps.update_version.outputs.new_version }}
       current_version: ${{ steps.update_version.outputs.current_version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        id: checkout
+        with:
+          auth-app-client-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
+          auth-app-private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
 
       - name: Setup Git Identity
-        uses: ./.github/actions/setup-git-identity
+        uses: gardener/cc-utils/.github/actions/setup-git-identity@master
 
       - name: Update Base Image and Increment Version
         id: update_version
@@ -92,4 +101,4 @@ jobs:
               - Base Image Version: ${{ steps.update_version.outputs.current_version }}.
               - Also increments the version to ${{ steps.update_version.outputs.new_version }}."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.checkout.outputs.token }}


### PR DESCRIPTION
Required, as default token is not permitted to create PRs.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
