### PR TITLE
Fix multi-line output handling in workflow and action

### DIFF
--- a/.github/actions/update-extension-provider-images/action.yaml
+++ b/.github/actions/update-extension-provider-images/action.yaml
@@ -44,9 +44,8 @@ runs:
         summary=$(python3 "${{ github.action_path }}/update-images.py" \
           --images-yaml-path "${{ inputs.images-yaml-path }}" \
           --release-notes-path "${{ inputs.release-notes-path }}")
-        
-        summary="${summary//'%'/'%25'}"
-        summary="${summary//$'\n'/'%0A'}"
-        summary="${summary//$'\r'/'%0D'}"
-        echo "summary=${summary}" >> $GITHUB_OUTPUT
-
+        {
+          echo "summary<<EOF"
+          echo "$summary"
+          echo "EOF"
+        } >> $GITHUB_OUTPUT

--- a/.github/workflows/update-extension-provider-images.yaml
+++ b/.github/workflows/update-extension-provider-images.yaml
@@ -49,10 +49,11 @@ jobs:
           release_notes_path="${{ inputs.release-notes-path }}"
           if [ -f "$release_notes_path" ]; then
             notes=$(cat "$release_notes_path")
-            notes="${notes//'%'/'%25'}"
-            notes="${notes//$'\n'/'%0A'}"
-            notes="${notes//$'\r'/'%0D'}"
-            echo "notes_content=${notes}" >> $GITHUB_OUTPUT
+          {
+            echo "notes_content<<EOF"
+            echo "$notes"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
           else
             echo "No release-notes.md file found. No updates were made."
             echo "notes_content=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This fixes the encoding of multi-line statements in the workflow and the action so that we get a clean output in the resulting PR.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix multi-line encoding in update-extension-provider-images workflow.
```
