### PR TITLE
Refactor `kubernetes-auth` action to support usage of Gardener discovery server

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -15,6 +15,11 @@ inputs:
     type: string
     description: |
       the base64-encoded certificate-bundle for the server-endpoint.
+  server-ca-discovery-url:
+    type: string
+    description: |
+      url to the Gardener discovery server to retrieve the Kubernetes server CA, e.g.
+      `https://discovery.ingress.garden.example.com/projects/<project_name>/shoots/<shoot-uid>/cluster-ca`
   cluster-cfg:
     type: string
     description: |
@@ -73,17 +78,22 @@ runs:
         set -euo pipefail
 
         server="${{ inputs.server }}"
+        server_ca_discovery_url="${{ inputs.server-ca-discovery-url }}"
 
-        # normalise api-url: remove `https://` prefix and add `:443` suffix if required
-        normalised_api_url="${server#https://}"
-        if [[ "${normalised_api_url}" != *:443 ]]; then
-          normalised_api_url="${normalised_api_url}:443"
+        if [ -n "${server_ca_discovery_url}" ]; then
+          server_ca=$(curl "${server_ca_discovery_url}" | jq -r .certs | base64 -w 0 | tr -d '\n')
+        else
+          # normalise api-url: remove `https://` prefix and add `:443` suffix if required
+          normalised_api_url="${server#https://}"
+          if [[ "${normalised_api_url}" != *:443 ]]; then
+            normalised_api_url="${normalised_api_url}:443"
+          fi
+
+          server_ca=$(echo | openssl s_client -showcerts -connect "${normalised_api_url}" 2>/dev/null \
+            | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
+            | base64 -w 0 \
+            | tr -d '\n')
         fi
-
-        server_ca=$(echo | openssl s_client -showcerts -connect "${normalised_api_url}" 2>/dev/null \
-          | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
-          | base64 -w 0 \
-          | tr -d '\n')
 
         echo "server_ca=$server_ca" >> "$GITHUB_OUTPUT"
     - name: prepare cluster-cfg

--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -65,9 +65,30 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: prepare-cluster-cfg
-      id: prepare
-      if: ${{ inputs.server == '' || inputs.server-ca == '' }}
+    - name: prepare server-ca
+      id: prepare-server-ca
+      if: ${{ inputs.server != '' && inputs.server-ca == '' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        server="${{ inputs.server }}"
+
+        # normalise api-url: remove `https://` prefix and add `:443` suffix if required
+        normalised_api_url="${server#https://}"
+        if [[ "${normalised_api_url}" != *:443 ]]; then
+          normalised_api_url="${normalised_api_url}:443"
+        fi
+
+        server_ca=$(echo | openssl s_client -showcerts -connect "${normalised_api_url}" 2>/dev/null \
+          | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
+          | base64 -w 0 \
+          | tr -d '\n')
+
+        echo "server_ca=$server_ca" >> "$GITHUB_OUTPUT"
+    - name: prepare cluster-cfg
+      id: prepare-cluster-cfg
+      if: ${{ inputs.server == '' && inputs.server-ca == '' }}
       shell: bash
       run: |
         cluster_cfg="${{ inputs.cluster-cfg }}"
@@ -75,10 +96,10 @@ runs:
         echo "repository=$(echo "${cluster_cfg}" | cut -d '/' -f1,2)" >> ${GITHUB_OUTPUT}
         echo "path=$(echo "${cluster_cfg}" | cut -d '/' -f3-)" >> ${GITHUB_OUTPUT}
     - name: checkout cluster-cfg repo
-      if: ${{ inputs.server == '' || inputs.server-ca == '' }}
+      if: ${{ inputs.server == '' && inputs.server-ca == '' }}
       uses: actions/checkout@v4
       with:
-        repository: ${{ steps.prepare.outputs.repository }}
+        repository: ${{ steps.prepare-cluster-cfg.outputs.repository }}
         path: ./cluster-cfg-repo
     - name: auth
       id: auth
@@ -100,8 +121,10 @@ runs:
         server="${{ inputs.server }}"
         server_ca="${{ inputs.server-ca }}"
 
-        if [ -z "${server}" -o -z ${server_ca} ]; then
-          cluster_cfg_file="./cluster-cfg-repo/${{ steps.prepare.outputs.path }}"
+        if [ -n "${server}" -a -z ${server_ca} ]; then
+          server_ca="${{ steps.prepare-server-ca.outputs.server_ca }}"
+        elif [ -z "${server}" -a -z ${server_ca} ]; then
+          cluster_cfg_file="./cluster-cfg-repo/${{ steps.prepare-cluster-cfg.outputs.path }}"
           server=$(cat $cluster_cfg_file | yq .api)
           server_ca=$(cat $cluster_cfg_file | yq .ca)
         fi

--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -34,9 +34,6 @@ inputs:
     default: gardener
     description: |
       the audience to request during OIDC-flow
-  oidc-user:
-    type: string
-    default: gha
   kubeconfig-path:
     type: string
     default: kubeconfig.yaml
@@ -166,12 +163,12 @@ runs:
           - name: gha
             context:
               cluster: cluster
-              user: ${{ inputs.oidc-user }}
+              user: gha
         current-context: gha
         kind: Config
         preferences: {}
         users:
-          - name: ${{ inputs.oidc-user }}
+          - name: gha
             user:
               token: ${auth_token}
         EOF

--- a/.github/workflows/run-testmachinery-tests.yaml
+++ b/.github/workflows/run-testmachinery-tests.yaml
@@ -11,6 +11,7 @@ on:
       k8s-api-endpoint:
         required: false
         type: string
+        default: https://api.tm-os-opensource.core.shoot.canary.k8s-hana.ondemand.com
         description: |
           The URL referring to the k8s-apiserver-endpoint in which the testmachinery-instance to use
           runs. Pipeline-Runs will authenticate against this cluster using OIDC.

--- a/.github/workflows/run-testmachinery-tests.yaml
+++ b/.github/workflows/run-testmachinery-tests.yaml
@@ -28,27 +28,6 @@ on:
         default: https://discovery.ingress.garden.canary.k8s.ondemand.com/projects/core/shoots/751e98f4-a57d-40f7-b8de-e5dbf4f48d2d/cluster-ca
         description: |
           url to the Gardener discovery server to retrieve the Kubernetes server CA
-      cluster-cfg:
-        required: false
-        type: string
-        default: gardener/clusters/testmachinery-canary.yaml
-        description: |
-          Refers to a file located in a GitHub repository containing the k8s-api-endpoint as well as
-          the k8s-api-ca of the cluster in which the testmachinery-instance runs. Pipeline-runs will
-          authenticate against this cluster using OIDC. If the `k8s-api-endpoint` _and_ `k8s-api-ca`
-          inputs are specified as well, those will take precedence over this input parameter.
-
-          The path must adhere to the following format: `<org>/<repo>/<path-to-file.yaml>`.
-
-          The file is expected to have to following format:
-          ```
-          api: <api-url>
-          ca: <base64-encoded-ca>
-          ```
-
-          Note that in case of the default-cluster, only a subset of repositories below
-          https://github.com/gardener is authorised. Runs triggered from forked repositories will
-          also fail, unless `on.pull_request_target` is used as trigger-event.
       kubeconfig-path:
         required: false
         type: string
@@ -115,7 +94,6 @@ jobs:
           server: ${{ inputs.k8s-api-endpoint }}
           server-ca: ${{ inputs.k8s-api-ca }}
           server-ca-discovery-url: ${{ inputs.k8s-api-ca-discovery-url }}
-          cluster-cfg: ${{ inputs.cluster-cfg }}
           kubeconfig-path: ${{ inputs.kubeconfig-path }}
           service-account-name: ${{ inputs.service-account-name }}
           service-account-namespace: ${{ inputs.service-account-namespace }}

--- a/.github/workflows/run-testmachinery-tests.yaml
+++ b/.github/workflows/run-testmachinery-tests.yaml
@@ -22,6 +22,12 @@ on:
       k8s-api-ca:
         required: false
         type: string
+      k8s-api-ca-discovery-url:
+        required: false
+        type: string
+        default: https://discovery.ingress.garden.canary.k8s.ondemand.com/projects/core/shoots/751e98f4-a57d-40f7-b8de-e5dbf4f48d2d/cluster-ca
+        description: |
+          url to the Gardener discovery server to retrieve the Kubernetes server CA
       cluster-cfg:
         required: false
         type: string
@@ -108,6 +114,7 @@ jobs:
         with:
           server: ${{ inputs.k8s-api-endpoint }}
           server-ca: ${{ inputs.k8s-api-ca }}
+          server-ca-discovery-url: ${{ inputs.k8s-api-ca-discovery-url }}
           cluster-cfg: ${{ inputs.cluster-cfg }}
           kubeconfig-path: ${{ inputs.kubeconfig-path }}
           service-account-name: ${{ inputs.service-account-name }}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
