### PR TITLE
Fix double minor version additions in update images GHA

### DIFF
--- a/.github/workflows/update-extension-provider-images.yaml
+++ b/.github/workflows/update-extension-provider-images.yaml
@@ -106,7 +106,7 @@ jobs:
 
           ---
 
-          ### Component Changelogs
+          # Component Changelogs
           This section lists the release notes for all updated components. Please review them for any breaking changes.
 
           ${{ steps.release_notes.outputs.notes_content }}
@@ -123,7 +123,7 @@ jobs:
 
           ---
 
-          ### ✅ Reviewer Checklist
+          # ✅ Reviewer Checklist
           - [ ] I have reviewed the release notes for all updated components.
           - [ ] I have verified that no breaking changes require modifications to our Helm charts or code.
           - [ ] I have confirmed that the changes in \`${{ inputs.images-yaml-path }}\` are correct.


### PR DESCRIPTION
* Only create one update per major.minor version showing the final patch version jump
   The [resulting PR](https://github.com/gardener/gardener-extension-provider-azure/pull/1312/files#diff-e51d05eeffce5a50c817901ecb1255a5d9983271e354384195066b4b906874d1R77) shows
   ```yaml
    - name: cloud-controller-manager
      sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
      repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
      tag: v1.34.0
      labels:
      - name: gardener.cloud/cve-categorisation
        value:
          network_exposure: protected
          authentication_enforced: false
          user_interaction: gardener-operator
          confidentiality_requirement: high
          integrity_requirement: high
          availability_requirement: low
        signing: false
      targetVersion: 1.34.x
   - name: cloud-controller-manager
      sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
      repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
      tag: v1.34.1
      labels:
      - name: gardener.cloud/cve-categorisation
        value:
          network_exposure: protected
          authentication_enforced: false
          user_interaction: gardener-operator
          confidentiality_requirement: high
          integrity_requirement: high
          availability_requirement: low
        signing: false
      targetVersion: '>= 1.34'
   ```
   but it should only add the last of the two image entries since `targetVersion: '>= 1.34'` includes `tag: v1.34.0`.
* Only show final patch version in summary that's used as release notes
   The `release notes` show:
    ```
      - cloud-controller-manager: v1.33.3 -> v1.34.0 (minor)
      - cloud-controller-manager: v1.34.0 -> v1.34.1 (minor)
    ```
    Since `v1.34.0` should not be in `images.yaml`, it's better not to mention it as a minor update, so the code is changed in order to not print the 1st line in such a case. For consistency reasons (and since it makes more sense), the same style is applied to patch updates, so intermediate updates that do not end up in the `images.yaml` are not mentioned anymore.
* Change headings formatting for better readability



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix double minor version additions in update-extension-provider-images action.
```
