### PR TITLE
fix: Deduplicate release notes as part of grouping

### DIFF
--- a/release_notes/model.py
+++ b/release_notes/model.py
@@ -1,5 +1,4 @@
 import collections
-import collections.abc
 import dataclasses
 import enum
 import functools

--- a/release_notes/ocm.py
+++ b/release_notes/ocm.py
@@ -245,10 +245,15 @@ def group_release_notes_docs(
     docs_by_component_id: dict[ocm.ComponentIdentity, rnm.ReleaseNotesDoc] = {}
 
     for doc in release_notes_docs:
-        if doc.component_id in docs_by_component_id:
-            docs_by_component_id[doc.component_id].release_notes.extend(doc.release_notes)
-        else:
+        if doc.component_id not in docs_by_component_id:
             docs_by_component_id[doc.component_id] = doc
+            continue
+
+        release_notes_doc = docs_by_component_id[doc.component_id]
+
+        for release_note in doc.release_notes:
+            if release_note not in release_notes_doc.release_notes:
+                release_notes_doc.release_notes.append(release_note)
 
     return list(docs_by_component_id.values())
 


### PR DESCRIPTION
In case the same OCM component is referenced multiple times by the root component, and all occurrences of this component contain the same upgrade vector, the current logic would group release notes by their component ID, but keep them for every occurence, ultimately causing duplicates. Hence, deduplicate release notes in case they are an exact match.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Deduplicate release notes in case the same OCM component is referenced and upgraded multiple times 
```
