### PR TITLE
fix(release-notes): Prefer author from release-notes again

### DIFF
--- a/release_notes/model.py
+++ b/release_notes/model.py
@@ -242,11 +242,11 @@ class SourceBlock:
         if isinstance(self.source, git.Commit):
             commit_hexsha = self.source.hexsha
             reference = f'[{org}/{repo}@{commit_hexsha}]({repo_url}/commit/{commit_hexsha})'
-            username = self.source.author.name
+            source_username = self.source.author.name
         elif isinstance(self.source, github3.pulls.ShortPullRequest):
             pr_number = self.source.number
             reference = f'[#{pr_number}]({repo_url}/pull/{pr_number})'
-            username = self.source.user.login
+            source_username = self.source.user.login
         else:
             raise ValueError(f'unsupported release-notes source: {type(self.source)=}')
 
@@ -257,7 +257,7 @@ class SourceBlock:
             audience=ReleaseNotesAudience(self.target_group.lower()),
             author=ReleaseNotesAuthor(
                 hostname=hostname,
-                username=username,
+                username=self.author or source_username, # prefer author from release-note
             ),
             reference=reference,
         )


### PR DESCRIPTION
There are automations which cherry-pick commits and merge them via PRs. These include original author information via the release-notes block.

With this fix we make sure to prefer the original author information (again), as it was handled in the Concourse world.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Release-notes for commits cherry-picked and merged by automation will now again be credited to the original author, not the service-user.
```
