### PR TITLE
Expose versionfile/-callback as input for `release` workflow

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -81,6 +81,7 @@ inputs:
     type: string
     description: |
       passed to `version` action as `versionfile`. see this action for documentation
+    required: false
   github-token:
     description: |
       the github-auth-token to use for authenticating against GitHub and OCI-Registry.
@@ -511,6 +512,7 @@ runs:
       id: bump
       uses: gardener/cc-utils/.github/actions/version@master
       with:
+        versionfile: ${{ inputs.version-versionfile }}
         read-callback: ${{ inputs.version-read-callback }}
         write-callback: ${{ inputs.version-write-callback }}
         version-operation: ${{ inputs.next-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,6 +191,21 @@ on:
               os: linux
               arch: x86_64
           ```
+      version-read-callback:
+        type: string
+        required: false
+        description: |
+          passed to `version` action as `read-callback`. see this action for documentation
+      version-write-callback:
+        type: string
+        required: false
+        description: |
+          passed to `version` action as `write-callback`. see this action for documentation
+      version-versionfile:
+        type: string
+        required: false
+        description: |
+          passed to `version` action as `versionfile`. see this action for documentation
       include-subcomponent-release-notes:
         type: boolean
         default: false
@@ -285,6 +300,9 @@ jobs:
           release-on-github: ${{ inputs.release-on-github }}
           github-tag-template: ${{ inputs.github-tag-template }}
           assets: ${{ inputs.assets }}
+          version-read-callback: ${{ inputs.version-read-callback }}
+          version-write-callback: ${{ inputs.version-write-callback }}
+          version-versionfile: ${{ inputs.version-versionfile }}
 
       - name: publish-release-notes-to-slack
         if: ${{ inputs.slack-channel-id != '' }}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
