### PR TITLE
Adapt upgrade PR logic to cope with component reference alias

### DIFF
--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -470,6 +470,7 @@ class ComponentReference(Artifact, LabelMethodsMixin):
         return ComponentIdentity(
             name=self.componentName,
             version=self.version,
+            alias=self.name,
         )
 
 


### PR DESCRIPTION
This PR adapts the upgrade PR logic to cope with component reference `name`, which we introduce as additional property to the `ComponentIdentity` as `alias` (as there is already a property called `name`, referring to the component name).

If the component name is `github.com/gardenlinux/gardenlinux`, we switch to a different schema for upgrade PR titles. Instead of `[ci:component:<component_name>:<version_from>-><version_to>]`, we switch to `[ci:alias:<component_alias>:<version_from>-><version_to>]`. This way, we can distinguish upgrade PRs for `gardenlinux` and `gardenlinux-test` on landscape-dev.

part of https://github.tools.sap/kubernetes/landscape-stability-backlog/issues/468

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt upgrade PR logic to cope with component reference alias
```
