### PR TITLE
fix: Only remove prefix from author if author is set

### DIFF
--- a/release_notes/model.py
+++ b/release_notes/model.py
@@ -299,12 +299,15 @@ def iter_source_blocks(source, content: str) -> tuple[
             if component_name and '|' in component_name:
                 component_name = None
 
+            if author := res.group('author'):
+                author = author.removeprefix('@')
+
             block = SourceBlock(
                 source=source,
                 category=res.group('category'),
                 target_group=res.group('target_group'),
                 note_message=res.group('note'),
-                author=res.group('author').removeprefix('@'),
+                author=author,
                 reference_identifier=res.group('reference_str'),
                 component_name=component_name,
             )


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
