### PR TITLE
allow specifying build-directory

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -111,6 +111,11 @@ on:
           Contained files will be merged recursively into existing directories.
         type: string
         required: false
+      build-directory:
+        description: |
+          relative path to repository-root in which docker-build should be run.
+        type: string
+        default: '.'
       untar-build-ctx-artefact:
         description: |
           If passed, along w/ build-ctx-artefact, the downloaded artefact is assumed to contain
@@ -334,7 +339,7 @@ jobs:
         with:
           outputs: type=docker
           tags: ${{ matrix.args.image-reference }}
-          context: '.'
+          context: ${{ inputs.build-directory }}
           platforms: ${{ matrix.args.platform-name }}
           target: ${{ inputs.target }}
           file: ${{ inputs.dockerfile }}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
ocm-oci-workflow now allows specification of docker-build-directory
```
