### PR TITLE
authenticate prior to installing docker-buildx

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -328,7 +328,6 @@ jobs:
       matrix:
         args: ${{ fromJSON(needs.preprocess.outputs.args) }}
     steps:
-      - uses: docker/setup-buildx-action@v3
       - name: inject-authtoken-for-dockerhub
         id: extra-auth
         shell: bash
@@ -362,6 +361,7 @@ jobs:
           oci-image-reference: ${{ matrix.args.image-reference }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
+      - uses: docker/setup-buildx-action@v3
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false


### PR DESCRIPTION
docker-buildx is retrieved from "Docker-Hub", which is subject to being quota-limited. Hence, run authentication ("docker login") prior to setting up docker-buildx to avoid running into quota-issues.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
