### PR TITLE
ocm overwrite

### DIFF
--- a/cli/gardener_ci/_ocm.py
+++ b/cli/gardener_ci/_ocm.py
@@ -276,6 +276,7 @@ def artefact(
 
 def upload(
     file: str,
+    overwrite: bool=False,
 ):
     with open(file) as f:
         component_descriptor = ocm.ComponentDescriptor.from_dict(
@@ -290,9 +291,15 @@ def upload(
 
     oci_client = ccc.oci.oci_client()
 
+    if overwrite:
+        on_exist = ocm.upload.UploadMode.OVERWRITE
+    else:
+        on_exist = ocm.upload.UploadMode.FAIL
+
     ocm.upload.upload_component_descriptor(
         component_descriptor=component_descriptor,
         oci_client=oci_client,
+        on_exist=on_exist,
     )
 
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`gardener-ci ocm upload` command now features an `--overwrite` flag allowing to replace existing component-descriptors.
```
