### PR TITLE
fix: avoid overwrites of equally-named local-blob-files

### DIFF
--- a/.github/actions/export-ocm-fragments/action.yaml
+++ b/.github/actions/export-ocm-fragments/action.yaml
@@ -191,14 +191,19 @@ runs:
               while chunk := f.read(4096):
                 fhash.update(chunk)
 
-            # symlink, unless file already is named according to its content-hash-digest
+            # mv and symlink, unless file already is named according to its content-hash-digest
+            # (in case of conflicts (same fname added by different jobs), this will still result
+            # in symlinks overwriting each other; however, references in component-descriptor will
+            # be fine, and artefacts will retain original fnames, which is more convenient for
+            # users inspecting them).
             fhashname = f'sha256:{fhash.hexdigest()}'
             if fname != fhashname:
-              os.symlink(fname, fhashname)
+              os.replace(fpath, os.path.join(blobs_dir, fhashname))
+              os.symlink(fhashname, fpath)
               orig_name_to_digest_names[fname] = fhashname
               orig_name_to_digest_names[os.path.join(blobs_dir, fname)] = fhashname
               ocm_tar.add(
-                name=fhashname,
+                name=os.path.join(blobs_dir, fhashname),
                 arcname=f'blobs.d/{fhashname}',
               )
 


### PR DESCRIPTION
If parallel jobs emit files w/ same fname in blobs-directory, those will overwrite each other if merged using `merge-ocm-fragments`-action.

Avoid this by moving local-blob-files to names consisting of their content-hexdigests. For convenience, create a symlink with original name (such that users can still have a more comfortable means to inspect uploaded artefacts; which is why original names were kept before, albeit with inverted logic (symlinks were created, original files were kept)). This will still result in overwrites. However, as local-blob-files are referenced in component-descriptor-fragments using their digest-names, this should not lead to unexpected behaviour.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
export-ocm-fragment will no longer be prone to overwriting local blobs of same name
```
