### PR TITLE
Adjust `S3Access` to OCM spec and turn old one into `LegacyS3Access`

### DIFF
--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -178,6 +178,13 @@ class GithubAccess(Access):
 
 @dc(kw_only=True)
 class S3Access(Access):
+    bucket: str
+    key: str
+    region: str | None = None
+
+
+@dc(kw_only=True)
+class LegacyS3Access(Access):
     bucketName: str
     objectKey: str
     region: str | None = None
@@ -488,6 +495,7 @@ class Resource(Artifact, LabelMethodsMixin):
         | OciAccess
         | RelativeOciAccess
         | S3Access
+        | LegacyS3Access
         | dict
         | None
     )

--- a/ocm/util.py
+++ b/ocm/util.py
@@ -68,6 +68,9 @@ def artifact_url(
         return access.reference
 
     elif isinstance(access, ocm.S3Access):
+        return f'http://{access.bucket}.s3.amazonaws.com/{access.key}'
+
+    elif isinstance(access, ocm.LegacyS3Access):
         return f'http://{access.bucketName}.s3.amazonaws.com/{access.objectKey}'
 
     elif isinstance(access, ocm.LocalBlobGlobalAccess):


### PR DESCRIPTION
See https://github.com/open-component-model/ocm-spec/blob/7bfbc171e814e73d6e95cfa07cc85813f89a1d44/doc/04-extensions/02-access-types/s3.md#v1 for reference.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Adjusted signature of `ocm.S3Access` to OCM spec and turned old signature into `ocm.LegacyS3Access`
```
