### PR TITLE
Allow specification of `ref` for `trusted-checkout` GHA

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -84,6 +84,10 @@ inputs:
     type: string
     description: |
       passed as `repository` input to checkout-action
+  ref:
+    type: string
+    description: |
+      passed as `ref` input to checkout-action
 outputs:
   token:
     description: |
@@ -130,12 +134,14 @@ runs:
         fetch-depth: ${{ inputs.fetch-depth }}
         path: ${{ inputs.path }}
         repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
     - uses: actions/checkout@v4
       if: ${{ inputs.token != '' || steps.token.outputs.token != '' }}
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         path: ${{ inputs.path }}
         repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
         token: ${{ steps.token.outputs.token || inputs.token }}
 
     - name: checkout-submodules


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
