### PR TITLE
fix: only validate artefact-accesses if pipeline-run is privileged

### DIFF
--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -179,7 +179,7 @@ jobs:
           on-validation-errors: ${{ inputs.on-validation-errors }}
           validation-cfg: |
             schema: fail
-            access: fail
+            access: ${{ steps.prep.outputs.can-push == 'true' && 'fail' || 'skip' }}
             artefact-uniqueness: fail
       - name: upload-component-descriptor-to-ocm-repository
         if: ${{ steps.prep.outputs.can-push == 'true' }}


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
