### PR TITLE
avoid parallel usage of {ocm,cnudie}.iter

### DIFF
--- a/cnudie/iter.py
+++ b/cnudie/iter.py
@@ -3,6 +3,12 @@ deprecation note: this package (cnudie.iter) is _deprecated_. Switch to `ocm.ite
 '''
 
 print('Warning: deprecation note. package `cnudie.iter` is deprecated. Switch to `ocm.iter`')
+import sys
+if 'ocm.iter' in sys.module:
+    print(
+        'Error: ocm.iter was already imported - aborting to avoid runtime errors from mixed imports'
+    )
+    exit(1)
 
 import collections.abc
 import dataclasses

--- a/ocm/iter.py
+++ b/ocm/iter.py
@@ -5,6 +5,14 @@ import enum
 import ocm
 import ocm.gardener
 
+import sys
+if 'cnudie.iter' in sys.module:
+    # todo: drop after all known usages of cnudie.iter are gone
+    print(
+      'Error: cnudie.iter was already imported - aborting to avoid runtime errors from mixed imports'
+    )
+    exit(1)
+
 
 class NodeReferenceType(enum.StrEnum):
     COMPONENT_REFERENCE = 'componentReference'


### PR DESCRIPTION
we keep cnudie.iter to be backwards-compatible, such as to allow for incremental migration. However, any usage should be done consistently, as mixing can lead to unexpected behaviour at runtime (e.g. if doing type-comparisons). Hence, add detections for mixed imports, and bail out in such cases.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
