### PR TITLE
Use correct OCI media type for branch info

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -396,11 +396,11 @@ runs:
           ocm.Resource(
             name='branch-info',
             version=component.version,
-            type='vnd.sap/branch-info+yaml',
+            type='application/vnd.gardener.cloud.branch-info+yaml',
             access=ocm.LocalBlobAccess(
               localReference=branch_info_digest,
               size=len(branch_info_bytes),
-              mediaType='vnd.sap/branch-info+yaml',
+              mediaType='application/vnd.gardener.cloud.branch-info+yaml',
             ),
           ),
         )


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
