### PR TITLE
fix: always ignore version-downgrades

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -396,9 +396,9 @@ def create_upgrade_pullrequests(
                     logger.info(f'already at target {cref.componentName} {target=} (skip)')
                     continue
 
-                if tv < cv and upstream_update_policy is not UpstreamUpdatePolicy.STRICTLY_FOLLOW:
+                if tv < cv:
                     logger.info(
-                        f'skip (no downgrade for ACCEPT_HOTFIXES): {cref.componentName} '
+                        f'skip (no downgrades): {cref.componentName} '
                         f'{cref.version=} -> {target=}'
                     )
                     continue


### PR DESCRIPTION
If following an upstream-component, if using `strictly-follow` mode, ocm-upgrade action should force thus-configured upgrade-pipelines to ignore any versions (such as hotfix-versions) that are not referenced from (greatest) version of upstream-component. However, it should never pick-up downgrades.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
