### PR TITLE
Allow overwriting of GH-hostname to determine default Git identity

### DIFF
--- a/.github/actions/setup-git-identity/action.yaml
+++ b/.github/actions/setup-git-identity/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: The Git user email
     required: false
     default: ''
+  github_hostname:
+    description: Overwrite of the GitHub hostname to determine the appropriate default GHA user
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -28,8 +32,12 @@ runs:
           user_email=${{ inputs.user_email }}
 
           if [[ -z "$user_email" ]]; then
-            # determine user email address based on current GH-instance
-            github_host="${GITHUB_SERVER_URL#https://}"
+            github_host=${{ inputs.github_hostname }}
+
+            if [[ -z "$github_host" ]]; then
+              # determine user email address based on current GH-instance
+              github_host="${GITHUB_SERVER_URL#https://}"
+            fi
 
             case "$github_host" in
               github.com*)


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
