### PR TITLE
Early exit after first created upgrade PR (concourse)

### DIFF
--- a/concourse/steps/update_component_deps.mako
+++ b/concourse/steps/update_component_deps.mako
@@ -209,6 +209,15 @@ for component_reference in greatest_component_references:
         # consideration
         upgrade_pull_requests.append(pull_request)
 
+        # early-exit after first created upgrade PR as a workaround (for now) to prevent
+        # unintended sideeffects (e.g. dirty worktree, git conflicts)
+        # -> possible upgrade PRs for other components will be created upon the next execution
+        break
+    else:
+        continue
+
+    break # early-exit (see above)
+
 for upgrade_pull_request in github.pullrequest.iter_obsolete_upgrade_pull_requests(
     list(upgrade_pull_requests)
 ):


### PR DESCRIPTION
Prevent dirty worktree (e.g. untracked files, submodule changes)



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
