### PR TITLE
collapse step-summaries

### DIFF
--- a/.github/actions/base-component-descriptor/action.yaml
+++ b/.github/actions/base-component-descriptor/action.yaml
@@ -242,11 +242,15 @@ runs:
 
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
           f.write(textwrap.dedent(f'''\
-            ## Base-Component-Descriptor
+            <details>
+            <summary>
+             <h2>Base-Component-Descriptor</h2>
+            </summary>
 
             ```
           {textwrap.indent(component_descriptor_str, '  ')}
             ```
+            </details>
           '''))
     - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -237,16 +237,21 @@ runs:
 
         echo "version=${version}" >> $GITHUB_OUTPUT
 
-        echo "## Version-Commit Summary" >> $GITHUB_STEP_SUMMARY
+        echo "<details><summary>" >> $GITHUB_STEP_SUMMARY
+        echo " <h2>Version-Commit Summary</h2>" >> $GITHUB_STEP_SUMMARY
+        echo "</summary>" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
 
         len=$(git show | wc -c)
         if [ $len -gt 4098 ]; then
           # GHA only allows a maximum of 1024 kiB. Let's stay well below this limit, and also avoid
           # spamming build-summary with lengthy diff.
           git log --stat -1 >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
           exit 0
         else
           git show >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
         fi
 
     - name: capture-commit


### PR DESCRIPTION
Outputs from version- and base-component-descriptor-actions will likely only be of interest in a minority of cases (e.g. when analysing related errors). Hence, collable them by default to reduce noise, and take up less space in beginning of step-summaries.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
