### PR TITLE
Fix upgrade-PRs not being closed in case of a stale "whence"-version

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -239,6 +239,7 @@ runs:
           upgrade_pull_requests=upgrade_pullrequests,
           keep_hotfix_versions=True,
           pr_naming_pattern='${{ inputs.pr-naming-pattern }}'
+          reference_component=component,
         ):
           obsolete_pullrequest.purge()
 

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -208,6 +208,7 @@ def iter_obsolete_upgrade_pull_requests(
     upgrade_pull_requests: collections.abc.Iterable[UpgradePullRequest],
     pr_naming_pattern: str='component-name',
     keep_hotfix_versions: bool=True,
+    reference_component: ocm.Component | None=None,
 ) -> collections.abc.Generator[UpgradePullRequest, None, None]:
     grouped_upgrade_pull_requests = collections.defaultdict(list)
 
@@ -240,6 +241,14 @@ def iter_obsolete_upgrade_pull_requests(
     for upgrade_pull_request in upgrade_pull_requests:
         if upgrade_pull_request.pull_request.state != 'open':
             continue
+
+        if reference_component and upgrade_pull_request.is_obsolete(
+            reference_component=reference_component,
+        ):
+            # whence version is already behind current component reference version
+            yield upgrade_pull_request
+            continue
+
         name = group_name(upgrade_pull_request,pr_naming_pattern)
         grouped_upgrade_pull_requests[name].append(upgrade_pull_request)
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Upgrade-PRs are now closed (again) if their "whence"-version is behind the currently referenced component version
```
