### PR TITLE
fix: resolve symlinks for mimetype-detection

### DIFF
--- a/.github/actions/export-ocm-fragments/action.yaml
+++ b/.github/actions/export-ocm-fragments/action.yaml
@@ -246,7 +246,9 @@ runs:
 
           if not 'type' in artefact:
             artefact['type'] = magic.detect_from_filename(
-              os.path.join(blobs_dir, local_ref),
+              os.path.realpath(
+                os.path.join(blobs_dir, local_ref)
+              ),
             ).mime_type
 
         ocm_artefacts_yaml_bytes = yaml.safe_dump(ocm_artefacts).encode('utf-8')


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
export-ocm-fragment would auto-inject `inode/symlink` as mimetype for inline-blobs w/o explicitly-declared type, as an unintended side-effect from a previous change (to avoid clashes between equally-named local-blobfiles).
```
