### PR TITLE
convey friendlier error-message if job lacks permission

### DIFF
--- a/.github/actions/oci-auth/oidc.py
+++ b/.github/actions/oci-auth/oidc.py
@@ -360,8 +360,17 @@ def write_docker_config(
     image_references: collections.abc.Iterable[str],
     extra_auths: dict | None=None,
 ) -> dict:
-    gh_token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
-    gh_token_url = os.environ['ACTIONS_ID_TOKEN_REQUEST_URL']
+    try:
+        gh_token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+        gh_token_url = os.environ['ACTIONS_ID_TOKEN_REQUEST_URL']
+    except KeyError:
+        print('Error: the following environment-variables are not set:')
+        print('- ACTIONS_ID_TOKEN_REQUEST_TOKEN')
+        print('- ACTIONS_ID_TOKEN_REQUEST_URL')
+        print()
+        print('This typically indicates the job was not run with needed permission:')
+        print('  id-token: write')
+        exit(1)
 
     auths = {}
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
print friendler error-message if oci-auth-action is used in a job that misses `id-token: write`-permission.
```
