### PR TITLE
Consistently support `RELATIVE_OCI_REFERENCE` access type in CTT

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -520,7 +520,10 @@ def iter_replication_resource_elements(
         (component_descriptor.component, resource)
         for component_descriptor in component_descriptors
         for resource in component_descriptor.component.resources
-        if resource.access.type is ocm.AccessType.OCI_REGISTRY
+        if resource.access.type in (
+            ocm.AccessType.OCI_REGISTRY,
+            ocm.AccessType.RELATIVE_OCI_REFERENCE,
+        )
     ]
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=16)

--- a/ctt/uploaders.py
+++ b/ctt/uploaders.py
@@ -59,8 +59,12 @@ class PrependTargetUploader(UploaderBase):
         tgt_oci_registry: str,
         target_as_source: bool=False,
     ) -> ctt.model.ReplicationResourceElement:
-        if replication_resource_element.source.access.type is not ocm.AccessType.OCI_REGISTRY:
-            raise RuntimeError(f'PrependTargetUploader only supports {ocm.AccessType.OCI_REGISTRY=}')
+        supported_access_types = (
+            ocm.AccessType.OCI_REGISTRY,
+            ocm.AccessType.RELATIVE_OCI_REFERENCE,
+        )
+        if replication_resource_element.source.access.type not in supported_access_types:
+            raise RuntimeError(f'PrependTargetUploader only supports {supported_access_types=}')
 
         if not target_as_source:
             src_ref = replication_resource_element.src_ref
@@ -131,8 +135,12 @@ class RepositoryUploader(UploaderBase):
         tgt_oci_registry: str,
         target_as_source: bool=False,
     ) -> ctt.model.ReplicationResourceElement:
-        if replication_resource_element.source.access.type is not ocm.AccessType.OCI_REGISTRY:
-            raise RuntimeError(f'RepositoryUploader only supports {ocm.AccessType.OCI_REGISTRY=}')
+        supported_access_types = (
+            ocm.AccessType.OCI_REGISTRY,
+            ocm.AccessType.RELATIVE_OCI_REFERENCE,
+        )
+        if replication_resource_element.source.access.type not in supported_access_types:
+            raise RuntimeError(f'RepositoryUploader only supports {supported_access_types=}')
 
         if not target_as_source:
             src_ref = replication_resource_element.src_ref


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Consistently support `RELATIVE_OCI_REFERENCE` access type in CTT
```
