### PR TITLE
Sort and group release note category entries by audience

### DIFF
--- a/release_notes/model.py
+++ b/release_notes/model.py
@@ -70,6 +70,15 @@ class ReleaseNotesAudience(enum.StrEnum):
     OPERATOR = 'operator'
     USER = 'user'
 
+    @staticmethod
+    def audience_priority(audience: typing.Self) -> int:
+        return {
+            ReleaseNotesAudience.OPERATOR: 0,
+            ReleaseNotesAudience.USER: 1,
+            ReleaseNotesAudience.DEVELOPER: 2,
+            ReleaseNotesAudience.DEPENDENCY: 3,
+        }[audience]
+
 
 class AuthorType(enum.StrEnum):
     GITHUB_USER = 'githubUser'
@@ -151,12 +160,15 @@ class ReleaseNotesDoc:
         )
 
         for category in sorted_categories:
-            release_notes = categorised_release_notes[category]
+            sorted_release_notes = sorted(
+                categorised_release_notes[category],
+                key=lambda rn: ReleaseNotesAudience.audience_priority(rn.audience)
+            )
             title = ReleaseNotesCategory.category_title(category)
 
             block_lines = [f'## {title}']
 
-            for release_note in release_notes:
+            for release_note in sorted_release_notes:
                 release_note: ReleaseNoteEntry
                 author = f'@{release_note.author.username}'
                 audience = release_note.audience.name


### PR DESCRIPTION
**Before**:

```
# [luca-gardener-dev:v24.0.0]

## ✨ New Features
- `[OPERATOR]` I am a release note by @luca-gardener-dev [None]
- `[DEVELOPER]` I am a release note by @luca-gardener-dev [None]
- `[USER]` I am a release note by @luca-gardener-dev [None]
- `[OPERATOR]` I am a release note by @luca-gardener-dev [None]
```

**After**:

```
# [luca-gardener-dev:v24.0.0]

## ✨ New Features
- `[OPERATOR]` I am a release note by @luca-gardener-dev [None]
- `[OPERATOR]` I am a release note by @luca-gardener-dev [None]
- `[USER]` I am a release note by @luca-gardener-dev [None]
- `[DEVELOPER]` I am a release note by @luca-gardener-dev [None]
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Release notes within one category are now grouped and sorted by audience.
```
