### PR TITLE
Drop `component-diff` output from equally named GitHub workflow/action

### DIFF
--- a/.github/actions/component-diff/action.yaml
+++ b/.github/actions/component-diff/action.yaml
@@ -25,11 +25,6 @@ outputs:
     description: |
       Indicates whether (at least) one of the component dependency versions has changed.
     value: ${{ steps.component-diff.outputs.has-diff }}
-  component-diff:
-    description: |
-      The determined component diff between the current and the greatest version, structured
-      according to `cnudie.util.ComponentDiff`.
-    value: ${{ steps.component-diff.outputs.component-diff }}
 
 runs:
   using: composite
@@ -112,17 +107,8 @@ runs:
             '''))
             sys.exit(0)
 
-        component_diff_str = yaml.dump(
-            data=component_diff,
-            Dumper=ocm.EnumValueYamlDumper,
-        )
-        print(component_diff_str)
-
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
           f.write('has-diff=true\n')
-          f.write('component-diff<<EOF\n')
-          f.write(component_diff_str)
-          f.write('EOF\n')
 
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
           f.write(textwrap.dedent(f'''\

--- a/.github/workflows/component-diff.yaml
+++ b/.github/workflows/component-diff.yaml
@@ -23,11 +23,6 @@ on:
         description: |
           Indicates whether (at least) one of the component dependency versions has changed.
         value: ${{ jobs.component-diff.outputs.has-diff }}
-      component-diff:
-        description: |
-          The determined component diff between the current and the greatest version, structured
-          according to `cnudie.util.ComponentDiff`.
-        value: ${{ jobs.component-diff.outputs.component-diff }}
 
 jobs:
   component-diff:
@@ -37,7 +32,6 @@ jobs:
       id-token: write
     outputs:
       has-diff: ${{ steps.component-diff.outputs.has-diff }}
-      component-diff: ${{ steps.component-diff.outputs.component-diff }}
     steps:
       - uses: actions/checkout@v4
       - name: collect-component-descriptor


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Dropped the `component-diff` output from equally named GitHub workflow/action
```
