### PR TITLE
allow passing-in static authtoken into oci-ocm workflow

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -45,6 +45,16 @@ on:
         description: |
           A comma-separated list of additional tags to set. Existing tags will be updated.
           Commonly used to reset `latest`-tag.
+      auth-token:
+        type: string
+        required: false
+        description: |
+          An optional authtoken to use for authenticating against push-target. It is written
+          unchanged into `$HOME/.docker/config.json`, and is assumed to be base64-encoded output of
+          `<username>:<secret>`.
+
+          Note that it is only necessary to pass an auth-token if OIDC-authentication is not
+          possible. OIDC-Authentication should be preferred over using a static token.
       oci-platforms-to-runners-map:
         type: string
         description: |
@@ -338,8 +348,7 @@ jobs:
           if [ -z '${{ secrets.DOCKERHUB_RO_AUTH }}' ]; then
             exit 0
           fi
-          echo 'extra-auths<<EOF' >> "${GITHUB_OUTPUT}"
-          cat <<EOF >> "${GITHUB_OUTPUT}"
+          cat <<EOF >> /tmp/config.json
           {
             "registry-1.docker.io": {
               "auth": "${{ secrets.DOCKERHUB_RO_AUTH }}"
@@ -355,6 +364,16 @@ jobs:
             }
           }
           EOF
+          echo 'extra-auths<<EOF' >> "${GITHUB_OUTPUT}"
+          if ${{ inputs.auth-token != '' }}; then
+            target_host=$(echo '${{ matrix.args.image-reference }}' | cut -d/ -f1)
+            jq \
+              "setpath([\"$target_host\"], {\"auth\": \"${{ inputs.auth-token }}\"})" \
+              /tmp/config.json \
+              >> "${GITHUB_OUTPUT}"
+          else
+            cat /tmp/config.json >> "${GITHUB_OUTPUT}"
+          fi
           echo EOF >> "${GITHUB_OUTPUT}"
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
         continue-on-error: true # successful auth might not be required
@@ -428,11 +447,21 @@ jobs:
       id-token: write
     steps:
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+      - name: inject-authtoken
+        if: ${{ inputs.auth-token != '' }}
+        id: extra-auth
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname=$(echo ${{ needs.preprocess.outputs.target-image-ref }} | cut -d/ -f1 )
+          echo "extra-auths={\"$hostname\": {\"auth\": \"${{ inputs.auth-token }}\" }}" \
+            >> $GITHUB_OUTPUT
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
         if: ${{ needs.preprocess.outputs.push == 'true' }}
         with:
           oci-image-reference: ${{ needs.preprocess.outputs.target-image-ref }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
       - name: collect-images
         id: collect-images
         shell: python


### PR DESCRIPTION
Allow callers to pass-in a prepared authtoken for authing against push-target's registry (limited to hostname, as imposed by dockerd). This is needed in cases where OIDC against target-registry is not possible.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
oci-ocm-workflow now allows passing-in of static authtokens
```
