### PR TITLE
Add GITHUB_TOKEN to cleanup-release-branches action

### DIFF
--- a/.github/actions/cleanup-release-branches/action.yaml
+++ b/.github/actions/cleanup-release-branches/action.yaml
@@ -3,6 +3,7 @@ description: |
   Deletes stale release branches in the remote git repository. A release branch is considered stale
   if its version (major, minor, or patch, according to `significant-part` in `.ocm/branch-info.yaml`)
   is older than the current version by at least the `supported-versions-count`.
+  Requires `contents: write` permissions in the calling workflow. 
 
 inputs:
   version:
@@ -22,6 +23,8 @@ runs:
   steps:
     - name: Cleanup Release Branches
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Fixes https://github.com/gardener/cc-utils/issues/1464


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
