### PR TITLE
also collapse version-commit-details by default

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -101,20 +101,30 @@ runs:
 
         if [ "${summary_kind}" == 'full' ]; then
         cat << EOF > ${GITHUB_STEP_SUMMARY}
-        ## Capture-Commit Summary
+        <details>
+          <summary>
+            <h2>Capture-Commit Summary</h2>
+          </summary>
+
         commit-digest: \`$(cat ${commit_out})\`
         objects-listing (tarfile):
         $(tar tf ${objects_out})
         commit-message:
         $(git show)
+        </details>
         EOF
 
         elif [ "${summary_kind}" == 'short' ]; then
         cat << EOF > ${GITHUB_STEP_SUMMARY}
-        ## Capture-Commit Summary
+        <details>
+          <summary>
+            <h2>Capture-Commit Summary</h2>
+          </summary>
+
         commit-digest: \`$(cat ${commit_out})\`
         objects-listing (tarfile):
         $(tar tf ${objects_out})
+        </details>
         EOF
 
         elif [ "${summary_kind}" == 'none' ]; then


### PR DESCRIPTION
Details about version-commit will in the majority of cases not be of interest. Hence collable them (by default) to reduce noise.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
