### PR TITLE
Improve pinning

### DIFF
--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -2,8 +2,8 @@ name: Install Gardener-GHA-Libs
 description: |
   Install Python3 and gardener-gha-libs
 
-  As GitHub-Actions in https://github.com/gardener/cc-utils still sees frequent development,
-  install from sources (checking out head of `master`), rather than from PYPI.
+  Sources are installed from the `v1` branch of cc-utils (pinned to a specific
+  commit digest on the pinned branch by the pin-actions-and-workflows action).
 
 runs:
   using: composite
@@ -19,6 +19,7 @@ runs:
       if: ${{ ! steps.check.outputs.already-installed && github.server_url == 'https://github.com' }}
       with:
         repository: gardener/cc-utils
+        ref: v1
         path: cc-utils
     - name: setup-python-on-ghe
       if: ${{ ! steps.check.outputs.already-installed && github.server_url != 'https://github.com' }}
@@ -39,7 +40,7 @@ runs:
       run: |
         set -euo pipefail
         # fallback if running on GHE
-        git clone https://github.com/gardener/cc-utils
+        git clone --branch v1 https://github.com/gardener/cc-utils
     - name: install-gardener-gha-libs
       if: ${{ ! steps.check.outputs.already-installed }}
       shell: bash

--- a/.github/actions/pin-actions-and-workflows/README.md
+++ b/.github/actions/pin-actions-and-workflows/README.md
@@ -58,7 +58,9 @@ runs `pin.py`, which:
 2. Processes files in topological order (leaves first), so that when a file is
    rewritten, all files it references have already been assigned a pinned digest.
 3. For each file whose cross-references need rewriting, creates a minimal commit
-   containing only that file's change.
+   containing only that file's change. This covers both `uses:` references to
+   own actions/workflows and `ref:` fields in `actions/checkout` steps that check
+   out the own repository (e.g. `install-gardener-gha-libs`).
 4. Force-pushes the resulting commit chain to the target branch (`v1`).
 5. Creates a preservation ref at `refs/tags/fixated/<own-commit-digest>` to prevent the
    tip commit from being garbage-collected after future force-pushes.

--- a/.github/actions/pin-actions-and-workflows/pin.py
+++ b/.github/actions/pin-actions-and-workflows/pin.py
@@ -167,6 +167,23 @@ def _iter_step_uses(parsed: dict):
                     yield step, 'uses'
 
 
+def _iter_steps(parsed: dict):
+    '''Yield all step dicts from composite actions and workflows.'''
+    runs = parsed.get('runs')
+    if isinstance(runs, dict):
+        for step in (runs.get('steps') or []):
+            if isinstance(step, dict):
+                yield step
+    jobs = parsed.get('jobs')
+    if isinstance(jobs, dict):
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            for step in (job.get('steps') or []):
+                if isinstance(step, dict):
+                    yield step
+
+
 def _extract_internal_deps(
     parsed: dict,
     *,
@@ -231,11 +248,13 @@ def _rewrite_parsed(
     *,
     own_org: str,
     own_repo: str,
+    own_digest: str,
     prefix_to_digest: dict[str, str],
     repo: gitpython.Repo,
 ) -> bool:
     '''
     Rewrite all own `uses:` values in-place from @<branch> to @<commit-digest>.
+    Also rewrites `ref:` in `actions/checkout` steps that check out own repo.
     Returns True if any changes were made.
     '''
     own_prefix = f'{own_org}/{own_repo}/'
@@ -256,6 +275,22 @@ def _rewrite_parsed(
             logger.warning('No pinned digest found for %s — leaving unchanged', dep_prefix)
             continue
         step[key] = f'{own_prefix}{dep_prefix}@{digest}'
+        changed = True
+
+    # also pin `ref:` in actions/checkout steps that check out own repo
+    for step in _iter_steps(parsed):
+        uses = step.get('uses', '')
+        if not isinstance(uses, str) or not uses.startswith('actions/checkout@'):
+            continue
+        with_block = step.get('with')
+        if not isinstance(with_block, dict):
+            continue
+        if with_block.get('repository') != f'{own_org}/{own_repo}':
+            continue
+        ref = with_block.get('ref', '')
+        if not isinstance(ref, str) or _is_pinned(ref, repo):
+            continue
+        with_block['ref'] = own_digest
         changed = True
 
     return changed
@@ -331,6 +366,7 @@ def create_pinned_branch(
                     parsed,
                     own_org=own_org,
                     own_repo=own_repo,
+                    own_digest=own_digest,
                     prefix_to_digest=prefix_to_digest,
                     repo=repo,
                 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
cc-util's "install-gardener-gha-libs" action and instrumentations of it now also pin pythoncode installed from cc-utils by commit-digest (along with pinning cross-references to actions and workflows).
```
