### PR TITLE
oci-ocm: generate SBOM and push as OCI referrer

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -197,6 +197,13 @@ on:
         default: false
         description: |
           Set to true to suppress emission of an OCM-Resource fragment via export-ocm-fragments.
+      generate-sbom:
+        type: boolean
+        default: true
+        required: false
+        description: |
+          Whether to generate an SPDX SBOM for each built image and push it as an OCI referrer
+          manifest alongside the image. Requires the image to have been pushed (`push != never`).
     secrets:
       auth-token:
         required: false
@@ -472,6 +479,41 @@ jobs:
         run: |
           set -eu
           docker push ${{ matrix.args.image-reference }}
+
+      - name: 'generate SBOM / ${{ matrix.args.platform-name }}'
+        if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ matrix.args.image-reference }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+        if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
+
+      - name: 'push SBOM referrer / ${{ matrix.args.platform-name }}'
+        if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
+        shell: python
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          import oci.auth
+          import oci.client
+          import oci.sbom
+
+          oci_client = oci.client.Client(
+              credentials_lookup=oci.auth.docker_credentials_lookup(),
+          )
+
+          referrer_digest = oci.sbom.push_sbom_referrer(
+              sbom_path='sbom.spdx.json',
+              image_reference='${{ matrix.args.image-reference }}',
+              oci_client=oci_client,
+          )
+
+          print(f'SBOM referrer pushed: {referrer_digest}')
 
   collect-images:
     needs:

--- a/oci/model.py
+++ b/oci/model.py
@@ -349,6 +349,10 @@ class OciImageManifest:
     mediaType: str = OCI_MANIFEST_SCHEMA_V2_MIME
     schemaVersion: int = 2
     annotations: dict = dataclasses.field(default_factory=dict)
+    # OCI 1.1: identifies the image this manifest refers to (used for referrers / attached artefacts)
+    subject: 'OciBlobRef | None' = None
+    # OCI 1.1: media-type of the artefact described by this manifest (e.g. 'application/spdx+json')
+    artifactType: str | None = None
 
     def as_dict(self) -> dict:
         def layer_to_dict(layer):
@@ -357,13 +361,18 @@ class OciImageManifest:
             else:
                 return layer.as_dict()
 
-        return {
+        raw = {
             'config': self.config.as_dict(),
             'layers': [layer_to_dict(layer) for layer in self.layers],
             'mediaType': self.mediaType,
             'schemaVersion': self.schemaVersion,
             'annotations': self.annotations,
         }
+        if self.subject is not None:
+            raw['subject'] = self.subject.as_dict()
+        if self.artifactType is not None:
+            raw['artifactType'] = self.artifactType
+        return raw
 
     def blobs(self) -> collections.abc.Generator[OciBlobRef, None, None]:
         yield self.config

--- a/oci/sbom.py
+++ b/oci/sbom.py
@@ -1,0 +1,120 @@
+'''
+Utilities for pushing SBOM documents as OCI referrers (OCI 1.1).
+
+An SBOM is stored as a single-layer OCI manifest whose `subject` field points
+to the image it describes.  The referrer manifest is pushed by digest; registries
+that implement the OCI 1.1 referrers API expose it via GET /v2/<repo>/referrers/<digest>.
+'''
+import hashlib
+import json
+import logging
+
+import oci.client as oc
+import oci.model as om
+
+logger = logging.getLogger(__name__)
+
+# empty JSON object — used as the config blob for non-image OCI artefacts
+_EMPTY_CONFIG = b'{}'
+_EMPTY_CONFIG_DIGEST = f'sha256:{hashlib.sha256(_EMPTY_CONFIG).hexdigest()}'
+
+SPDX_JSON_MEDIA_TYPE = 'application/spdx+json'
+OCI_EMPTY_CONFIG_MEDIA_TYPE = 'application/vnd.oci.empty.v1+json'
+
+
+def push_sbom_referrer(
+    sbom_path: str,
+    image_reference: str | om.OciImageReference,
+    oci_client: oc.Client,
+    sbom_media_type: str = SPDX_JSON_MEDIA_TYPE,
+) -> str:
+    '''
+    Push an SBOM file as an OCI referrer manifest for the given image.
+
+    The SBOM blob is pushed as the single layer of a new OCI manifest; the
+    manifest's `subject` is set to the digest-addressed descriptor of the
+    target image, establishing the referrer relationship.
+
+    Returns the digest of the pushed referrer manifest.
+    '''
+    image_ref = om.OciImageReference.to_image_ref(image_reference)
+
+    # resolve to digest so subject.digest is canonical
+    digest_ref = oci_client.to_digest_hash(image_ref)
+    # to_digest_hash returns a full ref like repo@sha256:...
+    digest_image_ref = om.OciImageReference.to_image_ref(digest_ref)
+    subject_digest = digest_image_ref.tag  # 'sha256:<hex>'
+
+    # retrieve the manifest to get its size and mediaType for the subject descriptor
+    manifest_raw_res = oci_client.manifest_raw(digest_image_ref)
+    manifest_bytes_for_subject = manifest_raw_res.content
+    subject_media_type = manifest_raw_res.headers.get('Content-Type', om.OCI_MANIFEST_SCHEMA_V2_MIME)
+    subject_size = len(manifest_bytes_for_subject)
+
+    with open(sbom_path, 'rb') as f:
+        sbom_bytes = f.read()
+
+    sbom_digest = f'sha256:{hashlib.sha256(sbom_bytes).hexdigest()}'
+    sbom_size = len(sbom_bytes)
+    repo_ref = image_ref.ref_without_tag  # push blobs/manifest to same repo
+
+    logger.info(f'pushing SBOM blob {sbom_digest} ({sbom_size} bytes) to {repo_ref}')
+    oci_client.put_blob(
+        image_reference=repo_ref,
+        digest=sbom_digest,
+        octets_count=sbom_size,
+        data=sbom_bytes,
+        mimetype=sbom_media_type,
+    )
+
+    # empty config blob (required by OCI image manifest structure)
+    oci_client.put_blob(
+        image_reference=repo_ref,
+        digest=_EMPTY_CONFIG_DIGEST,
+        octets_count=len(_EMPTY_CONFIG),
+        data=_EMPTY_CONFIG,
+        mimetype=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+    )
+
+    referrer_manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest=_EMPTY_CONFIG_DIGEST,
+            mediaType=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+            size=len(_EMPTY_CONFIG),
+        ),
+        layers=[
+            om.OciBlobRef(
+                digest=sbom_digest,
+                mediaType=sbom_media_type,
+                size=sbom_size,
+            ),
+        ],
+        subject=om.OciBlobRef(
+            digest=subject_digest,
+            mediaType=subject_media_type,
+            size=subject_size,
+        ),
+        artifactType=sbom_media_type,
+        annotations={
+            'org.opencontainers.image.created': _utcnow_iso(),
+        },
+    )
+
+    referrer_manifest_bytes = json.dumps(referrer_manifest.as_dict()).encode()
+    referrer_digest = f'sha256:{hashlib.sha256(referrer_manifest_bytes).hexdigest()}'
+
+    # push manifest addressed by digest (no symbolic tag needed for referrers API)
+    referrer_ref = f'{repo_ref}@{referrer_digest}'
+    logger.info(f'pushing SBOM referrer manifest to {referrer_ref}')
+    oci_client.put_manifest(
+        image_reference=referrer_ref,
+        manifest=referrer_manifest_bytes,
+    )
+
+    logger.info(f'SBOM referrer pushed: {referrer_digest}')
+    return referrer_digest
+
+
+def _utcnow_iso() -> str:
+    import datetime
+    return datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
https://github.com/gardener/cc-utils/issues/1467

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The oci-ocm build pipeline now generates an SPDX SBOM (via anchore/sbom-action) and pushes it as an OCI 1.1 referrer manifest alongside built images.
```