### PR TITLE
Improve GitHub auths resilience

### DIFF
--- a/.github/actions/github-auth/action.yaml
+++ b/.github/actions/github-auth/action.yaml
@@ -101,84 +101,15 @@ runs:
         echo "repositories=${repositories}" >> "$GITHUB_OUTPUT"
         echo "permissions=${permissions}" >> "$GITHUB_OUTPUT"
 
-    - name: Create OIDC token
-      id: create-oidc-token
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        token_request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
-        token_request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
-
-        if [ -z "${token_request_url}" ]; then
-          echo "ERROR: ACTIONS_ID_TOKEN_REQUEST_URL was not passed."
-          echo 'That typically means this workflow was not run with `id-token: write`-permission'
-          exit 1
-        fi
-
-        if [ -z "${token_request_token}" ]; then
-          echo "ERROR: ACTIONS_ID_TOKEN_REQUEST_TOKEN was not passed."
-          echo 'That typically means this workflow was not run with `id-token: write`-permission'
-          exit 1
-        fi
-
-        out_path="/tmp/resp.json"
-
-        resp=$(curl -sLS \
-          -H "Authorization: Bearer ${token_request_token}" \
-          -w "%{http_code}" \
-          -o "${out_path}" \
-          "${token_request_url}&audience=${{ inputs.audience }}"
-        )
-
-        if [[ "${resp}" -lt 200 || "${resp}" -ge 300 ]]; then
-          echo "ERROR: Failed to retrieve a GitHub identity-token"
-          cat "${out_path}"
-          exit 1
-        fi
-
-        id_token=$(cat "${out_path}" | jq -r .value)
-
-        if [ -z "${id_token}" ]; then
-          echo "ERROR: Failed to retrieve a GitHub identity-token"
-          exit 1
-        fi
-
-        echo "token=${id_token}" >> "$GITHUB_OUTPUT"
-
-    - name: Exchange ID Token for GitHub access token
+    - name: Retrieve GitHub access token
       id: token
       shell: bash
       run: |
         set -euo pipefail
-
-        out_path="/tmp/resp.json"
-        payload='{
-          "host": "${{ steps.preprocess.outputs.host }}",
-          "organization": "${{ steps.preprocess.outputs.organization }}",
-          "token": "${{ steps.create-oidc-token.outputs.token }}",
-          "repositories": ${{ steps.preprocess.outputs.repositories }},
-          "permissions": ${{ steps.preprocess.outputs.permissions }}
-        }'
-
-        echo "Payload: ${payload}"
-
-        sleep 1s # ensure the token's iat is not in the future
-
-        resp=$(curl -sLS \
-          -H "Content-Type: application/json" \
-          -w "%{http_code}" \
-          -o "${out_path}" \
-          -d "${payload}" \
-          "${{ inputs.token-server }}/token-exchange"
-        )
-
-        if [[ "${resp}" -lt 200 || "${resp}" -ge 300 ]]; then
-          echo "ERROR: Failed to retrieve GitHub token"
-          cat "${out_path}"
-          exit 1
-        fi
-
-        token=$(cat "${out_path}" | jq -r .token)
-
-        echo "token=${token}" >> "$GITHUB_OUTPUT"
+        python3 "${{ github.action_path }}/get-token.py" \
+          --token-server "${{ inputs.token-server }}" \
+          --audience "${{ inputs.audience }}" \
+          --host "${{ steps.preprocess.outputs.host }}" \
+          --organization "${{ steps.preprocess.outputs.organization }}" \
+          --repositories '${{ steps.preprocess.outputs.repositories }}' \
+          --permissions '${{ steps.preprocess.outputs.permissions }}'

--- a/.github/actions/github-auth/get-token.py
+++ b/.github/actions/github-auth/get-token.py
@@ -142,7 +142,7 @@ def main():
 
     token_server = args.token_server
     if '://' not in token_server:
-        token_server = f'http://{token_server}'
+        token_server = f'https://{token_server}'
 
     id_token = get_oidc_token(request_url, request_token, args.audience)
     token = exchange_token(

--- a/.github/actions/github-auth/get-token.py
+++ b/.github/actions/github-auth/get-token.py
@@ -40,22 +40,60 @@ _opener = urllib.request.build_opener(
 )
 
 
+def _open_with_retry(
+    req: urllib.request.Request,
+    timeout_seconds: int = 30,
+    retries: int = 4,
+    backoff_base: float = 2.0,
+) -> dict:
+    '''Open a request, retrying on transient errors with exponential backoff.
+
+    4xx responses are treated as systematic failures and are not retried.
+    '''
+    url = req.full_url
+    for attempt in range(retries + 1):
+        try:
+            with _opener.open(req, timeout=timeout_seconds) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode()
+            if e.code < 500 and e.code not in (408, 429):
+                # 4xx (except 408/429): systematic – retrying won't help
+                print(f'ERROR: HTTP {e.code} from {url}:\n{body}', file=sys.stderr)
+                sys.exit(1)
+            if attempt == retries:
+                print(
+                    f'ERROR: HTTP {e.code} from {url} (gave up after {retries} retries):\n{body}',
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            delay = backoff_base ** attempt
+            print(
+                f'WARNING: HTTP {e.code} from {url}, '
+                f'retrying in {delay:.0f}s ({attempt + 1}/{retries})...',
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+        except urllib.error.URLError as e:
+            if attempt == retries:
+                print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
+                sys.exit(1)
+            delay = backoff_base ** attempt
+            print(
+                f'WARNING: Request to {url} failed: {e.reason}, '
+                f'retrying in {delay:.0f}s ({attempt + 1}/{retries})...',
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+
 def http_get(
     url: str,
     headers: dict | None = None,
     timeout_seconds: int = 30,
 ) -> dict:
     req = urllib.request.Request(url, headers=headers or {})
-    try:
-        with _opener.open(req, timeout=timeout_seconds) as resp:
-            return json.load(resp)
-    except urllib.error.HTTPError as e:
-        body = e.read().decode()
-        print(f'ERROR: HTTP {e.code} from {url}:\n{body}', file=sys.stderr)
-        sys.exit(1)
-    except urllib.error.URLError as e:
-        print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
-        sys.exit(1)
+    return _open_with_retry(req, timeout_seconds)
 
 
 def http_post(
@@ -69,16 +107,7 @@ def http_post(
         data=data,
         headers={'Content-Type': 'application/json'},
     )
-    try:
-        with _opener.open(req, timeout=timeout_seconds) as resp:
-            return json.load(resp)
-    except urllib.error.HTTPError as e:
-        body = e.read().decode()
-        print(f'ERROR: HTTP {e.code} from {url}:\n{body}', file=sys.stderr)
-        sys.exit(1)
-    except urllib.error.URLError as e:
-        print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
-        sys.exit(1)
+    return _open_with_retry(req, timeout_seconds)
 
 
 def get_oidc_token(

--- a/.github/actions/github-auth/get-token.py
+++ b/.github/actions/github-auth/get-token.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+class _MethodPreservingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    '''Follow 307/308 redirects preserving method and body (urllib drops both by default).'''
+    def http_error_307(self, req, fp, code, msg, headers):
+        new_req = urllib.request.Request(
+            headers['Location'],
+            data=req.data,
+            headers=req.headers,
+            method=req.get_method(),
+        )
+        return self.parent.open(new_req)
+
+    http_error_308 = http_error_307
+
+
+def _ssl_ctx() -> ssl.SSLContext:
+    # Explicitly load system CA bundle so custom CAs installed on the runner are trusted.
+    # Python may otherwise use a bundled store that predates any runner-installed certs.
+    cafile = (
+        os.environ.get('SSL_CERT_FILE')
+        or ssl.get_default_verify_paths().cafile
+        or '/etc/ssl/certs/ca-certificates.crt'
+    )
+    return ssl.create_default_context(cafile=cafile)
+
+
+_opener = urllib.request.build_opener(
+    _MethodPreservingRedirectHandler,
+    urllib.request.HTTPSHandler(context=_ssl_ctx()),
+)
+
+
+def http_get(
+    url: str,
+    headers: dict | None = None,
+    timeout_seconds: int = 30,
+) -> dict:
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with _opener.open(req, timeout=timeout_seconds) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f'ERROR: HTTP {e.code} from {url}:\n{body}', file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
+        sys.exit(1)
+
+
+def http_post(
+    url: str,
+    payload: dict,
+    timeout_seconds: int = 30,
+) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={'Content-Type': 'application/json'},
+    )
+    try:
+        with _opener.open(req, timeout=timeout_seconds) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f'ERROR: HTTP {e.code} from {url}:\n{body}', file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
+        sys.exit(1)
+
+
+def get_oidc_token(
+    request_url: str,
+    request_token: str,
+    audience: str,
+) -> str:
+    url = f'{request_url}&audience={audience}'
+    data = http_get(url, headers={'Authorization': f'Bearer {request_token}'})
+    return data['value']
+
+
+def exchange_token(
+    token_server: str,
+    host: str,
+    organization: str,
+    id_token: str,
+    repositories: str,
+    permissions: str,
+) -> str:
+    time.sleep(1)  # ensure token's iat is not in the future
+    payload = {
+        'host': host,
+        'organization': organization,
+        'token': id_token,
+        'repositories': json.loads(repositories),
+        'permissions': json.loads(permissions),
+    }
+    print(f'Payload: {json.dumps(payload)}')
+    data = http_post(f'{token_server}/token-exchange', payload)
+    return data['token']
+
+
+def require_env(
+    name: str,
+    hint: str | None = None,
+) -> str:
+    val = os.environ.get(name, '')
+    if not val:
+        msg = f'ERROR: {name} is not set'
+        if hint:
+            msg += f'\n{hint}'
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--token-server', required=True)
+    parser.add_argument('--audience', required=True)
+    parser.add_argument('--host', required=True)
+    parser.add_argument('--organization', required=True)
+    parser.add_argument('--repositories', required=True)
+    parser.add_argument('--permissions', required=True)
+    args = parser.parse_args()
+
+    oidc_hint = 'That typically means this workflow was not run with `id-token: write`-permission'
+    request_url = require_env('ACTIONS_ID_TOKEN_REQUEST_URL', oidc_hint)
+    request_token = require_env('ACTIONS_ID_TOKEN_REQUEST_TOKEN', oidc_hint)
+
+    token_server = args.token_server
+    if '://' not in token_server:
+        token_server = f'http://{token_server}'
+
+    id_token = get_oidc_token(request_url, request_token, args.audience)
+    token = exchange_token(
+        token_server,
+        args.host,
+        args.organization,
+        id_token,
+        args.repositories,
+        args.permissions,
+    )
+
+    github_output = os.environ.get('GITHUB_OUTPUT', '')
+    if not github_output:
+        print('ERROR: GITHUB_OUTPUT is not set', file=sys.stderr)
+        sys.exit(1)
+
+    with open(github_output, 'a') as f:
+        f.write(f'token={token}\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
github-auth (used by trusted-checkout) is now more resilient in case of transient networking issues
```
