### PR TITLE
ocm-schema: forbid scheme-prefixed OCI image references

### DIFF
--- a/oci/util.py
+++ b/oci/util.py
@@ -2,7 +2,13 @@ import collections.abc
 import contextlib
 import io
 import queue
+import re
 import threading
+
+# OCI Image Reference Spec; leading `/` is additionally permitted as a local/relative ref
+_OCI_IMAGE_REF_RE = re.compile(
+    r'^(?!.*://)[^:?#][^?#]*(?:/[^?#]*)*(?::[^:/@][^@]*)?(?:@[a-zA-Z][a-zA-Z0-9]*:[a-fA-F0-9]+)?$'
+)
 
 
 def normalise_image_reference(image_reference: str):
@@ -10,8 +16,10 @@ def normalise_image_reference(image_reference: str):
         raise ValueError(image_reference)
 
     if image_reference.startswith('/'):
-        # keep relative reference as is
         return image_reference
+
+    if not _OCI_IMAGE_REF_RE.match(image_reference):
+        raise ValueError(f'not a valid OCI image reference: {image_reference!r}')
 
     parts = image_reference.split('/')
 

--- a/ocm/ocm-component-descriptor-schema.yaml
+++ b/ocm/ocm-component-descriptor-schema.yaml
@@ -283,6 +283,7 @@ definitions:
         enum: ['ociRegistry']
       imageReference:
         type: 'string'
+        pattern: '^(?!.*://)[^:?#][^?#]*(?:/[^?#]*)*(?::[^:/@][^@]*)?(?:@[a-zA-Z][a-zA-Z0-9]*:[a-fA-F0-9]+)?$'
 
   ociBlobAccess:
     type: 'object'
@@ -296,6 +297,7 @@ definitions:
       ref:
         description: 'A oci reference to the manifest'
         type: 'string'
+        pattern: '^(?!.*://)[^:?#][^?#]*(?:/[^?#]*)*(?::[^:/@][^@]*)?(?:@[a-zA-Z][a-zA-Z0-9]*:[a-fA-F0-9]+)?$'
       mediaType:
         description: 'The media type of the object this access refers to'
         type: 'string'


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
ocm-spec contained on `ocm` package now features strict OCI-Image-Reference schema.
```
