### PR TITLE
capture/import-commit: improve robustness, guard against darwin

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -72,6 +72,14 @@ runs:
     - name: capture-commit
       id: capture
       run: |
+        # darwin/macOS is not supported. differences that would need addressing:
+        # - `stat --format=%s` (GNU) -> `stat -f %z` (BSD)
+        # - `base64 -w0` (GNU) -> `base64 | tr -d '\n'` (BSD)
+        if [ "$(uname -s)" = 'Darwin' ]; then
+          echo "error: darwin/macOS is not supported"
+          exit 1
+        fi
+
         ts_ref=${{ inputs.timestamp-reference }}
         if [ ! -f ${ts_ref} ]; then
           echo "no timestamp-reference-file at expected path: ${ts_ref}"

--- a/.github/actions/capture-commit/capture-commit
+++ b/.github/actions/capture-commit/capture-commit
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 # usage:
 # export GIT_DIR
 # $1: path to target-archive
 # $2: path to ref-file (must be older than commit)
 # $3: path to output-file for commit-digest (defaults to commit-digest)
+
+# darwin/macOS is not supported. differences that would need addressing:
+# - `find -newermt` (GNU) -> `-newer` (BSD find; compares mtime, but no XY-syntax)
+if [ "$(uname -s)" = 'Darwin' ]; then
+  echo "error: darwin/macOS is not supported"
+  exit 1
+fi
 
 if [ -z "${GIT_DIR:-}" ]; then
   echo "must set GIT_DIR"
@@ -36,12 +43,12 @@ fi
 commit_digest="$(git rev-parse @)"
 echo "${commit_digest}" > "${GIT_DIR}/refs/capture-commit"
 
-object_paths=$(
+mapfile -t object_paths < <(
   cd "$(dirname "$GIT_DIR")"
-  find .git/objects -type f -neweraa "${ref}" | grep -v pack
+  find .git/objects -type f -newermt "${ref}" | grep -v pack
 )
 object_paths+=('.git/refs/capture-commit')
 
 # objects are already gzipped - there is no point in compressing them again
-tar cf "${archive}" -b1 -C $(dirname "${GIT_DIR}") ${object_paths[*]}
+tar cf "${archive}" -b1 -C "$(dirname "${GIT_DIR}")" "${object_paths[@]}"
 echo "${commit_digest}" > ${commit_digest_out}

--- a/.github/actions/import-commit/action.yaml
+++ b/.github/actions/import-commit/action.yaml
@@ -62,12 +62,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: validate-inputs
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.commit-objects }}" ] && [ -z "${{ inputs.commit-objects-artefact }}" ]; then
+          echo "error: either commit-objects or commit-objects-artefact must be provided"
+          exit 1
+        fi
     - name: import-commit-objects-from-input
       if: ${{ inputs.commit-objects != '' }}
       shell: bash
       run: |
         set -eu
-        echo "${{ inputs.commit-objects }}" | base64 -d | tar x
+        echo "${{ inputs.commit-objects }}" | base64 -d | tar x -C "${GITHUB_WORKSPACE}"
     - name: import-commit-objects-from-artefact
       if: ${{ inputs.commit-objects-artefact != '' }}
       uses: gardener/cc-utils/.github/actions/download-artifact@master
@@ -78,7 +85,7 @@ runs:
       shell: bash
       run: |
         set -eu
-        tar xf commit-objects.tar.gz
+        tar xf commit-objects.tar.gz -C "${GITHUB_WORKSPACE}"
         unlink commit-objects.tar.gz
     - name: import-commit
       shell: bash


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
capture-commit and import-commit now guard against runner running on Darwin (which is not supported)
```
