### PR TITLE
ctt: DescriptorRefRewriteUploader + force-overwrite-descriptors pruning mode

### DIFF
--- a/ctt/README
+++ b/ctt/README
@@ -73,3 +73,106 @@ CTT's `replicate`-command will recursively replicate any referenced sub-componen
 default parallelise replication using multithreading, and will early-exit replication of
 OCI-Artefacts, if already present in replication-target. It is designed to be safe (and
 resource-efficient) to be rerun against the same replication-target multiple times.
+
+Uploaders
+---------
+
+Uploaders control how OCI-Artefacts are pushed to the target registry and how their references are
+recorded in the replicated component-descriptors.  Multiple uploaders may be chained in the
+`upload` list of an `image_processing_cfg` entry; they are applied in order, each receiving the
+result of the previous one.
+
+### PrependTargetUploader
+
+The most common uploader.  It derives the target image-reference by prepending the target
+OCI-Registry to the (mangled) source image-reference path.
+
+Example: replicate everything from `registry.example.com` into `registry.acme.org`:
+
+```yaml
+targets:
+  acme:
+    type: RegistriesTarget
+    kwargs:
+      registries:
+        - registry.acme.org
+      ocm_repository: registry.acme.org
+
+processors:
+  no-op:
+    type: NoOpProcessor
+
+uploaders:
+  prepend_target:
+    type: PrependTargetUploader
+    kwargs:
+      remove_prefixes:
+        - registry.example.com/
+
+image_processing_cfg:
+  - name: default
+    filter:
+      - type: MatchAllFilter
+    processor: no-op
+    target: acme
+    upload:
+      - prepend_target
+```
+
+`remove_prefixes` strips the given prefix before prepending the target registry, so
+`registry.example.com/myorg/myimage:1.0` is pushed to (and recorded as)
+`registry.acme.org/myorg/myimage:1.0` rather than
+`registry.acme.org/registry_example_com/myorg/myimage:1.0`.
+
+### DescriptorRefRewriteUploader
+
+Use this when the registry the artefacts are _pushed to_ differs from the registry _clients should
+pull from_.  A typical case is a primary regional registry that feeds into a global CDN or
+geo-routing endpoint: artefacts are uploaded once to the primary region, but all consumers should
+reference the global endpoint so they are served from the closest replica automatically.
+
+`DescriptorRefRewriteUploader` replaces a prefix in the computed target reference and stores the
+result as the `imageReference` written into the component-descriptor, without affecting the actual
+push destination.  It must be placed _after_ the uploader that sets the push target (e.g.
+`PrependTargetUploader`).
+
+Example: push to `registry-primary.example.com` but record `registry-global.example.com`
+references in the component-descriptor:
+
+```yaml
+targets:
+  primary:
+    type: RegistriesTarget
+    kwargs:
+      registries:
+        - registry-primary.example.com
+      ocm_repository: registry-primary.example.com
+
+processors:
+  no-op:
+    type: NoOpProcessor
+
+uploaders:
+  push_to_primary:
+    type: PrependTargetUploader
+    kwargs: {}
+  rewrite_for_global:
+    type: DescriptorRefRewriteUploader
+    kwargs:
+      src_prefix: registry-primary.example.com/
+      tgt_prefix: registry-global.example.com/
+
+image_processing_cfg:
+  - name: default
+    filter:
+      - type: MatchAllFilter
+    processor: no-op
+    target: primary
+    upload:
+      - push_to_primary
+      - rewrite_for_global
+```
+
+With this configuration, an image `src.example.com/myorg/myimage:1.0` is pushed to
+`registry-primary.example.com/src_example_com/myorg/myimage:1.0`, while the component-descriptor
+records `registry-global.example.com/src_example_com/myorg/myimage:1.0`.

--- a/ctt/__main__.py
+++ b/ctt/__main__.py
@@ -72,7 +72,10 @@ def configure_parser(parser):
             f'"{ctt.process_dependencies.PruningMode.PRUNE_SUBTREES.value}" (default) '
             'skips subtrees already present in the target. '
             f'"{ctt.process_dependencies.PruningMode.REPLICATE_ALL.value}" '
-            'replicates the full transitive closure unconditionally.'
+            'replicates the full transitive closure unconditionally. '
+            f'"{ctt.process_dependencies.PruningMode.FORCE_OVERWRITE_DESCRIPTORS.value}" '
+            'replicates the full transitive closure and overwrites existing component-descriptors; '
+            'OCI artefacts are still skipped when already present.'
         ),
     )
 

--- a/ctt/model.py
+++ b/ctt/model.py
@@ -12,6 +12,8 @@ class ReplicationResourceOptions:
     reference_by_digest: bool = False
     retain_symbolic_tag: bool = False
     convert_to_relative_ref: bool = False
+    # if set, this ref is written into the component-descriptor instead of the actual push target
+    descriptor_ref_override: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -60,9 +60,15 @@ class PruningMode(enum.StrEnum):
     any subtree whose root descriptor already exists in the target, avoiding redundant work.
     This optimisation is robust in the common case but may miss partial replications in
     corner-cases; use REPLICATE_ALL for a full replication at the cost of extra HEAD requests.
+
+    FORCE_OVERWRITE_DESCRIPTORS behaves like REPLICATE_ALL for tree-traversal but additionally
+    overwrites component-descriptors even when they already exist in the target.  OCI artefacts
+    are still skipped when already present.  Useful when descriptor content must be refreshed
+    (e.g. after a reference-rewrite rule change) without re-pushing all images.
     '''
     PRUNE_SUBTREES = 'prune-subtrees'  # skip subtrees whose root descriptor exists in target
     REPLICATE_ALL = 'replicate-all'    # replicate full transitive closure unconditionally
+    FORCE_OVERWRITE_DESCRIPTORS = 'force-overwrite-descriptors'  # overwrite descriptors, skip images
 
 
 @functools.cache
@@ -727,6 +733,7 @@ def process_images(
             reftype_filter=reftype_filter,
             skip_cd_validation=skip_cd_validation,
             skip_component_upload=skip_component_upload,
+            overwrite_descriptors=pruning_mode is PruningMode.FORCE_OVERWRITE_DESCRIPTORS,
             max_workers=max_workers,
         )
 
@@ -744,6 +751,7 @@ def process_replication_plan_step(
     reftype_filter: collections.abc.Callable[[ocm.iter.NodeReferenceType], bool] | None=None,
     skip_cd_validation: bool=False,
     skip_component_upload: collections.abc.Callable[[ocm.Component], bool] | None=None,
+    overwrite_descriptors: bool=False,
     max_workers: int=16,
 ) -> collections.abc.Generator[ocm.iter.Node, None, None]:
     def process_replication_resource_element(
@@ -940,6 +948,7 @@ def process_replication_plan_step(
             patched_component_descriptor=replication_plan_component.target,
             src_ocm_repo=orig_ocm_repo,
             oci_client=oci_client,
+            overwrite=overwrite_descriptors,
         )
 
     if processing_mode is ProcessingMode.DRY_RUN:

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -808,26 +808,32 @@ def process_replication_plan_step(
                 ).local_ref,
             )
 
-        if not replication_resource_element.reference_by_digest:
-            return replication_resource_element
+        if replication_resource_element.reference_by_digest:
+            tgt_ref = replication_resource_element.tgt_ref
 
-        tgt_ref = replication_resource_element.tgt_ref
+            if (
+                replication_resource_element.retain_symbolic_tag
+                and (tgt_ref.has_symbolical_tag or tgt_ref.has_mixed_tag)
+            ):
+                tgt_ref = f'{tgt_ref.with_symbolical_tag}@{oci_manifest_digest}'
+            else:
+                tgt_ref = f'{tgt_ref.ref_without_tag}@{oci_manifest_digest}'
 
-        if (
-            replication_resource_element.retain_symbolic_tag
-            and (tgt_ref.has_symbolical_tag or tgt_ref.has_mixed_tag)
-        ):
-            tgt_ref = f'{tgt_ref.with_symbolical_tag}@{oci_manifest_digest}'
-        else:
-            tgt_ref = f'{tgt_ref.ref_without_tag}@{oci_manifest_digest}'
+            access_type = replication_resource_element.target.access.type
+            if access_type is ocm.AccessType.OCI_REGISTRY:
+                replication_resource_element.target.access.imageReference = tgt_ref
+            elif access_type is ocm.AccessType.RELATIVE_OCI_REFERENCE:
+                replication_resource_element.target.access.reference = tgt_ref
+            else:
+                raise ValueError(access_type)
 
-        access_type = replication_resource_element.target.access.type
-        if access_type is ocm.AccessType.OCI_REGISTRY:
-            replication_resource_element.target.access.imageReference = tgt_ref
-        elif access_type is ocm.AccessType.RELATIVE_OCI_REFERENCE:
-            replication_resource_element.target.access.reference = tgt_ref
-        else:
-            raise ValueError(access_type)
+        if descriptor_ref := replication_resource_element.descriptor_ref_override:
+            # overwrite the ref written into the component-descriptor, independently of where
+            # the artifact was actually pushed; the access-type is always OCI_REGISTRY here,
+            # since descriptor_ref_override is an absolute reference
+            replication_resource_element.target.access = ocm.OciAccess(
+                imageReference=descriptor_ref,
+            )
 
         return replication_resource_element
 

--- a/ctt/replicate.py
+++ b/ctt/replicate.py
@@ -23,6 +23,7 @@ def replicate_oci_artifact_with_patched_component_descriptor(
     patched_component_descriptor: ocm.ComponentDescriptor,
     src_ocm_repo: ocm.OciOcmRepository,
     oci_client: oci.client.Client,
+    overwrite: bool=False,
 ):
     if isinstance(src_ocm_repo, str):
         src_ocm_repo = ocm.OciOcmRepository(baseUrl=src_ocm_repo)
@@ -34,7 +35,7 @@ def replicate_oci_artifact_with_patched_component_descriptor(
     target_repository = component.current_ocm_repo
     target_ref = target_repository.component_version_oci_ref(component)
 
-    if oci_client.head_manifest(image_reference=target_ref, absent_ok=True):
+    if not overwrite and oci_client.head_manifest(image_reference=target_ref, absent_ok=True):
         # do not overwrite existing component-descriptors
         return
 

--- a/ctt/uploaders.py
+++ b/ctt/uploaders.py
@@ -287,3 +287,56 @@ class DigestUploader(UploaderBase):
         replication_resource_element.retain_symbolic_tag = self._retain_symbolic_tag
 
         return replication_resource_element
+
+
+class DescriptorRefRewriteUploader(UploaderBase):
+    '''
+    Rewrites the image-reference written into the component-descriptor without changing the actual
+    push target.  This is useful when the OCI registry the artifacts are pushed to differs from
+    the one clients are supposed to pull from (e.g. a primary region registry vs. a global CDN
+    endpoint that geo-routes to regional replicas).
+
+    `src_prefix` is matched against the beginning of the target ref (as computed by any preceding
+    uploaders) and replaced by `tgt_prefix`.  Both values are compared/applied on the full
+    image-reference string including the host.
+
+    Example cfg:
+    ```yaml
+    uploaders:
+      rewrite_for_global:
+        type: DescriptorRefRewriteUploader
+        kwargs:
+          src_prefix: keppel.eu-de-1.cloud.sap/
+          tgt_prefix: keppel.global.cloud.sap/
+    ```
+    '''
+    def __init__(
+        self,
+        src_prefix: str,
+        tgt_prefix: str,
+    ):
+        self._src_prefix = src_prefix
+        self._tgt_prefix = tgt_prefix
+
+    def process(
+        self,
+        replication_resource_element: ctt.model.ReplicationResourceElement,
+        /,
+        target_as_source: bool=False,
+        **kwargs,
+    ) -> ctt.model.ReplicationResourceElement:
+        if not target_as_source:
+            ref = str(replication_resource_element.src_ref)
+        else:
+            ref = str(replication_resource_element.tgt_ref)
+
+        if not ref.startswith(self._src_prefix):
+            raise ValueError(
+                f'{ref!r} does not start with {self._src_prefix!r}; '
+                'check DescriptorRefRewriteUploader configuration'
+            )
+
+        descriptor_ref = self._tgt_prefix + ref.removeprefix(self._src_prefix)
+        replication_resource_element.descriptor_ref_override = descriptor_ref
+
+        return replication_resource_element


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
CTT/ocm-replicate: new `DescriptorRefRewriteUploader` allows writing a different image-reference
into replicated component-descriptors than the one artifacts are pushed to (e.g. push to a primary
regional registry, but record a global geo-routing endpoint in descriptors).

New `--pruning-mode force-overwrite-descriptors` traverses the full component tree and overwrites
existing component-descriptors in the target without re-pushing OCI artefacts.
```