### PR TITLE
oci-ocm: record syft version in SBOM artefacts

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -490,6 +490,15 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
+      - name: 'get syft version / ${{ matrix.args.platform-name }}'
+        if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
+        id: syft-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(syft version --output json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
 
@@ -515,10 +524,13 @@ jobs:
               '${{ matrix.args.image-reference }}',
           )
 
+          syft_version = '${{ steps.syft-version.outputs.version }}' or None
+
           referrer_digest = oci.sbom.push_sbom_referrer(
               sbom_path='sbom.spdx.json',
               image_reference=image_ref,
               oci_client=oci_client,
+              syft_version=syft_version,
           )
 
           referrer_ref = f'{image_ref.ref_without_tag}@{referrer_digest}'
@@ -549,6 +561,16 @@ jobs:
               'architecture': architecture,
           }
 
+          syft_version = '${{ steps.syft-version.outputs.version }}' or None
+          syft_label = ocm.Label(
+              name='gardener.cloud/sbom/syft',
+              value={
+                  'version': syft_version,
+                  'format': 'spdx-json',
+              },
+          ) if syft_version else None
+          labels = [syft_label] if syft_label else []
+
           inline_resource = ocm.Resource(
               name=f'{name}-ocm',
               version='${{ inputs.version }}',
@@ -559,6 +581,7 @@ jobs:
                   mediaType='application/spdx+json',
               ),
               relation=ocm.ResourceRelation.LOCAL,
+              labels=labels,
           )
 
           ref_resource = ocm.Resource(
@@ -570,6 +593,7 @@ jobs:
                   imageReference='${{ steps.sbom-push.outputs.referrer-ref }}',
               ),
               relation=ocm.ResourceRelation.LOCAL,
+              labels=labels,
           )
 
           with open('sbom-ocm-resources.yaml', 'w') as f:

--- a/oci/sbom.py
+++ b/oci/sbom.py
@@ -27,6 +27,7 @@ def push_sbom_referrer(
     image_reference: str | om.OciImageReference,
     oci_client: oc.Client,
     sbom_media_type: str = SPDX_JSON_MEDIA_TYPE,
+    syft_version: str | None = None,
 ) -> str:
     '''
     Push an SBOM file as an OCI referrer manifest for the given image.
@@ -34,6 +35,9 @@ def push_sbom_referrer(
     The SBOM blob is pushed as the single layer of a new OCI manifest; the
     manifest's `subject` is set to the digest-addressed descriptor of the
     target image, establishing the referrer relationship.
+
+    If `syft_version` is given it is recorded in the manifest annotations as
+    `gardener.cloud/sbom/syft-version`.
 
     Returns the digest of the pushed referrer manifest.
     '''
@@ -97,6 +101,7 @@ def push_sbom_referrer(
         artifactType=sbom_media_type,
         annotations={
             'org.opencontainers.image.created': _utcnow_iso(),
+            **({'gardener.cloud/sbom/syft-version': syft_version} if syft_version else {}),
         },
     )
 


### PR DESCRIPTION
## Summary

- Captures the syft version used during SBOM generation via `syft version --output json` (syft is on `PATH` after `anchore/sbom-action`)
- Attaches it as an OCM label `gardener.cloud/sbom/syft` (`{version, format}`) on both SBOM resources (inline + referrer-ref)
- Attaches it as OCI annotation `gardener.cloud/sbom/syft-version` on the referrer manifest (string value; OCI annotations are `string → string`)

The OCI annotation addition is fully spec-compliant — the OCI image spec explicitly allows arbitrary annotations; existing tooling ignores unknown keys.