### PR TITLE
Enhance update-images.py with directives and comment preservation

### DIFF
--- a/.github/actions/update-extension-provider-images/update-images.py
+++ b/.github/actions/update-extension-provider-images/update-images.py
@@ -36,7 +36,7 @@ Comment Directives (one per line, placed above image entries):
 
 Comments not recognized as directives are preserved in the output.
 
-Manual k8s Constraints:
+Explicit K8s Constraints:
 Images with targetVersion like '>= 1.34' that don't correlate with the image version
 (e.g., csi-provisioner v6.x with '>= 1.34') are detected automatically. These entries
 are updated to the latest available version while preserving the original targetVersion.
@@ -52,11 +52,13 @@ are no longer supported.
 """
 
 import argparse
+import math
 import re
 import sys
 import traceback
 from collections import defaultdict
 from dataclasses import dataclass, asdict, replace
+from io import StringIO
 from typing import Optional, Any
 
 import dacite
@@ -67,6 +69,65 @@ from ruamel.yaml import YAMLError
 from oci import client as oci_client
 from ocm import Label as OcmLabel
 from version import parse_to_semver, is_final, iter_upgrade_path
+
+
+# Type alias for directives map: (name, repository, tag) -> directives dict
+DirectivesMap = dict[tuple[str, str, str], dict[str, Any]]
+
+
+def _directive_key(entry: 'ImageEntry') -> tuple[str, str, str]:
+    """Create a unique key for an image entry in the directives map."""
+    return (entry.name, entry.repository, entry.tag)
+
+
+def is_frozen(entry: 'ImageEntry', directives: DirectivesMap) -> bool:
+    """Check if an image entry is frozen (should skip all updates)."""
+    return directives.get(_directive_key(entry), {}).get('freeze', False)
+
+
+def should_skip_minor_update(entry: 'ImageEntry', directives: DirectivesMap) -> bool:
+    """Check if an image entry should skip minor/major updates (max-supported-k8s)."""
+    return directives.get(_directive_key(entry), {}).get('max_supported_k8s', False)
+
+
+def has_version_mapping(entry: 'ImageEntry', directives: DirectivesMap) -> bool:
+    """Check if an image entry has version-mapping directive (GCP CCM)."""
+    return directives.get(_directive_key(entry), {}).get('version_mapping', False)
+
+
+def has_explicit_k8s_constraint(entry: 'ImageEntry', directives: DirectivesMap) -> bool:
+    """
+    Check if this entry has an explicit k8s version constraint.
+
+    Returns True if:
+    - Entry has a targetVersion starting with '>='
+    - The constraint version doesn't match the image version
+    - No version-mapping directive is present
+
+    Example: image v6.2.0 with targetVersion '>= 1.34' is an explicit constraint
+    because 6.2 != 1.34 and there's no version-mapping.
+    """
+    if not entry.targetVersion or has_version_mapping(entry, directives):
+        return False
+
+    if not entry.targetVersion.startswith('>='):
+        return False
+
+    try:
+        target_version_str = entry.targetVersion.replace('>=', '').strip()
+        target_version = parse_to_semver(target_version_str)
+        image_version = parse_to_semver(entry.tag)
+
+        # If target version doesn't match image version, it's an explicit constraint
+        return (target_version.major, target_version.minor) != \
+               (image_version.major, image_version.minor)
+    except ValueError:
+        return False
+
+
+def get_entry_directives(entry: 'ImageEntry', directives: DirectivesMap) -> dict[str, Any]:
+    """Get the directives dict for an image entry."""
+    return directives.get(_directive_key(entry), {})
 
 
 # --- Data Classes ---
@@ -84,7 +145,6 @@ class ImageEntry:
     labels: list[OcmLabel]
     targetVersion: Optional[str] = None
     resourceId: Optional[ResourceId] = None
-    _directives: Optional[dict[str, Any]] = None  # Internal field for directives
 
     def has_target_version(self) -> bool:
         return self.targetVersion is not None
@@ -100,58 +160,11 @@ class ImageEntry:
             new_tag: str,
             new_target_version: str,
     ) -> 'ImageEntry':
-        # Only keep version_mapping
-        filtered_directives = {}
-        if self._directives and self._directives.get('version_mapping'):
-            filtered_directives['version_mapping'] = True
-
         return replace(
                 self,
                 tag=new_tag,
                 targetVersion=new_target_version,
-                _directives=filtered_directives if filtered_directives else None
         )
-
-    def is_frozen(self) -> bool:
-        return bool(self._directives and self._directives.get('freeze', False))
-
-    def should_skip_minor_update(self) -> bool:
-        return bool(self._directives and self._directives.get('max_supported_k8s', False))
-
-    def has_version_mapping(self) -> bool:
-        return bool(self._directives and self._directives.get('version_mapping', False))
-
-    def has_manual_k8s_constraint(self) -> bool:
-        """
-        Check if this entry has a manual k8s version constraint.
-
-        Returns True if:
-        - Entry has a targetVersion starting with '>='
-        - The constraint version doesn't match the image version
-        - No version-mapping directive is present
-
-        Example: image v6.2.0 with targetVersion '>= 1.34' is a manual constraint
-        because 6.2 != 1.34 and there's no version-mapping.
-        """
-        if not self.targetVersion or self.has_version_mapping():
-            return False
-
-        if not self.targetVersion.startswith('>='):
-            return False
-
-        try:
-            target_version_str = self.targetVersion.replace('>=', '').strip()
-            target_version = parse_to_semver(target_version_str)
-            image_version = parse_to_semver(self.tag)
-
-            # If target version doesn't match image version, it's a manual constraint
-            return (target_version.major, target_version.minor) != \
-                   (image_version.major, image_version.minor)
-        except ValueError:
-            return False
-
-    def set_directives(self, directives: dict[str, Any]) -> None:
-        self._directives = directives or {}
 
 
 @dataclass
@@ -182,8 +195,6 @@ class ImagesData:
         result = {'images': []}
         for image in self.images:
             image_dict = asdict(image)
-            # Remove internal fields that shouldn't end up in the new yaml
-            image_dict.pop('_directives', None)
             result['images'].append(image_dict)
 
         return self._remove_none_values(result)
@@ -211,29 +222,30 @@ class ImageUpdate:
 
 
 # --- Helper Functions ---
-def load_and_validate_images_data(images_yaml_path: str) -> tuple[ImagesData, Any]:
+def load_and_validate_images_data(yaml_content: str) -> ImagesData:
     """
     Load and validate images.yaml data using dacite.
 
     Args:
-        images_yaml_path: Path to the images.yaml file
+        yaml_content: Raw YAML content as string
 
     Returns:
-        Tuple of (Validated ImagesData object, raw YAML data for comment parsing)
+        Validated ImagesData object
 
     Raises:
-        ValueError: If the file cannot be read, parsed, or validated
+        ValueError: If the content cannot be parsed or validated
     """
     yaml = YAML()
     yaml.preserve_quotes = True
-    yaml.width = 4096
+    yaml.width = math.inf
 
-    with open(images_yaml_path, "r") as f:
-        raw_yaml_data = yaml.load(f)
-        raw_yaml_data['images']
+    raw_yaml_data = yaml.load(StringIO(yaml_content))
+
+    if 'images' not in raw_yaml_data:
+        raise ValueError("Missing required 'images' key in YAML content")
 
     try:
-        validated_data = dacite.from_dict(
+        return dacite.from_dict(
             data_class=ImagesData,
             data=dict(raw_yaml_data),  # Convert to regular dict for dacite
             config=dacite.Config(
@@ -241,12 +253,11 @@ def load_and_validate_images_data(images_yaml_path: str) -> tuple[ImagesData, An
                 check_types=True,
             ),
         )
-        return validated_data, raw_yaml_data
     except dacite.DaciteError as e:
-        raise ValueError(f"Invalid images.yaml structure in {images_yaml_path}: {e}")
+        raise ValueError(f"Invalid images.yaml structure: {e}")
 
 
-def parse_image_comments(yaml_content: str) -> dict[str, dict[str, Any]]:
+def parse_image_comments(yaml_content: str) -> dict[int, dict[str, Any]]:
     """
     Parse comments above image entries to extract directives.
 
@@ -332,7 +343,7 @@ def parse_comment_directives(comment_lines: list[str]) -> dict[str, Any]:
 def create_image_directive_map(
     yaml_content: str,
     images_data: ImagesData
-) -> dict[str, dict[str, Any]]:
+) -> DirectivesMap:
     """
     Create a mapping from image entries to their comment directives.
 
@@ -345,14 +356,14 @@ def create_image_directive_map(
         images_data: Parsed and validated ImagesData object
 
     Returns:
-        Dictionary mapping unique image keys (name:repository:tag) to their
+        DirectivesMap mapping (name, repository, tag) tuples to their
         comment directives
     """
     comment_directives = parse_image_comments(yaml_content)
 
     # Convert line-based mapping to image-based mapping
     lines = yaml_content.split('\n')
-    image_directives = {}
+    image_directives: DirectivesMap = {}
 
     for line_num, directive_info in comment_directives.items():
         # Find the corresponding image entry by matching name and position
@@ -360,7 +371,7 @@ def create_image_directive_map(
 
         # Count which occurrence of this image name this is
         occurrence = 0
-        for i in range(int(line_num)):
+        for i in range(line_num):
             if re.search(rf'- name:\s*{re.escape(image_name)}', lines[i]):
                 occurrence += 1
 
@@ -369,7 +380,7 @@ def create_image_directive_map(
         if occurrence < len(matching_images):
             # Create a unique key for this specific image entry
             img_entry = matching_images[occurrence]
-            key = f"{img_entry.name}:{img_entry.repository}:{img_entry.tag}"
+            key = _directive_key(img_entry)
             image_directives[key] = directive_info['directives']
 
     return image_directives
@@ -378,7 +389,7 @@ def create_image_directive_map(
 # --- Core Logic Functions ---
 def find_greater_versions(
     current_tags: list[str],
-    available_tags: list[str],
+    available_tags: list[str]
 ) -> dict[str, list[str]]:
     """
     Compare current tags with available tags to find greater patch and minor/major versions.
@@ -452,8 +463,9 @@ def find_greater_versions(
 def update_singleton_image(
     image_list: list[ImageEntry],
     all_greater_tags: list[str],
-    name: str
-) -> list[ImageUpdate]:
+    name: str,
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], DirectivesMap]:
     """
     Handle updates for images without targetVersion (singleton components).
 
@@ -464,15 +476,18 @@ def update_singleton_image(
         image_list: List of image entries for this component (should contain exactly 1 item)
         all_greater_tags: All available newer tags (combination of patch and minor updates)
         name: Image name for logging and update tracking
+        directives: Map of image entries to their directives
 
     Returns:
-        List containing zero or one ImageUpdate object
+        Tuple of:
+        - List containing zero or one ImageUpdate object
+        - Updated DirectivesMap with keys updated for changed tags
 
     Raises:
         SystemExit: If multiple entries found for singleton image (configuration error)
     """
     if not all_greater_tags:
-        return []
+        return [], {}
 
     if len(image_list) != 1:
         print(
@@ -483,31 +498,40 @@ def update_singleton_image(
         sys.exit(1)
 
     # Check if this singleton image should be kept
-    if image_list[0].is_frozen():
+    if is_frozen(image_list[0], directives):
         print(f"Skipping update for singleton {name} due to 'freeze' directive", file=sys.stderr)
-        return []
+        return [], {}
 
     latest_tag = max(all_greater_tags, key=parse_to_semver)
+    old_key = _directive_key(image_list[0])
     old_tag = image_list[0].tag
 
     if old_tag != latest_tag:
         image_list[0].update_tag(latest_tag)
+        new_key = _directive_key(image_list[0])
+
+        # Migrate directives to new key if entry had directives
+        updated_directives: DirectivesMap = {}
+        if old_key in directives:
+            updated_directives[new_key] = directives[old_key]
+
         return [ImageUpdate(
             image_name=name,
             old_tag=old_tag,
             new_tag=latest_tag,
             update_type="singleton",
             repository=image_list[0].repository,
-        )]
+        )], updated_directives
 
-    return []
+    return [], {}
 
 
 def apply_patch_updates(
     image_list: list[ImageEntry],
     patch_tags: list[str],
-    name: str
-) -> list[ImageUpdate]:
+    name: str,
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], DirectivesMap]:
     """
     Apply patch version updates to existing image entries.
     Only creates one update record per major.minor showing the final patch version jump.
@@ -519,11 +543,15 @@ def apply_patch_updates(
         image_list: List of image entries for this component
         patch_tags: List of patch version tags to apply
         name: Image name for logging and update tracking
+        directives: Map of image entries to their directives
 
     Returns:
-        List of ImageUpdate objects representing the applied patch updates
+        Tuple of:
+        - List of ImageUpdate objects representing the applied patch updates
+        - Updated DirectivesMap with keys updated for changed tags
     """
     updates: list[ImageUpdate] = []
+    updated_directives: DirectivesMap = {}
 
     # Group patch tags by major.minor version
     tags_by_version: dict[tuple[int, int], list[str]] = defaultdict(list)
@@ -545,7 +573,7 @@ def apply_patch_updates(
                 img_version = parse_to_semver(img_entry.tag)
                 if (img_version.major, img_version.minor) == (major, minor):
                     # Check if this specific image should skip patch updates
-                    if img_entry.is_frozen():
+                    if is_frozen(img_entry, directives):
                         print(
                             f"Skipping patch update for {name} tag {img_entry.tag} "
                             "due to 'freeze' directive",
@@ -553,8 +581,15 @@ def apply_patch_updates(
                         )
                         continue
 
+                    old_key = _directive_key(img_entry)
                     old_tag = img_entry.tag
                     img_entry.update_tag(highest_patch_tag)
+                    new_key = _directive_key(img_entry)
+
+                    # Migrate directives to new key if entry had directives
+                    if old_key in directives:
+                        updated_directives[new_key] = directives[old_key]
+
                     updates.append(ImageUpdate(
                         image_name=name,
                         old_tag=old_tag,
@@ -566,14 +601,15 @@ def apply_patch_updates(
             except ValueError:
                 continue
 
-    return updates
+    return updates, updated_directives
 
 
 def create_minor_version_entries(
     image_list: list[ImageEntry],
     minor_tags: list[str],
-    name: str
-) -> tuple[list[ImageUpdate], list[ImageEntry]]:
+    name: str,
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], list[ImageEntry], DirectivesMap]:
     """
     Create new image entries for minor/major version updates.
     Only creates one entry per major.minor (the highest patch version).
@@ -585,27 +621,33 @@ def create_minor_version_entries(
         image_list: List of existing image entries for this component
         minor_tags: List of minor/major version tags to add
         name: Image name for logging and update tracking
+        directives: Map of image entries to their directives
 
     Returns:
         Tuple containing:
         - List of ImageUpdate objects for minor version additions
         - List of new ImageEntry objects to be added to the main data structure
+        - Updated DirectivesMap with directives for new entries (if version_mapping)
     """
     updates: list[ImageUpdate] = []
     new_entries: list[ImageEntry] = []
+    new_directives: DirectivesMap = {}
 
     # Check if the highest version entry (which controls minor updates) should be kept
     try:
         highest_existing = max(image_list, key=lambda img: parse_to_semver(img.tag))
-        if highest_existing.should_skip_minor_update():
+        if should_skip_minor_update(highest_existing, directives):
             print(
                 f"Skipping minor/major updates for {name} due to "
                 "'max-supported-k8s' directive on highest version",
                 file=sys.stderr,
             )
-            return updates, new_entries
+            return updates, new_entries, new_directives
     except ValueError:
         pass  # If we can't parse versions, proceed with updates
+
+    # Check if we need to propagate version_mapping to new entries
+    uses_version_mapping = has_version_mapping(image_list[0], directives)
 
     # Group minor tags by major.minor version
     tags_by_version: dict[tuple[int, int], list[str]] = defaultdict(list)
@@ -622,13 +664,17 @@ def create_minor_version_entries(
         highest_tag = max(tags, key=parse_to_semver)
 
         # Create new entry for the highest patch version only
-        if image_list[0].has_version_mapping():
+        if uses_version_mapping:
             target_version = f"1.{major}.x"  # For k8s-ccm mapping
         else:
             target_version = f"{major}.{minor}.x"
 
         new_entry = image_list[-1].copy_as_template(highest_tag, target_version)
         new_entries.append(new_entry)
+
+        # Propagate version_mapping directive to new entries
+        if uses_version_mapping:
+            new_directives[_directive_key(new_entry)] = {'version_mapping': True}
 
         # Find the previous highest version for the update record
         all_tags = [img.tag for img in image_list] + [entry.tag for entry in new_entries]
@@ -650,12 +696,13 @@ def create_minor_version_entries(
             repository=new_entry.repository,
         ))
 
-    return updates, new_entries
+    return updates, new_entries, new_directives
 
 
 def update_target_versions(
     existing_entries: list[ImageEntry],
-    new_entries: list[ImageEntry]
+    new_entries: list[ImageEntry],
+    directives: DirectivesMap
 ) -> None:
     """
     Update targetVersion fields when new entries are added.
@@ -667,6 +714,7 @@ def update_target_versions(
     Args:
         existing_entries: The original image entries for this component
         new_entries: The newly created image entries
+        directives: Map of image entries to their directives
     """
     if not new_entries:
         return
@@ -701,7 +749,7 @@ def update_target_versions(
 
     # Update the previously highest version from ">= X.Y" to "X.Y.x"
     prev_version = parse_to_semver(previously_highest.tag)
-    if previously_highest.has_version_mapping():
+    if has_version_mapping(previously_highest, directives):
         previously_highest.update_target_version(f"1.{prev_version.major}.x")
     else:
         previously_highest.update_target_version(f"{prev_version.major}.{prev_version.minor}.x")
@@ -709,27 +757,28 @@ def update_target_versions(
     # Set all new entries to "X.Y.x" format
     for entry in parseable_new:
         version = parse_to_semver(entry.tag)
-        if entry.has_version_mapping():
+        if has_version_mapping(entry, directives):
             entry.update_target_version(f"1.{version.major}.x")
         else:
             entry.update_target_version(f"{version.major}.{version.minor}.x")
 
     # Set the new highest entry to ">= X.Y" format
     new_highest_version = parse_to_semver(new_highest.tag)
-    if new_highest.has_version_mapping():
+    if has_version_mapping(new_highest, directives):
         new_highest.update_target_version(f">= 1.{new_highest_version.major}")
     else:
         major_minor = f"{new_highest_version.major}.{new_highest_version.minor}"
         new_highest.update_target_version(f">= {major_minor}")
 
 
-def update_manual_constraint_images(
+def update_explicit_constraint_images(
     image_list: list[ImageEntry],
     all_greater_tags: list[str],
-    name: str
-) -> list[ImageUpdate]:
+    name: str,
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], DirectivesMap]:
     """
-    Handle updates for images with manual k8s version constraints.
+    Handle updates for images with explicit k8s version constraints.
 
     These are images where the targetVersion (e.g., '>= 1.34') doesn't correlate
     with the image version (e.g., v6.2.0). In this case:
@@ -741,20 +790,24 @@ def update_manual_constraint_images(
         image_list: List of image entries for this component
         all_greater_tags: All available newer tags (patch + minor combined)
         name: Image name for logging and update tracking
+        directives: Map of image entries to their directives
 
     Returns:
-        List of ImageUpdate objects representing the applied updates
+        Tuple of:
+        - List of ImageUpdate objects representing the applied updates
+        - Updated DirectivesMap with keys updated for changed tags
     """
     if not all_greater_tags:
-        return []
+        return [], {}
 
     updates: list[ImageUpdate] = []
+    updated_directives: DirectivesMap = {}
 
-    # Find the entry with the manual constraint (the '>= X.Y' one)
+    # Find the entry with the explicit constraint (the '>= X.Y' one)
     constraint_entry = None
     other_entries = []
     for entry in image_list:
-        if entry.has_manual_k8s_constraint():
+        if has_explicit_k8s_constraint(entry, directives):
             constraint_entry = entry
         else:
             other_entries.append(entry)
@@ -762,10 +815,17 @@ def update_manual_constraint_images(
     # Update the constraint entry to the latest available version
     if constraint_entry:
         latest_tag = max(all_greater_tags, key=parse_to_semver)
+        old_key = _directive_key(constraint_entry)
         old_tag = constraint_entry.tag
 
         if old_tag != latest_tag:
             constraint_entry.update_tag(latest_tag)
+            new_key = _directive_key(constraint_entry)
+
+            # Migrate directives to new key if entry had directives
+            if old_key in directives:
+                updated_directives[new_key] = directives[old_key]
+
             updates.append(ImageUpdate(
                 image_name=name,
                 old_tag=old_tag,
@@ -774,7 +834,7 @@ def update_manual_constraint_images(
                 repository=constraint_entry.repository,
             ))
             print(
-                f"Updated {name} with manual k8s constraint: {old_tag} -> {latest_tag} "
+                f"Updated {name} with explicit k8s constraint: {old_tag} -> {latest_tag} "
                 f"(keeping targetVersion: {constraint_entry.targetVersion})",
                 file=sys.stderr,
             )
@@ -792,7 +852,7 @@ def update_manual_constraint_images(
                 continue
 
         for entry in other_entries:
-            if entry.is_frozen():
+            if is_frozen(entry, directives):
                 continue
             try:
                 entry_version = parse_to_semver(entry.tag)
@@ -800,8 +860,15 @@ def update_manual_constraint_images(
                 if key in tags_by_version:
                     highest_patch = max(tags_by_version[key], key=parse_to_semver)
                     if entry.tag != highest_patch:
+                        old_key = _directive_key(entry)
                         old_tag = entry.tag
                         entry.update_tag(highest_patch)
+                        new_key = _directive_key(entry)
+
+                        # Migrate directives to new key if entry had directives
+                        if old_key in directives:
+                            updated_directives[new_key] = directives[old_key]
+
                         updates.append(ImageUpdate(
                             image_name=name,
                             old_tag=old_tag,
@@ -812,14 +879,15 @@ def update_manual_constraint_images(
             except ValueError:
                 continue
 
-    return updates
+    return updates, updated_directives
 
 
 def update_versioned_images(
     image_list: list[ImageEntry],
     greater: dict[str, list[str]],
-    name: str
-) -> tuple[list[ImageUpdate], list[ImageEntry]]:
+    name: str,
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], list[ImageEntry], DirectivesMap]:
     """
     Handle updates for images with targetVersion (versioned components).
 
@@ -831,33 +899,48 @@ def update_versioned_images(
         image_list: List of image entries for this component
         greater: Dictionary with 'patch' and 'minor' version lists
         name: Image name for logging and update tracking
+        directives: Map of image entries to their directives
 
     Returns:
         Tuple containing:
         - List of ImageUpdate objects for all updates (patch + minor)
         - List of new ImageEntry objects to be added
+        - Updated DirectivesMap with directives for new entries
     """
     all_updates: list[ImageUpdate] = []
+    new_directives: DirectivesMap = {}
 
     # Apply patch updates to existing entries
-    patch_updates = apply_patch_updates(image_list, greater["patch"], name)
+    patch_updates, patch_directives = apply_patch_updates(
+        image_list, greater["patch"], name, directives
+    )
     all_updates.extend(patch_updates)
+    new_directives.update(patch_directives)
+
+    # Merge patch directives into working directives for minor version checks
+    working_directives = {**directives, **new_directives}
 
     # Create new entries for minor/major versions
-    minor_updates, new_entries = create_minor_version_entries(image_list, greater["minor"], name)
+    minor_updates, new_entries, entry_directives = create_minor_version_entries(
+        image_list, greater["minor"], name, working_directives
+    )
     all_updates.extend(minor_updates)
+    new_directives.update(entry_directives)
+
+    # Merge all new directives for update_target_versions
+    merged_directives = {**directives, **new_directives}
 
     # Update targetVersion fields
-    update_target_versions(image_list, new_entries)
+    update_target_versions(image_list, new_entries, merged_directives)
 
-    return all_updates, new_entries
+    return all_updates, new_entries, new_directives
 
 
 def update_images_data(
     images_data: ImagesData,
     new_versions_by_name_repo: dict[tuple[str, str], dict[str, list[str]]],
-    image_directives: dict[str, dict[str, Any]]
-) -> list[ImageUpdate]:
+    directives: DirectivesMap
+) -> tuple[list[ImageUpdate], DirectivesMap]:
     """
     Update the ImagesData structure with new versions and return structured update info.
 
@@ -871,20 +954,18 @@ def update_images_data(
 
     Args:
         images_data: The ImagesData object loaded from images.yaml
-        new_versions_by_name: Maps (image_name, repository) to its new 'patch' and 'minor' versions
-        image_directives: Maps image entries to their comment directives
+        new_versions_by_name_repo: Maps (image_name, repository) to its new 'patch' and 'minor'
+            versions
+        directives: Map of image entries to their directives
 
     Returns:
-        List of structured ImageUpdate objects detailing each update performed
+        Tuple containing:
+        - List of structured ImageUpdate objects detailing each update performed
+        - Updated DirectivesMap including directives for newly created entries
     """
     all_updates: list[ImageUpdate] = []
     all_new_entries: list[ImageEntry] = []
-
-    # Apply directives to image entries
-    for image in images_data.images:
-        key = f"{image.name}:{image.repository}:{image.tag}"
-        if key in image_directives:
-            image.set_directives(image_directives[key])
+    updated_directives = dict(directives)  # Copy to avoid modifying original
 
     # Group images by (name, repository) for processing
     images_by_name_repo = defaultdict(list)
@@ -899,8 +980,8 @@ def update_images_data(
         greater = new_versions_by_name_repo[(name, repository)]
 
         # Separate frozen entries from active entries
-        frozen_entries = [img for img in image_list if img.is_frozen()]
-        active_entries = [img for img in image_list if not img.is_frozen()]
+        frozen_entries = [img for img in image_list if is_frozen(img, directives)]
+        active_entries = [img for img in image_list if not is_frozen(img, directives)]
 
         # Log frozen entries
         for img in frozen_entries:
@@ -911,34 +992,45 @@ def update_images_data(
             continue
 
         has_target_version = any(img.has_target_version() for img in active_entries)
-        has_manual_constraint = any(img.has_manual_k8s_constraint() for img in active_entries)
+        has_explicit_constraint = any(
+            has_explicit_k8s_constraint(img, directives) for img in active_entries
+        )
 
         if not has_target_version:
             # Handle singleton images (no targetVersion)
             all_greater_tags = greater["patch"] + greater["minor"]
-            updates = update_singleton_image(active_entries, all_greater_tags, name)
+            updates, new_directives = update_singleton_image(
+                active_entries, all_greater_tags, name, updated_directives,
+            )
             all_updates.extend(updates)
-        elif has_manual_constraint:
-            # Handle images with manual k8s constraints (e.g., '>= 1.34' with v6.x image)
+            updated_directives.update(new_directives)
+        elif has_explicit_constraint:
+            # Handle images with explicit k8s constraints (e.g., '>= 1.34' with v6.x image)
             all_greater_tags = greater["patch"] + greater["minor"]
-            updates = update_manual_constraint_images(active_entries, all_greater_tags, name)
+            updates, new_directives = update_explicit_constraint_images(
+                active_entries, all_greater_tags, name, updated_directives,
+            )
             all_updates.extend(updates)
+            updated_directives.update(new_directives)
         else:
             # Handle versioned images (with targetVersion)
-            updates, new_entries = update_versioned_images(active_entries, greater, name)
+            updates, new_entries, new_directives = update_versioned_images(
+                active_entries, greater, name, updated_directives,
+            )
             all_updates.extend(updates)
             all_new_entries.extend(new_entries)
+            updated_directives.update(new_directives)
 
     # Add all new entries to the main data structure
     images_data.add_images(all_new_entries)
-    return all_updates
+    return all_updates, updated_directives
 
 
 # --- I/O and Formatting Functions ---
 def write_yaml_file(
         data: ImagesData,
         filename: str,
-        original_yaml_data: Any
+        directives: DirectivesMap
 ) -> None:
     """
     Write the ImagesData and comments to a YAML file.
@@ -946,11 +1038,11 @@ def write_yaml_file(
     Args:
         data: The ImagesData object to be written
         filename: The path to the output YAML file
-        original_yaml_data: The original YAML data structure with comments
+        directives: Map of image entries to their directives for comment reconstruction
     """
     yaml = YAML()
     yaml.preserve_quotes = True
-    yaml.width = 4096
+    yaml.width = math.inf
 
     # Create completely new structure
     new_data = yaml.load("images: []\n")
@@ -958,26 +1050,26 @@ def write_yaml_file(
 
     # Add each image with comment preservation
     for i, img_data in enumerate(updated_data['images']):
-        clean_img = {k: v for k, v in img_data.items() if k != '_directives'}
-        new_data['images'].append(clean_img)
+        new_data['images'].append(img_data)
 
-        # Reconstruct comments from the original ImageEntry's directives
+        # Reconstruct comments from the directives map
         image_entry = data.images[i]
+        entry_directives = get_entry_directives(image_entry, directives)
 
-        if image_entry._directives:
+        if entry_directives:
             comment_lines = []
 
             # Add directive comments
-            if image_entry._directives.get('freeze'):
+            if entry_directives.get('freeze'):
                 comment_lines.append("freeze")
-            if image_entry._directives.get('max_supported_k8s'):
+            if entry_directives.get('max_supported_k8s'):
                 comment_lines.append("max-supported-k8s")
-            if image_entry._directives.get('version_mapping'):
+            if entry_directives.get('version_mapping'):
                 comment_lines.append("version-mapping")
 
             # Add additional comments (non-directive comments)
-            if image_entry._directives.get('additional_comments'):
-                comment_lines.extend(image_entry._directives['additional_comments'])
+            if entry_directives.get('additional_comments'):
+                comment_lines.extend(entry_directives['additional_comments'])
 
             # Apply all comments
             if comment_lines:
@@ -996,7 +1088,7 @@ def create_release_notes(
     updates: list[ImageUpdate],
     images_data: ImagesData,
     all_available_tags: dict[tuple[str, str], list[str]],
-    filename: str,
+    filename: str
 ) -> None:
     """
     Create a markdown file with links to release notes of all added or changed releases.
@@ -1128,13 +1220,13 @@ def main() -> None:
     try:
         with open(args.images_yaml_path, 'r') as f:
             yaml_content = f.read()
-        images_data, original_yaml_data = load_and_validate_images_data(args.images_yaml_path)
+        images_data = load_and_validate_images_data(yaml_content)
     except (FileNotFoundError, YAMLError, ValueError) as e:
         print(f"Error loading images data: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Parse comment directives
-    image_directives = create_image_directive_map(yaml_content, images_data)
+    directives = create_image_directive_map(yaml_content, images_data)
 
     oci_api = oci_client.client_with_dockerauth()
 
@@ -1179,11 +1271,13 @@ def main() -> None:
             all_new_versions[(name, repository)] = greater_versions
 
     if all_new_versions:
-        updates = update_images_data(images_data, all_new_versions, image_directives)
+        updates, updated_directives = update_images_data(
+            images_data, all_new_versions, directives
+        )
 
         if updates:
             images_data.sort_images()
-            write_yaml_file(images_data, args.images_yaml_path, original_yaml_data)
+            write_yaml_file(images_data, args.images_yaml_path, updated_directives)
             print(f"\nUpdated {args.images_yaml_path} with {len(updates)} changes.", file=sys.stderr)
 
         create_release_notes(updates, images_data, all_available_tags, args.release_notes_path)

--- a/.github/actions/update-extension-provider-images/update-images.py
+++ b/.github/actions/update-extension-provider-images/update-images.py
@@ -13,15 +13,33 @@ versions defined in Gardener's extension provider repos at `imagevector/images.y
 
 How it works:
 1.  The action is triggered by a reusable workflow.
-2.  It reads all image entries from the `images.yaml` file.
+2.  It reads all image entries from the `images.yaml` file and parses comment directives.
 3.  It uses the `oci.client` library to query container registries for new tags.
 4.  It updates the `images.yaml` file in-place based on a set of rules:
     - For patch updates, it updates the tag of the existing entry.
     - For new minor/major versions, it adds a new image entry.
     - It ensures the highest minor version has a `targetVersion` of ">= X.Y".
     - For images without a `targetVersion`, it keeps only the single latest tag.
+    - It respects comment directives that control update behavior.
 5.  It generates a `release-notes.md` file containing direct links to the
     release pages for all new and intermediate tags.
+
+Comment Directives (one per line, placed above image entries):
+- freeze: Freeze this entry completely (no updates). Use cases:
+    - Freeze a specific version due to a known issue in newer releases.
+    - Keep a legacy entry (without targetVersion) as fallback for older k8s versions
+      while allowing other entries with targetVersion to be updated normally.
+- max-supported-k8s: Prevent adding new entries for k8s versions not yet supported by
+    Gardener. Place on the highest version entry to stop automatic additions.
+- version-mapping: GCP cloud-controller-manager only. Maps image major version to k8s
+    minor version (e.g., image v32.x -> targetVersion 1.32.x).
+
+Comments not recognized as directives are preserved in the output.
+
+Manual k8s Constraints:
+Images with targetVersion like '>= 1.34' that don't correlate with the image version
+(e.g., csi-provisioner v6.x with '>= 1.34') are detected automatically. These entries
+are updated to the latest available version while preserving the original targetVersion.
 
 This script is not intended to be run manually by developers. It should be
 invoked via the `gardener/cc-utils/.github/workflows/update-extension-provider-images.yaml`
@@ -34,6 +52,7 @@ are no longer supported.
 """
 
 import argparse
+import re
 import sys
 import traceback
 from collections import defaultdict
@@ -42,7 +61,8 @@ from typing import Optional, Any
 
 import dacite
 import semver
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml import YAMLError
 
 from oci import client as oci_client
 from ocm import Label as OcmLabel
@@ -64,6 +84,7 @@ class ImageEntry:
     labels: list[OcmLabel]
     targetVersion: Optional[str] = None
     resourceId: Optional[ResourceId] = None
+    _directives: Optional[dict[str, Any]] = None  # Internal field for directives
 
     def has_target_version(self) -> bool:
         return self.targetVersion is not None
@@ -77,13 +98,60 @@ class ImageEntry:
     def copy_as_template(
             self,
             new_tag: str,
-            new_target_version: str
+            new_target_version: str,
     ) -> 'ImageEntry':
+        # Only keep version_mapping
+        filtered_directives = {}
+        if self._directives and self._directives.get('version_mapping'):
+            filtered_directives['version_mapping'] = True
+
         return replace(
                 self,
                 tag=new_tag,
-                targetVersion=new_target_version
+                targetVersion=new_target_version,
+                _directives=filtered_directives if filtered_directives else None
         )
+
+    def is_frozen(self) -> bool:
+        return bool(self._directives and self._directives.get('freeze', False))
+
+    def should_skip_minor_update(self) -> bool:
+        return bool(self._directives and self._directives.get('max_supported_k8s', False))
+
+    def has_version_mapping(self) -> bool:
+        return bool(self._directives and self._directives.get('version_mapping', False))
+
+    def has_manual_k8s_constraint(self) -> bool:
+        """
+        Check if this entry has a manual k8s version constraint.
+
+        Returns True if:
+        - Entry has a targetVersion starting with '>='
+        - The constraint version doesn't match the image version
+        - No version-mapping directive is present
+
+        Example: image v6.2.0 with targetVersion '>= 1.34' is a manual constraint
+        because 6.2 != 1.34 and there's no version-mapping.
+        """
+        if not self.targetVersion or self.has_version_mapping():
+            return False
+
+        if not self.targetVersion.startswith('>='):
+            return False
+
+        try:
+            target_version_str = self.targetVersion.replace('>=', '').strip()
+            target_version = parse_to_semver(target_version_str)
+            image_version = parse_to_semver(self.tag)
+
+            # If target version doesn't match image version, it's a manual constraint
+            return (target_version.major, target_version.minor) != \
+                   (image_version.major, image_version.minor)
+        except ValueError:
+            return False
+
+    def set_directives(self, directives: dict[str, Any]) -> None:
+        self._directives = directives or {}
 
 
 @dataclass
@@ -111,7 +179,13 @@ class ImagesData:
         self.images.sort(key=sort_key)
 
     def to_dict(self) -> dict[str, Any]:
-        result = asdict(self)
+        result = {'images': []}
+        for image in self.images:
+            image_dict = asdict(image)
+            # Remove internal fields that shouldn't end up in the new yaml
+            image_dict.pop('_directives', None)
+            result['images'].append(image_dict)
+
         return self._remove_none_values(result)
 
     def _remove_none_values(self, data: Any) -> Any:
@@ -133,10 +207,11 @@ class ImageUpdate:
     new_tag: str
     update_type: str  # 'patch', 'minor', or 'singleton'
     old_tag: Optional[str] = None
+    repository: Optional[str] = None
 
 
 # --- Helper Functions ---
-def load_and_validate_images_data(images_yaml_path: str) -> ImagesData:
+def load_and_validate_images_data(images_yaml_path: str) -> tuple[ImagesData, Any]:
     """
     Load and validate images.yaml data using dacite.
 
@@ -144,25 +219,160 @@ def load_and_validate_images_data(images_yaml_path: str) -> ImagesData:
         images_yaml_path: Path to the images.yaml file
 
     Returns:
-        Validated ImagesData object
+        Tuple of (Validated ImagesData object, raw YAML data for comment parsing)
 
     Raises:
         ValueError: If the file cannot be read, parsed, or validated
     """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+
     with open(images_yaml_path, "r") as f:
-        raw_data = yaml.safe_load(f)
+        raw_yaml_data = yaml.load(f)
+        raw_yaml_data['images']
 
     try:
-        return dacite.from_dict(
+        validated_data = dacite.from_dict(
             data_class=ImagesData,
-            data=raw_data,
+            data=dict(raw_yaml_data),  # Convert to regular dict for dacite
             config=dacite.Config(
                 strict=True,
                 check_types=True,
             ),
         )
+        return validated_data, raw_yaml_data
     except dacite.DaciteError as e:
         raise ValueError(f"Invalid images.yaml structure in {images_yaml_path}: {e}")
+
+
+def parse_image_comments(yaml_content: str) -> dict[str, dict[str, Any]]:
+    """
+    Parse comments above image entries to extract directives.
+
+    Scans through the YAML content line by line, collecting comment blocks
+    that appear immediately before image entries (lines starting with '- name:').
+    Each comment block is parsed for supported directives.
+
+    Args:
+        yaml_content: Raw YAML file content as string
+
+    Returns:
+        Dictionary mapping line numbers to directive information, where each
+        value contains the image name and parsed directives
+    """
+    lines = yaml_content.split('\n')
+    image_directives = {}
+    current_comment_block = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Collect comment lines
+        if stripped.startswith('#'):
+            current_comment_block.append(stripped[1:].strip())
+        elif stripped.startswith('- name:'):
+            # This is an image entry, parse the preceding comments
+            image_name_match = re.search(r'- name:\s*(.+)', stripped)
+            if image_name_match:
+                image_name = image_name_match.group(1).strip()
+                directives = parse_comment_directives(current_comment_block)
+                if directives:
+                    # Use line number as unique key since image names can repeat
+                    image_directives[i] = {
+                        'name': image_name,
+                        'directives': directives
+                    }
+            current_comment_block = []
+
+    return image_directives
+
+
+def parse_comment_directives(comment_lines: list[str]) -> dict[str, Any]:
+    """
+    Parse individual comment directives from a block of comment lines.
+
+    Recognizes the following directives (case-insensitive, one per line):
+    - freeze: Freezes this entry completely (no updates)
+    - max-supported-k8s: Prevents minor/major version updates
+    - version-mapping: Enables special version mapping (e.g., for K8s CCM)
+
+    All other line comments are preserved in additional_comments.
+
+    Args:
+        comment_lines: List of comment line contents (without '#' prefix)
+
+    Returns:
+        Dictionary of recognized directives with boolean values
+    """
+    directives = {}
+    additional_comments = []
+
+    for line in comment_lines:
+        cleaned_line = line.strip().lstrip('#').strip()
+        line_lower = cleaned_line.lower()
+
+        # Check if the line is a standalone directive
+        if line_lower == 'freeze':
+            directives['freeze'] = True
+        elif line_lower == 'max-supported-k8s':
+            directives['max_supported_k8s'] = True
+        elif line_lower == 'version-mapping':
+            directives['version_mapping'] = True
+        elif cleaned_line:
+            additional_comments.append(cleaned_line)
+
+    # Save additional comments if any
+    if additional_comments:
+        directives['additional_comments'] = additional_comments
+
+    return directives
+
+
+def create_image_directive_map(
+    yaml_content: str,
+    images_data: ImagesData
+) -> dict[str, dict[str, Any]]:
+    """
+    Create a mapping from image entries to their comment directives.
+
+    Converts the line-number-based directive mapping to an image-entry-based
+    mapping by matching image names and their occurrence order. This allows
+    directives to be applied to specific ImageEntry objects.
+
+    Args:
+        yaml_content: Raw YAML file content as string
+        images_data: Parsed and validated ImagesData object
+
+    Returns:
+        Dictionary mapping unique image keys (name:repository:tag) to their
+        comment directives
+    """
+    comment_directives = parse_image_comments(yaml_content)
+
+    # Convert line-based mapping to image-based mapping
+    lines = yaml_content.split('\n')
+    image_directives = {}
+
+    for line_num, directive_info in comment_directives.items():
+        # Find the corresponding image entry by matching name and position
+        image_name = directive_info['name']
+
+        # Count which occurrence of this image name this is
+        occurrence = 0
+        for i in range(int(line_num)):
+            if re.search(rf'- name:\s*{re.escape(image_name)}', lines[i]):
+                occurrence += 1
+
+        # Find the corresponding ImageEntry object
+        matching_images = [img for img in images_data.images if img.name == image_name]
+        if occurrence < len(matching_images):
+            # Create a unique key for this specific image entry
+            img_entry = matching_images[occurrence]
+            key = f"{img_entry.name}:{img_entry.repository}:{img_entry.tag}"
+            image_directives[key] = directive_info['directives']
+
+    return image_directives
 
 
 # --- Core Logic Functions ---
@@ -272,6 +482,11 @@ def update_singleton_image(
         )
         sys.exit(1)
 
+    # Check if this singleton image should be kept
+    if image_list[0].is_frozen():
+        print(f"Skipping update for singleton {name} due to 'freeze' directive", file=sys.stderr)
+        return []
+
     latest_tag = max(all_greater_tags, key=parse_to_semver)
     old_tag = image_list[0].tag
 
@@ -282,6 +497,7 @@ def update_singleton_image(
             old_tag=old_tag,
             new_tag=latest_tag,
             update_type="singleton",
+            repository=image_list[0].repository,
         )]
 
     return []
@@ -328,6 +544,15 @@ def apply_patch_updates(
             try:
                 img_version = parse_to_semver(img_entry.tag)
                 if (img_version.major, img_version.minor) == (major, minor):
+                    # Check if this specific image should skip patch updates
+                    if img_entry.is_frozen():
+                        print(
+                            f"Skipping patch update for {name} tag {img_entry.tag} "
+                            "due to 'freeze' directive",
+                            file=sys.stderr,
+                        )
+                        continue
+
                     old_tag = img_entry.tag
                     img_entry.update_tag(highest_patch_tag)
                     updates.append(ImageUpdate(
@@ -335,6 +560,7 @@ def apply_patch_updates(
                         old_tag=old_tag,
                         new_tag=highest_patch_tag,
                         update_type="patch",
+                        repository=img_entry.repository,
                     ))
                     break
             except ValueError:
@@ -368,6 +594,19 @@ def create_minor_version_entries(
     updates: list[ImageUpdate] = []
     new_entries: list[ImageEntry] = []
 
+    # Check if the highest version entry (which controls minor updates) should be kept
+    try:
+        highest_existing = max(image_list, key=lambda img: parse_to_semver(img.tag))
+        if highest_existing.should_skip_minor_update():
+            print(
+                f"Skipping minor/major updates for {name} due to "
+                "'max-supported-k8s' directive on highest version",
+                file=sys.stderr,
+            )
+            return updates, new_entries
+    except ValueError:
+        pass  # If we can't parse versions, proceed with updates
+
     # Group minor tags by major.minor version
     tags_by_version: dict[tuple[int, int], list[str]] = defaultdict(list)
     for tag in minor_tags:
@@ -383,8 +622,12 @@ def create_minor_version_entries(
         highest_tag = max(tags, key=parse_to_semver)
 
         # Create new entry for the highest patch version only
-        target_version = f"{major}.{minor}.x"
-        new_entry = image_list[0].copy_as_template(highest_tag, target_version)
+        if image_list[0].has_version_mapping():
+            target_version = f"1.{major}.x"  # For k8s-ccm mapping
+        else:
+            target_version = f"{major}.{minor}.x"
+
+        new_entry = image_list[-1].copy_as_template(highest_tag, target_version)
         new_entries.append(new_entry)
 
         # Find the previous highest version for the update record
@@ -404,47 +647,172 @@ def create_minor_version_entries(
             old_tag=old_tag,
             new_tag=highest_tag,
             update_type="minor",
+            repository=new_entry.repository,
         ))
 
     return updates, new_entries
 
 
-def update_target_versions(all_image_entries: list[ImageEntry]) -> None:
+def update_target_versions(
+    existing_entries: list[ImageEntry],
+    new_entries: list[ImageEntry]
+) -> None:
     """
-    Update targetVersion fields for all image entries of a component.
+    Update targetVersion fields when new entries are added.
 
-    The highest version gets ">= X.Y" format and all others get "X.Y.x" format.
-    Only processes entries with valid semantic versions.
+    Updates the previously highest version (from ">= X.Y" to "X.Y.x"),
+    new version entries to "X.Y.x" format,
+    and sets the new highest version to ">= X.Y" format.
 
     Args:
-        all_image_entries: All image entries for a component (existing + new)
+        existing_entries: The original image entries for this component
+        new_entries: The newly created image entries
     """
-    # Filter to entries with parseable semantic versions
-    parseable_entries = []
-    for entry in all_image_entries:
+    if not new_entries:
+        return
+
+    # Find the previously highest version among existing entries
+    parseable_existing = []
+    for entry in existing_entries:
         try:
             parse_to_semver(entry.tag)
-            parseable_entries.append(entry)
+            parseable_existing.append(entry)
         except ValueError:
             continue
 
-    if not parseable_entries:
+    # Find the new highest version among all entries
+    parseable_new = []
+    for entry in new_entries:
+        try:
+            parse_to_semver(entry.tag)
+            parseable_new.append(entry)
+        except ValueError:
+            continue
+
+    if not parseable_existing or not parseable_new:
         return
 
-    # Find the highest version entry
-    highest_entry = max(
-        parseable_entries,
-        key=lambda img: parse_to_semver(img.tag),
-    )
-    highest_version = parse_to_semver(highest_entry.tag)
+    # Get the previously highest existing entry
+    previously_highest = max(parseable_existing, key=lambda img: parse_to_semver(img.tag))
 
-    # Set all entries to "X.Y.x" format first
-    for entry in parseable_entries:
+    # Get the new overall highest entry (could be existing or new)
+    all_parseable = parseable_existing + parseable_new
+    new_highest = max(all_parseable, key=lambda img: parse_to_semver(img.tag))
+
+    # Update the previously highest version from ">= X.Y" to "X.Y.x"
+    prev_version = parse_to_semver(previously_highest.tag)
+    if previously_highest.has_version_mapping():
+        previously_highest.update_target_version(f"1.{prev_version.major}.x")
+    else:
+        previously_highest.update_target_version(f"{prev_version.major}.{prev_version.minor}.x")
+
+    # Set all new entries to "X.Y.x" format
+    for entry in parseable_new:
         version = parse_to_semver(entry.tag)
-        entry.update_target_version(f"{version.major}.{version.minor}.x")
+        if entry.has_version_mapping():
+            entry.update_target_version(f"1.{version.major}.x")
+        else:
+            entry.update_target_version(f"{version.major}.{version.minor}.x")
 
-    # Set the highest one to ">= X.Y" format
-    highest_entry.update_target_version(f">= {highest_version.major}.{highest_version.minor}")
+    # Set the new highest entry to ">= X.Y" format
+    new_highest_version = parse_to_semver(new_highest.tag)
+    if new_highest.has_version_mapping():
+        new_highest.update_target_version(f">= 1.{new_highest_version.major}")
+    else:
+        major_minor = f"{new_highest_version.major}.{new_highest_version.minor}"
+        new_highest.update_target_version(f">= {major_minor}")
+
+
+def update_manual_constraint_images(
+    image_list: list[ImageEntry],
+    all_greater_tags: list[str],
+    name: str
+) -> list[ImageUpdate]:
+    """
+    Handle updates for images with manual k8s version constraints.
+
+    These are images where the targetVersion (e.g., '>= 1.34') doesn't correlate
+    with the image version (e.g., v6.2.0). In this case:
+    - Update the constrained entry's tag to the latest available version
+    - Preserve the original targetVersion (don't create new entries)
+    - Apply patch updates to any other entries without the constraint
+
+    Args:
+        image_list: List of image entries for this component
+        all_greater_tags: All available newer tags (patch + minor combined)
+        name: Image name for logging and update tracking
+
+    Returns:
+        List of ImageUpdate objects representing the applied updates
+    """
+    if not all_greater_tags:
+        return []
+
+    updates: list[ImageUpdate] = []
+
+    # Find the entry with the manual constraint (the '>= X.Y' one)
+    constraint_entry = None
+    other_entries = []
+    for entry in image_list:
+        if entry.has_manual_k8s_constraint():
+            constraint_entry = entry
+        else:
+            other_entries.append(entry)
+
+    # Update the constraint entry to the latest available version
+    if constraint_entry:
+        latest_tag = max(all_greater_tags, key=parse_to_semver)
+        old_tag = constraint_entry.tag
+
+        if old_tag != latest_tag:
+            constraint_entry.update_tag(latest_tag)
+            updates.append(ImageUpdate(
+                image_name=name,
+                old_tag=old_tag,
+                new_tag=latest_tag,
+                update_type="singleton",
+                repository=constraint_entry.repository,
+            ))
+            print(
+                f"Updated {name} with manual k8s constraint: {old_tag} -> {latest_tag} "
+                f"(keeping targetVersion: {constraint_entry.targetVersion})",
+                file=sys.stderr,
+            )
+
+    # Apply patch updates to other entries (non-constraint ones)
+    if other_entries:
+        # Group all_greater_tags by major.minor to find patches for existing entries
+        tags_by_version: dict[tuple[int, int], list[str]] = defaultdict(list)
+        for tag in all_greater_tags:
+            try:
+                version = parse_to_semver(tag)
+                key = (version.major, version.minor)
+                tags_by_version[key].append(tag)
+            except ValueError:
+                continue
+
+        for entry in other_entries:
+            if entry.is_frozen():
+                continue
+            try:
+                entry_version = parse_to_semver(entry.tag)
+                key = (entry_version.major, entry_version.minor)
+                if key in tags_by_version:
+                    highest_patch = max(tags_by_version[key], key=parse_to_semver)
+                    if entry.tag != highest_patch:
+                        old_tag = entry.tag
+                        entry.update_tag(highest_patch)
+                        updates.append(ImageUpdate(
+                            image_name=name,
+                            old_tag=old_tag,
+                            new_tag=highest_patch,
+                            update_type="patch",
+                            repository=entry.repository,
+                        ))
+            except ValueError:
+                continue
+
+    return updates
 
 
 def update_versioned_images(
@@ -479,16 +847,16 @@ def update_versioned_images(
     minor_updates, new_entries = create_minor_version_entries(image_list, greater["minor"], name)
     all_updates.extend(minor_updates)
 
-    # Update targetVersion fields for all entries (existing + new)
-    all_image_entries = image_list + new_entries
-    update_target_versions(all_image_entries)
+    # Update targetVersion fields
+    update_target_versions(image_list, new_entries)
 
     return all_updates, new_entries
 
 
 def update_images_data(
     images_data: ImagesData,
-    new_versions_by_name: dict[str, dict[str, list[str]]]
+    new_versions_by_name_repo: dict[tuple[str, str], dict[str, list[str]]],
+    image_directives: dict[str, dict[str, Any]]
 ) -> list[ImageUpdate]:
     """
     Update the ImagesData structure with new versions and return structured update info.
@@ -497,9 +865,14 @@ def update_images_data(
     type (singleton vs versioned). It modifies the images_data in-place
     and returns a comprehensive list of all changes made.
 
+    Frozen entries (with 'freeze' directive) are excluded from processing entirely.
+    This allows a frozen entry without targetVersion to coexist with active versioned
+    entries for the same image name.
+
     Args:
         images_data: The ImagesData object loaded from images.yaml
-        new_versions_by_name: Maps image name to its new 'patch' and 'minor' versions
+        new_versions_by_name: Maps (image_name, repository) to its new 'patch' and 'minor' versions
+        image_directives: Maps image entries to their comment directives
 
     Returns:
         List of structured ImageUpdate objects detailing each update performed
@@ -507,25 +880,52 @@ def update_images_data(
     all_updates: list[ImageUpdate] = []
     all_new_entries: list[ImageEntry] = []
 
-    # Group images by name for processing
-    images_by_name = images_data.get_images_by_name()
+    # Apply directives to image entries
+    for image in images_data.images:
+        key = f"{image.name}:{image.repository}:{image.tag}"
+        if key in image_directives:
+            image.set_directives(image_directives[key])
+
+    # Group images by (name, repository) for processing
+    images_by_name_repo = defaultdict(list)
+    for image in images_data.images:
+        images_by_name_repo[(image.name, image.repository)].append(image)
 
     # Process each image group that has new versions available
-    for name, image_list in images_by_name.items():
-        if name not in new_versions_by_name:
+    for (name, repository), image_list in images_by_name_repo.items():
+        if (name, repository) not in new_versions_by_name_repo:
             continue
 
-        greater = new_versions_by_name[name]
-        has_target_version = any(img.has_target_version() for img in image_list)
+        greater = new_versions_by_name_repo[(name, repository)]
+
+        # Separate frozen entries from active entries
+        frozen_entries = [img for img in image_list if img.is_frozen()]
+        active_entries = [img for img in image_list if not img.is_frozen()]
+
+        # Log frozen entries
+        for img in frozen_entries:
+            print(f"Skipping frozen entry {name} tag {img.tag}", file=sys.stderr)
+
+        # If no active entries remain, nothing to update
+        if not active_entries:
+            continue
+
+        has_target_version = any(img.has_target_version() for img in active_entries)
+        has_manual_constraint = any(img.has_manual_k8s_constraint() for img in active_entries)
 
         if not has_target_version:
             # Handle singleton images (no targetVersion)
             all_greater_tags = greater["patch"] + greater["minor"]
-            updates = update_singleton_image(image_list, all_greater_tags, name)
+            updates = update_singleton_image(active_entries, all_greater_tags, name)
+            all_updates.extend(updates)
+        elif has_manual_constraint:
+            # Handle images with manual k8s constraints (e.g., '>= 1.34' with v6.x image)
+            all_greater_tags = greater["patch"] + greater["minor"]
+            updates = update_manual_constraint_images(active_entries, all_greater_tags, name)
             all_updates.extend(updates)
         else:
             # Handle versioned images (with targetVersion)
-            updates, new_entries = update_versioned_images(image_list, greater, name)
+            updates, new_entries = update_versioned_images(active_entries, greater, name)
             all_updates.extend(updates)
             all_new_entries.extend(new_entries)
 
@@ -537,30 +937,65 @@ def update_images_data(
 # --- I/O and Formatting Functions ---
 def write_yaml_file(
         data: ImagesData,
-        filename: str
+        filename: str,
+        original_yaml_data: Any
 ) -> None:
     """
-    Write the ImagesData to a YAML file using standard YAML formatting.
+    Write the ImagesData and comments to a YAML file.
 
     Args:
         data: The ImagesData object to be written
         filename: The path to the output YAML file
+        original_yaml_data: The original YAML data structure with comments
     """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+
+    # Create completely new structure
+    new_data = yaml.load("images: []\n")
+    updated_data = data.to_dict()
+
+    # Add each image with comment preservation
+    for i, img_data in enumerate(updated_data['images']):
+        clean_img = {k: v for k, v in img_data.items() if k != '_directives'}
+        new_data['images'].append(clean_img)
+
+        # Reconstruct comments from the original ImageEntry's directives
+        image_entry = data.images[i]
+
+        if image_entry._directives:
+            comment_lines = []
+
+            # Add directive comments
+            if image_entry._directives.get('freeze'):
+                comment_lines.append("freeze")
+            if image_entry._directives.get('max_supported_k8s'):
+                comment_lines.append("max-supported-k8s")
+            if image_entry._directives.get('version_mapping'):
+                comment_lines.append("version-mapping")
+
+            # Add additional comments (non-directive comments)
+            if image_entry._directives.get('additional_comments'):
+                comment_lines.extend(image_entry._directives['additional_comments'])
+
+            # Apply all comments
+            if comment_lines:
+                comment_text = "\n".join(comment_lines)
+                new_data['images'].yaml_set_comment_before_after_key(
+                    key=i,
+                    before=comment_text,
+                    indent=0
+                )
+
     with open(filename, "w") as f:
-        yaml.safe_dump(
-            data.to_dict(),
-            f,
-            default_flow_style=False,
-            sort_keys=False,
-            allow_unicode=True,
-            width=float('inf'),
-        )
+        yaml.dump(new_data, f)
 
 
 def create_release_notes(
     updates: list[ImageUpdate],
     images_data: ImagesData,
-    all_available_tags: dict[str, list[str]],
+    all_available_tags: dict[tuple[str, str], list[str]],
     filename: str,
 ) -> None:
     """
@@ -572,28 +1007,33 @@ def create_release_notes(
     Args:
         updates: A list of structured update objects
         images_data: The updated ImagesData (used to find source repositories)
-        all_available_tags: A map of image names to all their available tags
+        all_available_tags: A map of (image_name, repository) to all their available tags
         filename: The path to the output release notes markdown file
     """
     if not updates:
         return
 
-    repos_by_name = {
-        img.name: img.sourceRepository
-        for img in images_data.images
-        if img.sourceRepository
-    }
+    repos_by_name_repo = {}
+    for img in images_data.images:
+        if img.sourceRepository:
+            repos_by_name_repo[(img.name, img.repository)] = img.sourceRepository
 
-    updates_by_image: dict[str, list[str]] = defaultdict(list)
+    # Group updates by (image_name, repository) to handle multiple repos per image name
+    updates_by_image_repo: dict[tuple[str, str, str], list[str]] = defaultdict(list)
+
     for update in updates:
         image_name = update.image_name
         old_tag = update.old_tag
         new_tag = update.new_tag
+        repository = update.repository
 
         if old_tag:
             try:
+                if not repository or (image_name, repository) not in all_available_tags:
+                    continue
+
                 valid_tags = []
-                for t in all_available_tags[image_name]:
+                for t in all_available_tags[(image_name, repository)]:
                     try:
                         v = parse_to_semver(t)
                         if is_final(v):
@@ -608,13 +1048,20 @@ def create_release_notes(
                         versions=valid_tags,
                     )
                 )
-                updates_by_image[image_name].extend(intermediate)
+
+                source_repo = repos_by_name_repo.get((image_name, repository), "")
+                key = (image_name, repository, source_repo)
+                updates_by_image_repo[key].extend(intermediate)
             except ValueError as e:
                 print(f"Error: Could not determine upgrade path for {image_name} ")
                 print(f" with update {update}: {e}", file=sys.stderr)
                 sys.exit(1)
         else:
-            updates_by_image[image_name].append(new_tag)
+            if not repository:
+                continue
+            source_repo = repos_by_name_repo.get((image_name, repository), "")
+            key = (image_name, repository, source_repo)
+            updates_by_image_repo[key].append(new_tag)
 
     with open(filename, "w") as f:
         f.write("## Release Notes\n\n")
@@ -627,18 +1074,34 @@ def create_release_notes(
             "to ensure no breaking changes are missed.\n\n"
         )
 
-        for image_name in sorted(updates_by_image.keys()):
+        # Group by image name for display, but keep repository separation
+        by_image_name = defaultdict(list)
+        for (image_name, repository, source_repo), tags in updates_by_image_repo.items():
+            by_image_name[image_name].append((repository, source_repo, tags))
+
+        for image_name in sorted(by_image_name.keys()):
             f.write(f"### {image_name}\n\n")
-            repo_url = repos_by_name.get(image_name)
 
-            unique_tags = sorted(list(set(updates_by_image[image_name])), key=parse_to_semver)
+            # Sort by repository to have consistent output
+            repo_data = sorted(by_image_name[image_name], key=lambda x: x[0])
 
-            for tag in unique_tags:
-                if repo_url:
-                    release_link = f"https://{repo_url}/releases/tag/{tag}"
-                    f.write(f"- [{tag}]({release_link})\n")
-                else:
-                    f.write(f"- {tag}\n")
+            for repository, source_repo, tags in repo_data:
+                unique_tags = sorted(list(set(tags)), key=parse_to_semver)
+
+                # Add repository info if multiple repos for same image
+                if len(repo_data) > 1:
+                    f.write(f"**{repository}:**\n")
+
+                for tag in unique_tags:
+                    if source_repo:
+                        release_link = f"https://{source_repo}/releases/tag/{tag}"
+                        f.write(f"- [{tag}]({release_link})\n")
+                    else:
+                        f.write(f"- {tag}\n")
+
+                if len(repo_data) > 1:
+                    f.write("\n")
+
             f.write("\n")
 
 
@@ -661,11 +1124,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Read the raw YAML content first (for comment parsing)
     try:
-        images_data = load_and_validate_images_data(args.images_yaml_path)
-    except (FileNotFoundError, yaml.YAMLError, ValueError) as e:
+        with open(args.images_yaml_path, 'r') as f:
+            yaml_content = f.read()
+        images_data, original_yaml_data = load_and_validate_images_data(args.images_yaml_path)
+    except (FileNotFoundError, YAMLError, ValueError) as e:
         print(f"Error loading images data: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # Parse comment directives
+    image_directives = create_image_directive_map(yaml_content, images_data)
 
     oci_api = oci_client.client_with_dockerauth()
 
@@ -673,8 +1142,8 @@ def main() -> None:
     for image in images_data.images:
         image_groups[(image.name, image.repository)].append(image)
 
-    all_new_versions: dict[str, dict[str, list[str]]] = {}
-    all_available_tags: dict[str, list[str]] = {}
+    all_new_versions: dict[tuple[str, str], dict[str, list[str]]] = {}
+    all_available_tags: dict[tuple[str, str], list[str]] = {}
 
     for (name, repository), image_list in image_groups.items():
         print(f"Checking {name} at {repository}...", file=sys.stderr)
@@ -694,7 +1163,7 @@ def main() -> None:
             )
             sys.exit(1)
 
-        all_available_tags[name] = available_tags
+        all_available_tags[(name, repository)] = available_tags
         current_tags = [img.tag for img in image_list]
 
         greater_versions = find_greater_versions(current_tags, available_tags)
@@ -707,14 +1176,14 @@ def main() -> None:
                 print(
                     f"  Minor/Major updates: {', '.join(greater_versions['minor'])}", file=sys.stderr
                 )
-            all_new_versions[name] = greater_versions
+            all_new_versions[(name, repository)] = greater_versions
 
     if all_new_versions:
-        updates = update_images_data(images_data, all_new_versions)
+        updates = update_images_data(images_data, all_new_versions, image_directives)
 
         if updates:
             images_data.sort_images()
-            write_yaml_file(images_data, args.images_yaml_path)
+            write_yaml_file(images_data, args.images_yaml_path, original_yaml_data)
             print(f"\nUpdated {args.images_yaml_path} with {len(updates)} changes.", file=sys.stderr)
 
         create_release_notes(updates, images_data, all_available_tags, args.release_notes_path)


### PR DESCRIPTION
- Add 'freeze' directive to prevent updates on specific entries
- Add 'max-supported-k8s' directive to prevent new k8s version entries
- Add 'version-mapping' directive for GCP CCM version format
- Preserve custom comments in images.yaml output
- Handle manual k8s constraints (e.g., csi-provisioner '>= 1.34')
- Fix comment indentation in YAML output

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add directives for update-images.py: `freeze` (prevent updates), `max-supported-k8s` (limit k8s
  version entries), `version-mapping` (GCP CCM version format). Custom comments above image entries
  are now preserved. Images with manual k8s constraints (e.g., `>= 1.34` unrelated to image version)
   are updated while preserving targetVersion.
```
