### PR TITLE
fix(send-mail): add setup python to ensure proper python version

### DIFF
--- a/.github/actions/send-mail/action.yaml
+++ b/.github/actions/send-mail/action.yaml
@@ -71,6 +71,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
     - name: Send Mail
       shell: bash
       run: |


### PR DESCRIPTION
**What this PR does:**
Add `setup-python@v5` step to the `send-mail` composite action to ensure Python 3.14+ is available.

**Which issue(s) this PR fixes:**
https://github.tools.sap/kubernetes/documentation/actions/runs/32615993/job/154188090

**Release note**:
```bugfix operator
Fix send-mail action, ensuring the proper python version is installed. 
```