### PR TITLE
feat(oci-ocm): add postbuild-hook input

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -102,6 +102,21 @@ on:
           The value will _not_ be quoted, so any valid bash-script can be passed.
         type: string
         required: false
+      postbuild-callback-action-path:
+        required: false
+        type: string
+        description: |
+          the path to a local action (relative to repository-root) that will be called
+          _after_ docker-build, but _before_ pushing the built image.
+
+          The action will receive the following inputs:
+            - `image-reference`: the image-reference of the just-built image
+
+          The action is expected to overwrite the image under the same tag (i.e. the tag
+          must remain unchanged after the action completes).
+
+          This can be useful, e.g. to run `unbase_oci` or other image-slimming tools on
+          the built image before it is pushed.
       build-ctx-artefact:
         description: |
           Specifies GitHub-Actions-Artifact to download.
@@ -464,6 +479,18 @@ jobs:
           target: ${{ inputs.target }}
           file: ${{ inputs.dockerfile }}
           build-args: ${{ inputs.build-args }}
+
+      - name: prepare-postbuild-callback-action
+        if: ${{ inputs.postbuild-callback-action-path != '' }}
+        shell: bash
+        run: |
+          set -eu
+          cp -r "${{ inputs.postbuild-callback-action-path }}" ../postbuild-callback-action
+      - name: postbuild-callback-action
+        if: ${{ inputs.postbuild-callback-action-path != '' }}
+        uses: ./../postbuild-callback-action
+        with:
+          image-reference: ${{ matrix.args.image-reference }}
 
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
         if: ${{ needs.preprocess.outputs.push == 'true' }}


### PR DESCRIPTION
Add a `postbuild-callback-action-path` input to `oci-ocm.yaml` (mirrors `prebuild-hook`). Accepts the path (relative to repository root) of a local GitHub Action that runs after `docker build`, before `docker push`. The built image reference is passed via the `image-reference` action input.

Motivation: enable [gardenlinux/unbase_oci](https://github.com/gardenlinux/unbase_oci) to strip base-image layers from built container images before pushing, producing smaller "bare" images.

We could also add `unbase_oci` as a dedicated option, but a generic callback-action fits the existing `prebuild-hook` pattern better and keeps the workflow flexible for other post-build transformations.

Example usage (PoC — still needs testing, and not sure yet about the best way to pull in the `unbase_oci` dependency):
```yaml
# in your workflow
uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
with:
  postbuild-callback-action-path: .github/actions/unbase-oci
  # ...
```

```yaml
# .github/actions/unbase-oci/action.yaml
name: unbase-oci
inputs:
  image-reference:
    required: true
runs:
  using: composite
  steps:
    - shell: bash
      run: |
        wget -q https://github.com/gardenlinux/unbase_oci/releases/download/latest/unbase_oci
        chmod +x unbase_oci
        ./unbase_oci --ldd-dependencies --container-engine docker \
          "docker:debian" \
          "docker:${{ inputs.image-reference }}" \
          "docker:${{ inputs.image-reference }}"
```