### PR TITLE
Drop usage of Delivery-Service client in CTT

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -16,7 +16,6 @@ import jsonschema
 import logging
 import os
 import threading
-import typing
 
 import dacite
 import yaml
@@ -75,13 +74,10 @@ class PruningMode(enum.StrEnum):
 def create_component_descriptor_lookup_for_ocm_repo(
     ocm_repo_url: str,
     oci_client: oci.client.Client | None=None,
-    delivery_service_client: typing.Union['delivery.client.DeliveryServiceClient', None]=None,
 ) -> cnudie.retrieve.ComponentDescriptorLookupById:
     return cnudie.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo_url),
         oci_client=oci_client,
-        delivery_client=delivery_service_client,
-        fallback_to_service_mapping=False,
     )
 
 
@@ -631,7 +627,6 @@ def process_images(
     skip_cd_validation: bool=False,
     platform_filter: collections.abc.Callable[[om.OciPlatform], bool]=None,
     skip_component_upload: collections.abc.Callable[[ocm.Component], bool]=None,
-    delivery_service_client: typing.Union['delivery.client.DeliveryServiceClient', None]=None,
     component_filter: collections.abc.Callable[[ocm.Component], bool]=None,
     remove_label: collections.abc.Callable[[str], bool]=None,
     max_workers: int=16,
@@ -691,7 +686,6 @@ def process_images(
         tgt_component_descriptor_lookup = create_component_descriptor_lookup_for_ocm_repo(
             ocm_repo_url=ocm_repository,
             oci_client=oci_client,
-            delivery_service_client=delivery_service_client,
         )
 
         replication_plan_step = create_replication_plan_step(
@@ -717,7 +711,6 @@ def process_images(
         tgt_component_descriptor_lookup = create_component_descriptor_lookup_for_ocm_repo(
             ocm_repo_url=replication_plan_step.target_ocm_repository,
             oci_client=oci_client,
-            delivery_service_client=delivery_service_client,
         )
 
         yield from process_replication_plan_step(


### PR DESCRIPTION
Because of the existing fallbacks in the OCM repository lookup which are integrated into the Delivery-Service, it is not a good fit for usages within the CTT where no fallbacks should be used to do qualified existence checks.
For reference, see https://github.com/open-component-model/delivery-service/pull/745.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Dropped usage of Delivery-Service client in CTT
```
