### PR TITLE
Remove needs-trusted-label

### DIFF
--- a/.github/actions/pullrequest-trust-helper/action.yaml
+++ b/.github/actions/pullrequest-trust-helper/action.yaml
@@ -6,15 +6,11 @@ description: |
   of privileged pipeline-runs is restricted to presence of a certain label - default
   being `ok-to-test`).
 
-  If "trust-label" is absent, it will be conveyed to users that it needs to be set (by
-  adding a "trust-label needed" label). If pullrequest-author is trusted, this action will
-  add said label.
+  If "trust-label" is absent, it will be conveyed to users that it needs to be set.
+  If pullrequest-author is trusted, this action will add said label.
 
 inputs:
   trusted-label:
-    type: string
-    required: false
-  needs-trusted-label:
     type: string
     required: false
   trusted-teams:
@@ -90,16 +86,11 @@ runs:
         pull_request =  repository.issue(${{ github.event.number }})
 
         trusted_label = "${{ inputs.trusted-label || 'ok-to-test' }}"
-        needs_trusted_label = "${{ inputs.needs-trusted-label || 'needs-ok-to-test' }}"
-
-        has_needs_trusted_label = False
 
         for label in pull_request.labels():
           if label.name == trusted_label:
             print(f'{trusted_label=} already present - exiting')
             exit(0)
-          if label.name == needs_trusted_label:
-            has_needs_trusted_label = True
 
         author_association = '${{ github.event.pull_request.author_association }}'
         allowed_author_associations = (
@@ -129,5 +120,7 @@ runs:
 
         if okay_to_add_trusted_label:
           pull_request.add_labels(trusted_label)
-        elif not has_needs_trusted_label:
-          pull_request.add_labels(needs_trusted_label)
+        else:
+          pull_request.create_comment(
+            body=f'The PR needs to be labeled with {trusted_label} by a maintainer to trigger the automated validation of the change',
+          )

--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -64,11 +64,6 @@ inputs:
 
       For security-reasons, this action will remove the label, such that it will have to be
       added again (adding the label will work as trigger).
-  needs-trusted-label:
-    type: string
-    required: false
-    description: |
-      a label that is added as a marker in order to notify lack of "trusted-label"
   remove-trusted-label:
     type: boolean
     default: true
@@ -336,7 +331,7 @@ runs:
         )
     - if: ${{ steps.calc.outputs.remove-label }}
       uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
-    - name: remove-trusted-and-add-needs-label
+    - name: remove-trusted-label
       if: ${{ steps.calc.outputs.remove-label != '' && inputs.remove-trusted-label == 'true' }}
       shell: python
       run: |
@@ -363,8 +358,6 @@ runs:
           # trusted-checkout typically runs multiple times, so the label already being absent
           # is an expected, and of course, acceptable case
           exit(0)
-
-        pull_request.add_labels('${{ inputs.needs-trusted-label || 'needs-ok-to-test' }}')
     - if: ${{ inputs.init-git-identity == 'true' }}
       uses: gardener/cc-utils/.github/actions/setup-git-identity@master
       with:

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -2,8 +2,8 @@ name: Pull-Request-Trust Helper
 
 # description: |
 #   An opinionated re-usable workflow to help with trusting Pull-Requests. Depending on the
-#   trustedness of a pullrequest's author, the workflow will either add an indication (via
-#   a "needs-review"-label) that a label needs to be added, or automatically add a "trusted-label".
+#   trustedness of a pullrequest's author, the workflow will either add an indication
+#   that a label needs to be added, or automatically add a "trusted-label".
 #
 #   A user is considered trusted, if:
 #     - he is member of the pullrequest-target-repository's organisation
@@ -28,12 +28,6 @@ on:
       trusted-label:
         description: |
           the label to set in order to trigger pipeline-runs trusting that label
-          needs to exist for the target-repository
-        type: string
-        required: false
-      needs-trusted-label:
-        description: |
-          the label used to indicate the `trusted-label` needs to be set
           needs to exist for the target-repository
         type: string
         required: false
@@ -76,6 +70,5 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/pullrequest-trust-helper@master
         with:
           trusted-label: ${{ inputs.trusted-label || vars.DEFAULT_LABEL_OK_TO_TEST || 'ok-to-test' }}
-          needs-trusted-label: ${{ inputs.needs-trusted-label || vars.DEFAULT_LABEL_NEEDS_OK_TO_TEST || 'needs-ok-to-test' }}
           trusted-teams: ${{ inputs.trusted-teams }}
           github-token: ${{ steps.fed-token.outputs.token }}


### PR DESCRIPTION
Trusted labels are usually used to control when a workflow to run. The expected flow is a trusted label to be added, then the workflow runs, and one of the early jobs, e.g. 'prepare' removes the trusted label so that the trust is not maintained after PR gets updates. The needs-trusted-label is causing some troubles, because it triggers new `labeled` event which is usually skipped and this resets the GH PR check status to `skipped` which could block the PR to be merged.

Instead of using label, the information that the PR needs to be checked by a maintainer and labeled with the trusted label is now conveyed via comment.



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `needs-trusted-label` input has been removed from `pullrequest-trust-helper` action, `trusted-checkout` action and `pullrequest-trust-helper` workflow. 
```
