### PR TITLE
add tests for send_mail, version_cli; act wiring test for install-gardener-gha-libs

### DIFF
--- a/test/actions/install-gardener-gha-libs/basic/workflow.yaml
+++ b/test/actions/install-gardener-gha-libs/basic/workflow.yaml
@@ -1,0 +1,19 @@
+name: test-install-gardener-gha-libs-basic
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+      - name: assert
+        shell: python
+        run: |
+          import importlib.util
+          # ocm + oci are from gardener-ocm / gardener-oci;
+          # release_notes is from gardener-gha-libs
+          for mod in ('ocm', 'oci', 'release_notes'):
+              spec = importlib.util.find_spec(mod)
+              if spec is None:
+                  raise AssertionError(f'expected module {mod!r} to be importable after install')
+              print(f'{mod}: OK ({spec.origin})')

--- a/test/actions/send-mail/test_send_mail.py
+++ b/test/actions/send-mail/test_send_mail.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import email.mime.multipart
+import os
+import sys
+import unittest.mock as mock
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', '.github', 'actions', 'send-mail')
+    ),
+)
+
+import send_mail
+
+
+# --- create_mail ---
+
+def test_create_mail_structure():
+    msg = send_mail.create_mail(
+        subject='Test',
+        sender='sender@example.com',
+        body='Hello',
+        smtp_headers={},
+        recipients=['a@example.com'],
+        cc_recipients=[],
+    )
+    assert isinstance(msg, email.mime.multipart.MIMEMultipart)
+    assert msg['Subject'] == 'Test'
+    assert msg['From'] == 'sender@example.com'
+    assert msg['To'] == 'a@example.com'
+
+
+def test_create_mail_multiple_recipients():
+    msg = send_mail.create_mail(
+        subject='S',
+        sender='s@x.com',
+        body='B',
+        smtp_headers={},
+        recipients=['a@x.com', 'b@x.com'],
+        cc_recipients=['c@x.com'],
+    )
+    assert 'a@x.com' in msg['To']
+    assert 'b@x.com' in msg['To']
+    assert msg['Cc'] == 'c@x.com'
+
+
+def test_create_mail_smtp_headers_override():
+    msg = send_mail.create_mail(
+        subject='Original',
+        sender='s@x.com',
+        body='B',
+        smtp_headers={'Subject': 'Overridden'},
+        recipients=['r@x.com'],
+        cc_recipients=[],
+    )
+    # smtp_headers are set after the defaults; the last assignment wins in MIMEMultipart
+    assert 'Overridden' in msg.values()
+
+
+def test_create_mail_attachment(tmp_path):
+    att = tmp_path / 'data.txt'
+    att.write_text('content')
+    msg = send_mail.create_mail(
+        subject='S',
+        sender='s@x.com',
+        body='B',
+        smtp_headers={},
+        recipients=['r@x.com'],
+        cc_recipients=[],
+        attachments=[str(att)],
+    )
+    payloads = msg.get_payload()
+    # body + attachment
+    assert len(payloads) == 2
+
+
+def test_create_mail_no_attachment():
+    msg = send_mail.create_mail(
+        subject='S',
+        sender='s@x.com',
+        body='B',
+        smtp_headers={},
+        recipients=['r@x.com'],
+        cc_recipients=[],
+    )
+    payloads = msg.get_payload()
+    assert len(payloads) == 1
+
+
+# --- send_mail recipients normalisation ---
+
+def test_send_mail_lowercases_recipients():
+    captured = {}
+
+    def fake_send_email(**kwargs):
+        captured['to'] = kwargs['Destination']['ToAddresses']
+        return {'MessageId': 'x'}
+
+    mock_client = mock.MagicMock()
+    mock_client.send_email.side_effect = fake_send_email
+
+    with mock.patch('send_mail.boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        send_mail.send_mail(
+            aws_key_id='key',
+            aws_key='secret',
+            aws_session_token=None,
+            aws_region='eu-central-1',
+            subject='S',
+            body='B',
+            smtp_headers={},
+            recipients=['User@Example.COM'],
+        )
+
+    assert all(r == r.lower() for r in captured['to'])
+
+
+def test_send_mail_deduplicates_recipients():
+    captured = {}
+
+    def fake_send_email(**kwargs):
+        captured['to'] = kwargs['Destination']['ToAddresses']
+        return {'MessageId': 'x'}
+
+    mock_client = mock.MagicMock()
+    mock_client.send_email.side_effect = fake_send_email
+
+    with mock.patch('send_mail.boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        send_mail.send_mail(
+            aws_key_id='key',
+            aws_key='secret',
+            aws_session_token=None,
+            aws_region='eu-central-1',
+            subject='S',
+            body='B',
+            smtp_headers={},
+            recipients=['a@x.com', 'A@X.COM'],
+        )
+
+    assert len(captured['to']) == 1
+
+
+def test_send_mail_bcc_included_in_destinations():
+    captured = {}
+
+    def fake_send_email(**kwargs):
+        captured['to'] = kwargs['Destination']['ToAddresses']
+        return {'MessageId': 'x'}
+
+    mock_client = mock.MagicMock()
+    mock_client.send_email.side_effect = fake_send_email
+
+    with mock.patch('send_mail.boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        send_mail.send_mail(
+            aws_key_id='key',
+            aws_key='secret',
+            aws_session_token=None,
+            aws_region='eu-central-1',
+            subject='S',
+            body='B',
+            smtp_headers={},
+            recipients=['to@x.com'],
+            bcc_recipients=['bcc@x.com'],
+        )
+
+    assert 'bcc@x.com' in captured['to']
+
+
+def test_send_mail_truncates_at_max_recipients():
+    called_with = {}
+
+    def fake_send_email(**kwargs):
+        called_with['to'] = kwargs['Destination']['ToAddresses']
+        return {'MessageId': 'x'}
+
+    mock_client = mock.MagicMock()
+    mock_client.send_email.side_effect = fake_send_email
+
+    recipients = [f'user{i}@x.com' for i in range(60)]
+    with mock.patch('send_mail.boto3') as mock_boto3:
+        mock_boto3.client.return_value = mock_client
+        send_mail.send_mail(
+            aws_key_id='key',
+            aws_key='secret',
+            aws_session_token=None,
+            aws_region='eu-central-1',
+            subject='S',
+            body='B',
+            smtp_headers={},
+            recipients=recipients,
+            max_recipients=50,
+        )
+
+    assert len(called_with['to']) == 50
+
+
+# --- authenticate_against_aws ---
+
+def test_authenticate_against_aws(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://token.example.com')
+
+    mock_session = mock.MagicMock()
+    mock_session.get.return_value.json.return_value = {'value': 'oidc-tok'}
+    mock_session.post.return_value.json.return_value = {
+        'AssumeRoleWithWebIdentityResponse': {
+            'AssumeRoleWithWebIdentityResult': {
+                'Credentials': {
+                    'AccessKeyId': 'AKID',
+                    'SecretAccessKey': 'SECRET',
+                    'SessionToken': 'TOKEN',
+                },
+            },
+        },
+    }
+
+    with mock.patch('send_mail.requests.Session', return_value=mock_session):
+        key_id, key, token = send_mail.authenticate_against_aws(
+            role_to_assume='arn:aws:iam::123:role/Foo',
+        )
+
+    assert key_id == 'AKID'
+    assert key == 'SECRET'
+    assert token == 'TOKEN'
+
+
+def test_authenticate_against_aws_missing_env_exits(monkeypatch):
+    monkeypatch.delenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', raising=False)
+    monkeypatch.delenv('ACTIONS_ID_TOKEN_REQUEST_URL', raising=False)
+
+    with mock.patch('send_mail.exit') as mock_exit:
+        mock_exit.side_effect = SystemExit(1)
+        try:
+            send_mail.authenticate_against_aws(role_to_assume='arn:...')
+        except SystemExit:
+            pass
+    mock_exit.assert_called_once_with(1)

--- a/test/actions/version/test_version_cli.py
+++ b/test/actions/version/test_version_cli.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', '.github', 'actions', 'version')
+    ),
+)
+
+import version_cli
+
+
+# --- process_version ---
+
+def test_process_version_noop():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.NOOP,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '1.2.3'
+
+
+def test_process_version_noop_preserves_prerelease():
+    result = version_cli.process_version(
+        version='1.2.3-dev',
+        operation=version_cli.VersionOperation.NOOP,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '1.2.3-dev'
+
+
+def test_process_version_bump_patch():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.BUMP_PATCH,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '1.2.4'
+
+
+def test_process_version_bump_minor():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.BUMP_MINOR,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '1.3.0'
+
+
+def test_process_version_bump_major():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.BUMP_MAJOR,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '2.0.0'
+
+
+def test_process_version_bump_patch_with_prerelease():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.BUMP_PATCH,
+        prerelease='dev',
+        commit_digest=None,
+    )
+    assert result == '1.2.4-dev'
+
+
+def test_process_version_set_prerelease():
+    result = version_cli.process_version(
+        version='1.2.3',
+        operation=version_cli.VersionOperation.SET_PRERELEASE,
+        prerelease='rc.1',
+        commit_digest=None,
+    )
+    assert result == '1.2.3-rc.1'
+
+
+def test_process_version_set_prerelease_empty_finalises():
+    result = version_cli.process_version(
+        version='1.2.3-dev',
+        operation=version_cli.VersionOperation.SET_PRERELEASE,
+        prerelease='',
+        commit_digest=None,
+    )
+    assert result == '1.2.3'
+
+
+# --- read_version_from_file / write_version_to_file ---
+
+def test_read_version_from_file(tmp_path):
+    vf = tmp_path / 'VERSION'
+    vf.write_text('1.2.3\n')
+    assert version_cli.read_version_from_file(str(vf)) == '1.2.3'
+
+
+def test_read_version_from_file_skips_comments(tmp_path):
+    vf = tmp_path / 'VERSION'
+    vf.write_text('# this is a comment\n1.2.3\n')
+    assert version_cli.read_version_from_file(str(vf)) == '1.2.3'
+
+
+def test_write_version_to_file(tmp_path):
+    vf = tmp_path / 'VERSION'
+    version_cli.write_version_to_file('2.0.0', str(vf))
+    assert vf.read_text() == '2.0.0\n'
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    vf = tmp_path / 'VERSION'
+    version_cli.write_version_to_file('3.1.4', str(vf))
+    assert version_cli.read_version_from_file(str(vf)) == '3.1.4'
+
+
+# --- check_default_files ---
+
+def test_check_default_files_finds_versionfile(tmp_path):
+    vf = tmp_path / 'VERSION'
+    vf.write_text('1.0.0\n')
+    result = version_cli.check_default_files(str(tmp_path))
+    assert result == str(vf)
+
+
+def test_check_default_files_returns_none_when_nothing(tmp_path):
+    result = version_cli.check_default_files(str(tmp_path))
+    assert result is None
+
+
+def test_check_default_files_callbacks_take_precedence(tmp_path):
+    vf = tmp_path / 'VERSION'
+    vf.write_text('1.0.0\n')
+    ci = tmp_path / '.ci'
+    ci.mkdir()
+    rv = ci / 'read-version'
+    wv = ci / 'write-version'
+    rv.write_text('#!/bin/sh\necho 1.0.0\n')
+    wv.write_text('#!/bin/sh\n')
+    rv.chmod(0o755)
+    wv.chmod(0o755)
+    result = version_cli.check_default_files(str(tmp_path))
+    assert isinstance(result, tuple)
+    assert result == (str(rv), str(wv))
+
+
+# --- parse_and_check_args ---
+
+def test_parse_and_check_args_none_when_no_args():
+    import argparse
+    parsed = argparse.Namespace(
+        versionfile=None,
+        read_callback=None,
+        write_callback=None,
+        root_dir='/tmp',
+    )
+    result = version_cli.parse_and_check_args(parsed)
+    assert result is None
+
+
+def test_parse_and_check_args_versionfile(tmp_path):
+    import argparse
+    vf = tmp_path / 'VERSION'
+    vf.write_text('1.0.0\n')
+    parsed = argparse.Namespace(
+        versionfile='VERSION',
+        read_callback=None,
+        write_callback=None,
+        root_dir=str(tmp_path),
+    )
+    result = version_cli.parse_and_check_args(parsed)
+    assert result == str(vf)
+
+
+def test_parse_and_check_args_exits_on_conflict():
+    import argparse
+    parsed = argparse.Namespace(
+        versionfile='VERSION',
+        read_callback='/some/read',
+        write_callback=None,
+        root_dir='/tmp',
+    )
+    with __import__('pytest').raises(SystemExit):
+        version_cli.parse_and_check_args(parsed)
+
+
+def test_parse_and_check_args_exits_on_single_callback():
+    import argparse
+    parsed = argparse.Namespace(
+        versionfile=None,
+        read_callback='/some/read',
+        write_callback=None,
+        root_dir='/tmp',
+    )
+    with __import__('pytest').raises(SystemExit):
+        version_cli.parse_and_check_args(parsed)


### PR DESCRIPTION
## Summary

- **`test/actions/send-mail/`**: 11 unit tests for `create_mail`, `send_mail` (recipient deduplication/lowercasing/truncation, BCC handling), and `authenticate_against_aws` (mocked OIDC/STS flow, missing-env guard)
- **`test/actions/version/test_version_cli.py`**: 19 unit tests for `process_version` (all operations: noop, bump-{patch,minor,major}, set-prerelease), `read/write_version_to_file`, `check_default_files`, `parse_and_check_args`
- **`test/actions/install-gardener-gha-libs/basic/`**: act-based wiring test verifying the bundle install path produces importable `ocm`/`oci`/`gha` modules

## Test plan

- [ ] CI (non-release) passes: lint + unittests (171 → expected) + bundling
- [ ] test-actions workflow passes: all 7 act tests green (including new install-gardener-gha-libs/basic)