### PR TITLE
fix params: use valid GHA expression syntax for trusted-label default

### DIFF
--- a/.github/actions/params/action.yaml
+++ b/.github/actions/params/action.yaml
@@ -136,7 +136,7 @@ runs:
             head_owner='${{ github.event.pull_request.head.repo.owner.login }}',
             author_association='${{ github.event.pull_request_target.author_association }}',
             event_action='${{ github.event.action }}',
-            trusted_label='${{ inputs.trusted-label || ''ok-to-test'' }}',
+            trusted_label="${{ inputs.trusted-label || 'ok-to-test' }}",
             event_label='${{ github.event.label.name }}',
             ref='${{ github.ref }}',
         )


### PR DESCRIPTION
## Summary

- Fixes `''ok-to-test''` in `params/action.yaml` which is invalid GHA expression syntax — the `''` token inside a `${{ }}` expression is parsed as two empty string literals, causing a `TemplateValidationException`
- Changed the Python string from single-quoted to double-quoted so the GHA string literal `'ok-to-test'` inside `${{ }}` is valid

## Test plan

- [ ] CI (non-release) passes: `prepare/version-and-ocm` step no longer fails with template validation error