### PR TITLE
fix: cd into cc_utils before bdist_wheel to resolve package dirs correctly

### DIFF
--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -84,6 +84,7 @@ runs:
         cc_utils="${tmpdir}/cc-utils"
         pip install -q setuptools
         version=$(CC_UTILS_ROOT="${cc_utils}" python3 "${{ github.action_path }}/normalise_version.py")
+        cd "${cc_utils}"
         for setup_file in setup.gha.py setup.oci.py setup.ocm.py; do
           python3 "${cc_utils}/${setup_file}" bdist_wheel --dist-dir "${cc_utils}/dist"
         done


### PR DESCRIPTION
## Summary

- `install-gardener-gha-libs/action.yaml` moves `cc-utils` to a tmpdir before building wheels
- `bdist_wheel` resolves `packages=['oci']` relative to **cwd**, not `own_dir`
- cwd remained `$GITHUB_WORKSPACE` (which no longer contains `oci/`), causing `error: package directory 'oci' does not exist`
- Fix: `cd "${cc_utils}"` before the build loop so all three setup scripts find their package dirs

## Test plan

- [ ] `test-actions` passes
- [ ] `CI (non-release)` build-and-test and post-build/component-descriptor pass
- [ ] `Build OCM (Image w/ CLI)` passes