### PR TITLE
fix(github): handle missing avatar_url in release author

### DIFF
--- a/github/release.py
+++ b/github/release.py
@@ -50,7 +50,11 @@ def _iter_releases(
         if raw.get('author') is None:
             raw['author'] = {}  # github3 crashes on null author (deleted accounts)
         raw['author'].setdefault('avatar_url', None)  # GHES may omit this field
-        yield github3.repos.release.Release(raw, repository)
+        try:
+            yield github3.repos.release.Release(raw, repository)
+        except Exception as e:
+            logger.warning(f'failed to parse release {raw.get("name") or raw.get("tag_name")}: {e}')
+            continue
 
 
 def find_draft_release(

--- a/github/release.py
+++ b/github/release.py
@@ -49,6 +49,7 @@ def _iter_releases(
     for raw in repository._iter(number, url, dict):
         if raw.get('author') is None:
             raw['author'] = {}  # github3 crashes on null author (deleted accounts)
+        raw['author'].setdefault('avatar_url', None)  # GHES may omit this field
         yield github3.repos.release.Release(raw, repository)
 
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
handle absence of avatar_url in github-api-response
```
