### PR TITLE
fix: reset index before worktree-restore to prevent submodule pointer…

### DIFF
--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -439,6 +439,7 @@ def commit_and_push_to_tmp_branch(
         repository.ref(f'heads/{new_branch_name}').delete()
         raise
 
+    git_helper.repo.git.reset('HEAD')  # also resets submodule gitlinks in index
     git_helper.repo.git.checkout('.')
     git_helper.repo.git.clean('-fd')
 


### PR DESCRIPTION
… leaking across upgrade PRs

`commit_and_push_to_tmp_branch` previously restored the worktree with `git checkout . && git clean -fd` after pushing the upgrade-commit. This resets tracked file content and removes untracked paths, but does NOT unstage changes to the git index — in particular, submodule gitlinks (`.gitmodules` pointer entries) remain staged if they were modified.

`index_to_commit` runs `git add .` before building the tree, so any submodule pointer already in the index is carried into the next upgrade commit as well, producing a PR that silently upgrades the submodule to an unintended ref.

The bug was latent: the original code had an early-exit after the first created PR (removed in 0da7aa404 to allow creating all upgrade PRs per run), so the dirty index was never reused within the same invocation.

Fix: prepend `git reset HEAD` to unstage everything — including submodule gitlinks — before the checkout/clean, fully restoring the index to HEAD.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix regression for submodule-handling. upgrade-dependencies no longer is prone to include wrong diff for submodule-updates in case of repositories with submodules.
```
