### PR TITLE
capture-commit: allow passing explicit commit (default: HEAD)

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -35,6 +35,10 @@ inputs:
     required: true
     description: |
       a filepath pointing to a file that was created before the head-commit
+  commit:
+    required: false
+    description: |
+      the commit to capture. Defaults to HEAD if not specified.
   to-artefact:
     required: false
     description: |
@@ -91,7 +95,8 @@ runs:
           ${GITHUB_ACTION_PATH}/capture-commit \
             ${objects_out} \
             ${ts_ref} \
-            ${commit_out}
+            ${commit_out} \
+            ${{ inputs.commit }}
 
         tar tf ${objects_out}
         objects_size=$(stat --format=%s ${objects_out})

--- a/.github/actions/capture-commit/capture-commit
+++ b/.github/actions/capture-commit/capture-commit
@@ -7,6 +7,7 @@ set -euo pipefail
 # $1: path to target-archive
 # $2: path to ref-file (must be older than commit)
 # $3: path to output-file for commit-digest (defaults to commit-digest)
+# $4: commit to capture (defaults to HEAD)
 
 # darwin/macOS is not supported. differences that would need addressing:
 # - `find -newermt` (GNU) -> `-newer` (BSD find; compares mtime, but no XY-syntax)
@@ -40,7 +41,11 @@ else
   commit_digest_out=${3}
 fi
 
-commit_digest="$(git rev-parse @)"
+if [ -z "${4:-}" ]; then
+  commit_digest="$(git rev-parse HEAD)"
+else
+  commit_digest="$(git rev-parse ${4})"
+fi
 echo "${commit_digest}" > "${GIT_DIR}/refs/capture-commit"
 
 object_paths=$(


### PR DESCRIPTION
## Summary

- Add optional `commit` input to `capture-commit` action and helper script
- Defaults to `HEAD` if not specified, preserving existing behaviour
- Useful when HEAD may not reliably point to the commit of interest at the time the action runs (e.g. after a failed rebase leaves the repo in an intermediate state)

## Test plan

- [ ] Verify existing behaviour unchanged when `commit` input is omitted
- [ ] Verify correct commit is captured when `commit` input is passed explicitly