### PR TITLE
Allow disabling of Delivery-Service's OCM repository lookup

### DIFF
--- a/cnudie/retrieve.py
+++ b/cnudie/retrieve.py
@@ -334,6 +334,7 @@ def delivery_service_component_descriptor_lookup(
                     name=component_id.name,
                     version=component_id.version,
                     ocm_repo_url=ocm_repo.oci_ref if ocm_repo else None,
+                    ignore_lookup=ocm_repo is not None, # don't use lookup if `ocm_repo` is specified
                 )
 
                 if component_descriptor:

--- a/cnudie/retrieve_async.py
+++ b/cnudie/retrieve_async.py
@@ -276,6 +276,7 @@ def delivery_service_component_descriptor_lookup(
                     name=component_id.name,
                     version=component_id.version,
                     ocm_repo_url=ocm_repo.oci_ref if ocm_repo else None,
+                    ignore_lookup=ocm_repo is not None, # don't use lookup if `ocm_repo` is specified
                 )
 
                 if component_descriptor:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ html2text
 jq
 jsonpath-ng
 jsonschema
-odg-client
+odg-client>=0.4.0
 pycryptodome
 pyjwt
 pylama


### PR DESCRIPTION
When specifying `fallback_to_service_mapping=False` in the `delivery_service_component_descriptor_lookup`, it is expected that the built-in OCM repository lookup in the Delviery-Service is not used, and instead the (local) explicitly configured OCM repositories are to be exclusively used. To adhere to this behaviour, make use of the (new) `ignore_lookup` parameter.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
