### PR TITLE
fix(trusted-checkout): default to https:// for TOKEN_SERVER if no sch…

### DIFF
--- a/.github/actions/trusted-checkout/checkout-submodules.sh
+++ b/.github/actions/trusted-checkout/checkout-submodules.sh
@@ -112,6 +112,10 @@ function app_token() {
     --github-org $org
 }
 
+if [ -n "${TOKEN_SERVER:-}" ] && [ "${TOKEN_SERVER#*://}" = "${TOKEN_SERVER}" ]; then
+  TOKEN_SERVER="https://${TOKEN_SERVER}"
+fi
+
 git submodule status | while read -r s; do
   path=$(echo $s | cut -d' ' -f2-)
   cdig=$(echo $s | cut -d' ' -f1 | cut -d- -f2)


### PR DESCRIPTION
…eme given

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
trusted-checkout will now default to https (instead of http) for submodules when retrieving access-tokens.
```
