### PR TITLE
add github-artifact as asset type

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -455,6 +455,11 @@ runs:
     - name: create github-release
       if: ${{ inputs.release-on-github == 'true' }}
       shell: python
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_API_URL: ${{ github.api_url }}
       run: |
         import os
         import sys
@@ -521,16 +526,22 @@ runs:
           )
 
         for asset in release.iter_assets(path='/tmp/assets.yaml'):
-          path, access = release.find_blob(
-            blobs_dir='${{ inputs.component-descriptor-blobs-dir }}',
-            asset=asset,
-            component=component_descriptor.component,
-          )
-
-          if asset.mime_type:
-            mime_type = asset.mime_type
+          if asset.type == 'github-artifact':
+            path = release.find_github_artifact(
+              asset=asset,
+              run_id=os.environ['GITHUB_RUN_ID'],
+              api_url=os.environ['GITHUB_API_URL'],
+              repository=os.environ['GITHUB_REPOSITORY'],
+              token=os.environ['GITHUB_TOKEN'],
+            )
+            mime_type = asset.mime_type or 'application/octet-stream'
           else:
-            mime_type = access.mediaType
+            path, access = release.find_blob(
+              blobs_dir='${{ inputs.component-descriptor-blobs-dir }}',
+              asset=asset,
+              component=component_descriptor.component,
+            )
+            mime_type = asset.mime_type or access.mediaType
 
           print(f'Uploading {asset=} as github-release-asset')
           fh = open(path, 'rb')

--- a/.github/actions/release/release.py
+++ b/.github/actions/release/release.py
@@ -2,7 +2,11 @@ import collections.abc
 import dataclasses
 import enum
 import hashlib
+import io
+import json
 import os
+import urllib.request
+import zipfile
 
 import dacite
 import yaml
@@ -38,8 +42,8 @@ class Asset:
         return True
 
     def __post_init__(self):
-        # basic validation: id.name must be present and non-empty
-        if not self.id.get('name'):
+        # basic validation: id.name must be present and non-empty for ocm-resource assets
+        if self.type == 'ocm-resource' and not self.id.get('name'):
             print('Error: asset.id.name must not be empty:')
             print(self)
             exit(1)
@@ -114,6 +118,55 @@ def find_blob(
         exit(1)
 
     return path, access
+
+
+def find_github_artifact(
+    asset: Asset,
+    run_id: str,
+    api_url: str,
+    repository: str,
+    token: str,
+) -> str:
+    '''
+    Downloads a GHA artifact from the current workflow run and returns a local file path.
+
+    asset.id['name'] is the artifact name. asset.id.get('file') optionally names a specific
+    file to extract from within the artifact zip; if absent the artifact zip itself is returned.
+    '''
+    artifact_name = asset.id['name']
+    file_in_artifact = asset.id.get('file')
+
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github.v3+json',
+    }
+
+    url = f'{api_url}/repos/{repository}/actions/runs/{run_id}/artifacts'
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        artifacts = json.loads(resp.read())['artifacts']
+
+    artifact = next((a for a in artifacts if a['name'] == artifact_name), None)
+    if artifact is None:
+        print(f'Error: GHA artifact "{artifact_name}" not found in run {run_id}')
+        exit(1)
+
+    req = urllib.request.Request(artifact['archive_download_url'], headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        zip_data = resp.read()
+
+    tmp_dir = '/tmp/gha-artifacts'
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    if file_in_artifact:
+        with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+            zf.extract(file_in_artifact, tmp_dir)
+        return os.path.join(tmp_dir, file_in_artifact)
+    else:
+        path = os.path.join(tmp_dir, f'{artifact_name}.zip')
+        with open(path, 'wb') as f:
+            f.write(zip_data)
+        return path
 
 
 def attach_release_notes(

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,17 +179,29 @@ on:
           ```
           name: <name, as it should be set for the release-asset>, required
           mime-type: # optional (will be determined using libmagic, if absent)
-          type: ocm-resource # mandatory; only `ocm-resource` is supported; for future extensions
+          type: ocm-resource | github-artifact # mandatory
+          id: # contents depend on type (see below)
+          ```
+
+          For `type: ocm-resource`:
+          ```
           id:
             name: <ocm-resource-name>, required
             type: <ocm-resource-type>, optional
             <extra-id-attr>: <value> # optional - any attributes from extraIdentity
           ```
-
           `id` must be specified such that a resource is identified unambiguously. Only resources
           that are stored as a localBlob (access-type) are supported.
 
-          Example (assuming pipeline builds `helm` for multiple platforms):
+          For `type: github-artifact`:
+          ```
+          id:
+            name: <artifact-name>  # required - the GHA artifact name from the current run
+            file: <filename>       # optional - extract a specific file from the artifact zip;
+                                   # if absent the whole zip is uploaded
+          ```
+
+          Example (ocm-resource, assuming pipeline builds `helm` for multiple platforms):
           ```
           assets: |
            - name: helm-linux-x86-64
@@ -199,6 +211,20 @@ on:
               name: helm
               os: linux
               arch: x86_64
+          ```
+
+          Example (github-artifact):
+          ```
+          assets: |
+           - name: testresults.zip
+             type: github-artifact
+             id:
+               name: testrunner-results
+           - name: overview.json
+             type: github-artifact
+             id:
+               name: testrunner-results
+               file: overview.json
           ```
       version-read-callback:
         type: string


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Add github-artifact as asset type so we can use the release wf to also publish github artifacts to releases


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
