### PR TITLE
fix(params): Use correct event name `pull_request` (omit `_target`)

### DIFF
--- a/.github/actions/params/action.yaml
+++ b/.github/actions/params/action.yaml
@@ -134,7 +134,7 @@ runs:
             event_name='${{ github.event_name }}',
             repo_owner='${{ github.repository_owner }}',
             head_owner='${{ github.event.pull_request.head.repo.owner.login }}',
-            author_association='${{ github.event.pull_request_target.author_association }}',
+            author_association='${{ github.event.pull_request.author_association }}',
             event_action='${{ github.event.action }}',
             trusted_label="${{ inputs.trusted-label || 'ok-to-test' }}",
             event_label='${{ github.event.label.name }}',


### PR DESCRIPTION
GitHub does not emit an event called `pull_request_target` but only a `pull_request` one. This one should be used instead to retrieve the respective author association (consistently like how it is done in the trusted-checkout action). Refs:
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
- https://github.com/gardener/cc-utils/blob/7dd669e3ca119ba3a0de8ce49815928dd25b5a3e/.github/actions/trusted-checkout/action.yaml#L255

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Correctly determine author association in params action to determine "can-push" status later
```
