### PR TITLE
fix(ocm-upgrade): use greatest upstream ref version, not first match

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -421,15 +421,10 @@ def create_upgrade_pullrequests(
                     version=upstream_version,
                 )
             )
-            upstream_target_version = None
-            for uref in upstream_cd.component.componentReferences or ():
-                if uref.componentName != cref.componentName:
-                    continue
-                if upstream_target_version is None or (
-                    version.parse_to_semver(uref.version)
-                    > version.parse_to_semver(upstream_target_version)
-                ):
-                    upstream_target_version = uref.version
+            upstream_target_version = ocm.gardener.greatest_component_reference_version(
+                references=upstream_cd.component.componentReferences or (),
+                component_name=cref.componentName,
+            )
             if upstream_target_version is None:
                 logger.info(f'upstream has no reference for {cref.componentName}')
                 continue

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -423,10 +423,14 @@ def create_upgrade_pullrequests(
             )
             upstream_target_version = None
             for uref in upstream_cd.component.componentReferences or ():
-                if uref.componentName == cref.componentName:
+                if uref.componentName != cref.componentName:
+                    continue
+                if upstream_target_version is None or (
+                    version.parse_to_semver(uref.version)
+                    > version.parse_to_semver(upstream_target_version)
+                ):
                     upstream_target_version = uref.version
-                    break
-            else:
+            if upstream_target_version is None:
                 logger.info(f'upstream has no reference for {cref.componentName}')
                 continue
 

--- a/ocm/gardener.py
+++ b/ocm/gardener.py
@@ -176,6 +176,25 @@ def iter_greatest_component_references(
     yield from greatest_crefs.values()
 
 
+def greatest_component_reference_version(
+    references: collections.abc.Iterable[ocm.ComponentReference],
+    component_name: str,
+) -> str | None:
+    '''
+    Returns the greatest version among all component-references whose
+    componentName matches the given name, or None if there is no match.
+    '''
+    greatest: str | None = None
+    for ref in references:
+        if ref.componentName != component_name:
+            continue
+        if greatest is None or (
+            version.parse_to_semver(ref.version) > version.parse_to_semver(greatest)
+        ):
+            greatest = ref.version
+    return greatest
+
+
 def find_imagevector_file(
     repo_root: str=None,
 ) -> str | None:

--- a/test/actions/ocm-upgrade/test_ocm_upgrade.py
+++ b/test/actions/ocm-upgrade/test_ocm_upgrade.py
@@ -49,3 +49,44 @@ def test_find_upgrade_vector_ignores_prerelease():
     )
 
     assert vector is None
+
+
+def _make_cref(name, component_name, ver):
+    return ocm.ComponentReference(
+        name=name,
+        componentName=component_name,
+        version=ver,
+    )
+
+
+def test_upstream_duplicate_crefs_picks_greatest_version():
+    '''
+    Regression test: greatest_component_reference_version must return the
+    greatest version across all refs matching a componentName, not the first.
+
+    Mirrors the gardenlinux/landscape bug: upstream had 1877.14 listed before
+    2150.2.0; the old first-match code would have returned 1877.14.
+    '''
+    gl_name = 'example.com/gardenlinux'
+    crefs = [
+        _make_cref('gardenlinux', gl_name, '1877.14'),  # comes first (old bug trigger)
+        _make_cref('gardenlinux', gl_name, '2150.2.0'),
+    ]
+
+    result = ocm.gardener.greatest_component_reference_version(
+        references=crefs,
+        component_name=gl_name,
+    )
+
+    assert result == '2150.2.0'
+
+
+def test_upstream_no_matching_cref_returns_none():
+    crefs = [_make_cref('other', 'example.com/other', '1.0.0')]
+
+    result = ocm.gardener.greatest_component_reference_version(
+        references=crefs,
+        component_name='example.com/gardenlinux',
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

When resolving the `whither-version` from an upstream component descriptor,
the previous code stopped at the first `componentReference` whose `componentName`
matched (`break`). If the upstream landscape has multiple references to the same
component (e.g. two `gardenlinux` entries at different versions for different seed
architectures), the result depended on YAML order rather than semantics.

The fix mirrors what `iter_greatest_component_references` already does for the
downstream component: scan all matching upstream refs and keep the greatest version.

## Test plan

- [ ] Verify that a landscape with duplicate upstream component-refs (same `componentName`, different versions) now gets an upgrade PR targeting the greatest upstream version rather than the first one encountered.