### PR TITLE
handle only ocm related files/folders in merge-ocm-fragments action

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -163,10 +163,7 @@ runs:
         cd "${{ inputs.outdir }}"
 
         # workaround: download-artifact@v3 does not allow merging. hence, flatten directories
-        for d in $(find -type d); do
-          if [ "$d" == "." ]; then
-            continue
-          fi
+        for d in $(find -type d -name "${{ steps.preprocess.outputs.artefact-name }}"); do
           echo "debug: sub-directory $d contains:"
           ls $d
           mv $d/* .


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
handle only ocm related resources in the merge-ocm-fragments action


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
