### PR TITLE
fix(oci): propagate replication mode in recursive `replicate_artifact` calls

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -203,6 +203,7 @@ def replicate_artifact(
                     src_image_reference=src_reference,
                     tgt_image_reference=tgt_reference,
                     oci_client=client,
+                    mode=mode,
                     annotations=annotations,
                 )
 

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -199,12 +199,17 @@ def replicate_artifact(
 
                 logger.info(f'replicating to {tgt_reference=}')
 
+                # only propagate PREFER_MULTIARCH (preserves nested indices); never pass
+                # NORMALISE_TO_MULTIARCH as it would wrap sub-manifests in spurious index layers
+                recursive_mode = ReplicationMode.REGISTRY_DEFAULTS
+                if mode is ReplicationMode.PREFER_MULTIARCH:
+                    recursive_mode = ReplicationMode.PREFER_MULTIARCH
+
                 res, ref, submanifest_bytes = replicate_artifact(
                     src_image_reference=src_reference,
                     tgt_image_reference=tgt_reference,
                     oci_client=client,
-                    mode=mode,
-                    platform_filter=platform_filter,
+                    mode=recursive_mode,
                     annotations=annotations,
                 )
 

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -204,6 +204,7 @@ def replicate_artifact(
                     tgt_image_reference=tgt_reference,
                     oci_client=client,
                     mode=mode,
+                    platform_filter=platform_filter,
                     annotations=annotations,
                 )
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Without this, nested indexes fail because the recursive call defaults to `REGISTRY_DEFAULTS`, losing the Accept header needed to resolve sub-indexes.

**Note for the reviewer:**
I confirmed the fix with a manual script run.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Support replication of nested index manifests
```
