### PR TITLE
fix(ci): Avoid collisions of capture-commit archive

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -154,3 +154,11 @@ runs:
       with:
         name: ${{ inputs.to-artefact }}
         path: commit-objects.tar.gz
+
+    - name: clean-up-capture-commit-archive
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # archive was uploaded already, avoid local collisions in filesystem
+        unlink commit-objects.tar.gz


### PR DESCRIPTION
When using the optional release-branch feature, the capture-commit archive is not cleaned up. As both steps will run on the same worker (with the very same filesystem), there can be collisions if the archive names match.

Clean up after archive upload is safe, as subsequent steps only consume the archive via explicit artifact download.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```
