### PR TITLE
Onboard new org to oidc-config

### DIFF
--- a/.github/actions/oci-auth/oidc-cfgs.yaml
+++ b/.github/actions/oci-auth/oidc-cfgs.yaml
@@ -145,6 +145,7 @@
   github_host: gh-tools
   github_orgs:
     - kubernetes-dev
+    - kubernetes-dev-gdch
 
 - name: tools-aws-delivery-dev
   type: aws


### PR DESCRIPTION
Adds a new ghe-org to the OIDC-config, to grant actions running therein access to required oci-repositories.