### PR TITLE
fix(oci): Use (by now) required `BasicAuth` object instead of tuple

### DIFF
--- a/oci/client_async.py
+++ b/oci/client_async.py
@@ -325,7 +325,10 @@ class Client:
                 image_reference=image_reference,
                 scope=scope,
             ).token
-            auth = 'AWS', password
+            auth = aiohttp.BasicAuth(
+                login='AWS',
+                password=password,
+            )
         else:
             token = self.token_cache.token(
                 image_reference=image_reference,


### PR DESCRIPTION
Fixes https://github.com/open-component-model/delivery-service/issues/833

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Use (by now) required `BasicAuth` object instead of tuple in async OCI client
```
