### PR TITLE
fix(oci): Only check content-type in case of error in tag listing

### DIFF
--- a/oci/client_async.py
+++ b/oci/client_async.py
@@ -610,7 +610,9 @@ class Client:
         # Google-Artifact-Registry (maybe also others) will return http-200 + HTML in certain
         # error cases (e.g. if image_reference contains a pipe (|) character)
         try:
-            tags_res = await res.json()
+            tags_res = await res.json(
+                content_type=None, # AWS ECR is using `text/plain` instead of `application/json`
+            )
             tags = tags_res['tags']
         except json.decoder.JSONDecodeError as jde:
             if not (content_type := res.headers['Content-Type']) == 'application/json':


### PR DESCRIPTION
Apparently, AWS ECR is using the `Content-Type: text/plain` even for valid JSON responses in the tag listing route. Therefore, don't fixate the content-type during deserialisation already, but only in case an error occurs (that part was already implemented).

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The async OCI client is not enforcing a content-type as part of the deserialisation of tags (AWS ECR is using `text/plain` instead of `application/json`)
```
