### PR TITLE
fix: reset submodule worktrees after upgrade-PR commit

### DIFF
--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -440,6 +440,7 @@ def commit_and_push_to_tmp_branch(
         raise
 
     git_helper.repo.git.reset('HEAD')  # also resets submodule gitlinks in index
+    git_helper.repo.git.submodule('update')  # checkout submodules to HEAD-recorded commit
     git_helper.repo.git.checkout('.')
     git_helper.repo.git.clean('-fd')
 


### PR DESCRIPTION
## Summary

- `git reset HEAD` (added in 502e981bf) unstages submodule gitlinks from the index, but does **not** update the submodule working tree — the submodule directory remains at the wrong commit.
- A subsequent `git add .` compares the working tree against the (now-reset) index, sees the discrepancy, and re-stages the dirty gitlink. Every PR after the first affected one therefore still carries the unwanted submodule diff.
- Fix: add `git submodule update` after the reset to check out all initialised submodules to the HEAD-recorded commit before the next iteration begins.

`git submodule update` without `--init` is a no-op when no submodules are initialised, so this is safe for repos that don't use submodules.