### PR TITLE
chore: update maintainers: drop zkdev/8R0WNI3, add Michael5601

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # cc-utils maintainers
-*   @ccwienk @8R0WNI3 @TuanAnh17N
+*   @ccwienk @Michael5601 @TuanAnh17N

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,11 +3,9 @@
 aliases:
   cc-utils-reviewers:
   - ccwienk
-  - 8R0WNI3
-  - zkdev
+  - Michael5601
   - TuanAnh17N
   cc-utils-approvers:
   - ccwienk
-  - 8R0WNI3
-  - zkdev
+  - Michael5601
   - TuanAnh17N


### PR DESCRIPTION
## Summary
- Remove `zkdev` and `8R0WNI3` from `OWNERS_ALIASES` (both reviewers and approvers lists) and `CODEOWNERS`
- Add `Michael5601` in their place