### PR TITLE
install syft to ~/.local/bin to fix GHE runner permission error

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -342,8 +342,11 @@ runs:
       if: ${{ inputs.oci-registry != '' }}
       shell: bash
       run: |
+        install_dir="${HOME}/.local/bin"
+        mkdir -p "${install_dir}"
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-          | sh -s -- -b /usr/local/bin
+          | sh -s -- -b "${install_dir}"
+        echo "${install_dir}" >> "${GITHUB_PATH}"
 
     - name: authenticate-for-spdx
       if: ${{ inputs.oci-registry != '' }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -379,9 +379,13 @@ jobs:
           remove-trusted-label: false
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: install-syft
+        shell: bash
         run: |
+          install_dir="${HOME}/.local/bin"
+          mkdir -p "${install_dir}"
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-            | sh -s -- -b /usr/local/bin
+            | sh -s -- -b "${install_dir}"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
         with:
           oci-image-reference: ${{ needs.prepare.outputs.oci-registry }}

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -510,7 +510,13 @@ jobs:
 
       - name: 'install syft / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
-        uses: anchore/sbom-action/download-syft@v0
+        shell: bash
+        run: |
+          install_dir="${HOME}/.local/bin"
+          mkdir -p "${install_dir}"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b "${install_dir}"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
 
       - name: 'generate SBOM / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}


### PR DESCRIPTION
## Summary

- GHE runners run as a non-root user without write access to `/usr/local/bin`
- The existing syft install used `curl ... | sh -s -- -b /usr/local/bin`, which fails with `Permission denied`
- Fix: install to `~/.local/bin` (user-writable) and append to `GITHUB_PATH`

Affects three places:
- `.github/actions/merge-ocm-fragments/action.yaml` (the reported regression)
- `.github/workflows/build-and-test.yaml` (same pattern)
- `.github/workflows/oci-ocm.yaml` (previously used `anchore/sbom-action/download-syft@v0`, replaced with inlined equivalent that works on GHE)

Validated on a GHE runner (install + `syft scan alpine:latest`).