### PR TITLE
ctt: add SbomInjectionProcessor with permanent integration test

### DIFF
--- a/.github/actions/merge-ocm-fragments/spdx_external.py
+++ b/.github/actions/merge-ocm-fragments/spdx_external.py
@@ -425,45 +425,16 @@ def _build_sbom_resources(
 ) -> tuple[dict, dict]:
     '''Return (spdx_resource, cdx_resource) OCM resource dicts for one external image.'''
     resource = info.resource
-    version = resource.get('version') or component_version
-
-    def _make_resource(media_type, sbom_format, blob_digest, data):
-        label_value = {
-            'data-source': {
-                'kind': 'local-scan',
-                'tool': 'syft',
-                'tool-version': tool_ver,
-            },
-            'format': sbom_format,
-        } if tool_ver else None
-        return {
-            'name': resource['name'],
-            'version': version,
-            'type': media_type,
-            'relation': str(ocm.ResourceRelation.EXTERNAL),
-            'extraIdentity': {'sbom-format': sbom_format},
-            'access': {
-                'type': str(ocm.AccessType.LOCAL_BLOB),
-                'localReference': blob_digest,
-                'mediaType': media_type,
-                'size': len(data),
-            },
-            'labels': [
-                {'name': 'gardener.cloud/sbom/source-image',
-                 'value': resource['access']['imageReference']},
-                {'name': 'gardener.cloud/sbom/source-image-digest',
-                 'value': info.source_digest},
-                *(
-                    [{'name': 'gardener.cloud/sbom', 'value': label_value}]
-                    if label_value else []
-                ),
-            ],
-        }
-
-    return (
-        _make_resource(osbom.SPDX_JSON_MEDIA_TYPE, 'spdx-2.3', spdx_blob_digest, spdx_bytes),
-        _make_resource(osbom.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_blob_digest,
-                       cdx_bytes),
+    return osbom.build_sbom_ocm_resources(
+        resource_name=resource['name'],
+        version=resource.get('version') or component_version,
+        source_image_ref=resource['access']['imageReference'],
+        source_digest=info.source_digest,
+        spdx_bytes=spdx_bytes,
+        cdx_bytes=cdx_bytes,
+        spdx_blob_digest=spdx_blob_digest,
+        cdx_blob_digest=cdx_blob_digest,
+        tool_ver=tool_ver,
     )
 
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -364,6 +364,37 @@ jobs:
           git commit -m "update documentation"
           git push origin refs/heads/gh-pages
 
+  test-ctt-sbom-inject:
+    name: integration-test ctt-sbom-inject
+    runs-on: ubuntu-latest
+    if: ${{ needs.prepare.outputs.can-push == 'true' }}
+    needs:
+      - prepare
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+      - name: install-syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b /usr/local/bin
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
+        with:
+          oci-image-reference: ${{ needs.prepare.outputs.oci-registry }}
+          gh-token: ${{ github.token }}
+      - name: run
+        shell: python
+        run: |
+          import os
+          import sys
+          sys.path.insert(0, '.')
+          import ctt.test.test_ctt_sbom_inject as t
+          t.run(run_id=os.environ['GITHUB_RUN_ID'])
+
   test-spdx-external:
     name: integration-test spdx-external
     runs-on: ubuntu-latest

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -551,18 +551,16 @@ jobs:
 
           tool_version = '${{ steps.sbom-generate.outputs.version }}' or None
 
-          spdx_digest = oci.sbom.push_sbom_referrer(
-              sbom_path='sbom.spdx.json',
+          with open('sbom.spdx.json', 'rb') as f:
+              spdx_bytes = f.read()
+          with open('sbom.cdx.json', 'rb') as f:
+              cdx_bytes = f.read()
+
+          spdx_digest, cdx_digest = oci.sbom.push_sbom_referrers(
+              spdx_bytes=spdx_bytes,
+              cdx_bytes=cdx_bytes,
               image_reference=image_ref,
               oci_client=oci_client,
-              sbom_media_type=oci.sbom.SPDX_JSON_MEDIA_TYPE,
-              tool_version=tool_version,
-          )
-          cdx_digest = oci.sbom.push_sbom_referrer(
-              sbom_path='sbom.cdx.json',
-              image_reference=image_ref,
-              oci_client=oci_client,
-              sbom_media_type=oci.sbom.CYCLONEDX_JSON_MEDIA_TYPE,
               tool_version=tool_version,
           )
 

--- a/ctt/model.py
+++ b/ctt/model.py
@@ -14,6 +14,7 @@ class ReplicationResourceOptions:
     convert_to_relative_ref: bool = False
     # if set, this ref is written into the component-descriptor instead of the actual push target
     descriptor_ref_override: str | None = None
+    inject_sboms: bool = False
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -23,6 +23,7 @@ import yaml
 import cnudie.retrieve
 import ctt.oci_util
 import ctt.replicate
+import ctt.sbom_inject
 import oci
 import oci.client
 import oci.model as om
@@ -851,6 +852,118 @@ def process_replication_plan_step(
         replication_plan_step.resources,
     ))
 
+    # --- SBOM injection (between Phase 1 image uploads and Phase 2 descriptor patching) ---
+    # Maps component_identity → list of extra OCM resource dicts to append.
+    sbom_extra_resources: dict[ocm.ComponentIdentity, list[dict]] = collections.defaultdict(list)
+
+    sbom_candidates = [
+        rre for rre in replication_resource_elements
+        if rre.inject_sboms
+    ]
+    if sbom_candidates:
+        if processing_mode is not ProcessingMode.DRY_RUN:
+            ctt.sbom_inject.check_syft()
+
+        tmpdir = os.environ.get('TMPDIR') or os.environ.get('RUNNER_TEMP') or None
+        syft_ver = ctt.sbom_inject._syft_version()
+
+        # parallel referrer lookup
+        def _lookup(rre):
+            tgt_ref = rre.tgt_ref
+            # resolve to digest; use multiarch accept so registries serve index manifests
+            digest_ref_str = oci_client.to_digest_hash(
+                tgt_ref,
+                accept=replication_mode.accept_header(),
+            )
+            digest_ref = om.OciImageReference.to_image_ref(digest_ref_str)
+
+            # if the manifest is a multiarch index, resolve to linux/amd64 so syft
+            # can scan a concrete single-platform manifest (some registries reject
+            # index manifest requests when the Accept header doesn't include index types)
+            try:
+                manifest = oci_client.manifest(
+                    digest_ref,
+                    accept=replication_mode.accept_header(),
+                )
+                if isinstance(manifest, om.OciImageManifestList):
+                    entries = [
+                        e for e in manifest.manifests
+                        if e.platform and e.platform.os == 'linux'
+                        and e.platform.architecture == 'amd64'
+                    ] or (manifest.manifests[:1] if manifest.manifests else [])
+                    if entries:
+                        plat_digest = entries[0].digest
+                        digest_ref = om.OciImageReference.to_image_ref(
+                            f'{digest_ref.ref_without_tag}@{plat_digest}'
+                        )
+            except Exception:  # nosec B110
+                pass  # keep the index digest ref; scan will fail gracefully
+
+            hit = ctt.sbom_inject.lookup_sbom_referrers(
+                image_ref=digest_ref,
+                oci_client=oci_client,
+            )
+            return rre, digest_ref, hit
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as lk_exec:
+            lookup_results = list(lk_exec.map(_lookup, sbom_candidates))
+
+        hits = [(rre, dref, hit) for rre, dref, hit in lookup_results if hit is not None]
+        misses = [(rre, dref) for rre, dref, hit in lookup_results if hit is None]
+
+        logger.info(
+            f'SBOM injection: {len(hits)} cache hit(s), {len(misses)} cache miss(es)'
+        )
+
+        # process cache hits
+        for rre, dref, hit in hits:
+            spdx_bytes, cdx_bytes, spdx_ref_digest, cdx_ref_digest = hit
+            tool_ver = ctt.sbom_inject._syft_version_from_spdx(spdx_bytes)
+            repo_ref = dref.ref_without_tag
+            source_image_ref = str(rre.src_ref)
+            source_digest = dref.tag  # sha256:<hex>
+            spdx_res, cdx_res = ctt.sbom_inject.build_sbom_ocm_resources(
+                resource_name=rre.source.name,
+                version=rre.source.version,
+                source_image_ref=source_image_ref,
+                source_digest=source_digest,
+                repo_ref=repo_ref,
+                spdx_referrer_digest=spdx_ref_digest,
+                cdx_referrer_digest=cdx_ref_digest,
+                tool_ver=tool_ver,
+            )
+            sbom_extra_resources[rre.component_id].extend((spdx_res, cdx_res))
+
+        # process cache misses (resource-aware scans)
+        if misses and processing_mode is not ProcessingMode.DRY_RUN:
+            miss_items = [(rre.source.name, dref) for rre, dref in misses]
+            miss_map = {rre.source.name: (rre, dref) for rre, dref in misses}
+
+            scan_results = ctt.sbom_inject.run_injections_resource_aware(
+                items=miss_items,
+                oci_client=oci_client,
+                tmpdir=tmpdir or '/tmp',  # nosec B108
+                tool_ver=syft_ver,
+            )
+            for name, spdx_bytes, cdx_bytes, tool_ver, spdx_dig, cdx_dig, status in scan_results:
+                if status != 'scanned':
+                    continue
+                rre, dref = miss_map[name]
+                repo_ref = dref.ref_without_tag
+                source_digest = dref.tag
+                spdx_res, cdx_res = ctt.sbom_inject.build_sbom_ocm_resources(
+                    resource_name=rre.source.name,
+                    version=rre.source.version,
+                    source_image_ref=str(rre.src_ref),
+                    source_digest=source_digest,
+                    repo_ref=repo_ref,
+                    spdx_referrer_digest=spdx_dig,
+                    cdx_referrer_digest=cdx_dig,
+                    tool_ver=tool_ver,
+                )
+                sbom_extra_resources[rre.component_id].extend((spdx_res, cdx_res))
+
+    # --- Phase 2: component-descriptor patching ---
     is_root_component_descriptor = lambda component_descriptor: (
         component_descriptor.component.name == root_component_descriptor.component.name
         and component_descriptor.component.version == root_component_descriptor.component.version
@@ -886,6 +999,10 @@ def process_replication_plan_step(
             patched_resources.get(resource.identity(peer_resources), resource)
             for resource in component.resources
         ]
+
+        # append any SBOM resources injected for this component
+        for sbom_resource in sbom_extra_resources.get(component.identity(), ()):
+            component.resources.append(sbom_resource)
 
         # Validate the patched component-descriptor and exit on fail
         if not skip_cd_validation:

--- a/ctt/processors.py
+++ b/ctt/processors.py
@@ -49,3 +49,13 @@ class FileFilter(ProcessorBase):
         replication_resource_element.remove_files = self._remove_entries
 
         return replication_resource_element
+
+
+class SbomInjectionProcessor(ProcessorBase):
+    '''Marks resources for SBOM injection. No image modification performed here.'''
+    def process(
+        self,
+        replication_resource_element: ctt.model.ReplicationResourceElement,
+    ) -> ctt.model.ReplicationResourceElement:
+        replication_resource_element.inject_sboms = True
+        return replication_resource_element

--- a/ctt/sbom_inject.py
+++ b/ctt/sbom_inject.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+SBOM injection for CTT replication.
+
+For each replicated OCI image that has `inject_sboms=True`:
+  1. Check the target registry for existing SPDX + CycloneDX referrer manifests.
+  2. Cache hit: download both SBOM blobs from the target.
+  3. Cache miss: run syft, push both referrer manifests to the target.
+
+Scan admission mirrors the resource-aware approach in spdx_external.py:
+  disk:   compressed_layer_bytes * 5.0
+  memory: 200 MiB + compressed_layer_bytes * 2.0
+Minimum headroom: 2 GiB disk, 1 GiB memory.  At least one scan is always admitted.
+'''
+import concurrent.futures
+import json
+import logging
+import os
+import subprocess
+import tempfile
+
+import oci.client as oc
+import oci.model as om
+import oci.sbom as osbom
+import ocm
+
+_DOCKER_CONFIG_PATH = os.path.expanduser('~/.docker/config.json')
+
+logger = logging.getLogger(__name__)
+
+_DISK_HEADROOM  = 2 * 1024 * 1024 * 1024   # 2 GiB
+_MEM_HEADROOM   = 1 * 1024 * 1024 * 1024   # 1 GiB
+_DISK_FACTOR    = 5.0
+_MEM_BASE       = 200 * 1024 * 1024         # 200 MiB
+_MEM_FACTOR     = 2.0
+
+
+def check_syft():
+    '''Verify syft is on PATH; raise RuntimeError with a friendly message if not.'''
+    try:
+        subprocess.run(  # nosec B607
+            ['syft', 'version'],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            'syft is not installed or not on PATH. '
+            'Please install syft (https://github.com/anchore/syft) before running CTT '
+            'with SBOM injection enabled.'
+        )
+
+
+def _syft_version() -> str | None:
+    try:
+        result = subprocess.run(  # nosec B607
+            ['syft', 'version', '--output', 'text'],
+            capture_output=True,
+            text=True,
+        )
+        for line in result.stdout.splitlines():
+            if 'version' in line.lower():
+                parts = line.split()
+                if parts:
+                    return parts[-1]
+    except Exception:  # nosec B110
+        pass
+    return None
+
+
+def _syft_version_from_spdx(spdx_bytes: bytes) -> str | None:
+    try:
+        doc = json.loads(spdx_bytes)
+        for creator in doc.get('creationInfo', {}).get('creators', []):
+            if creator.startswith('Tool: syft-'):
+                return creator[len('Tool: syft-'):]
+    except Exception:  # nosec B110
+        pass
+    return None
+
+
+def _available_disk_bytes(path: str) -> int:
+    st = os.statvfs(path)
+    return st.f_bavail * st.f_frsize
+
+
+def _available_mem_bytes() -> int:
+    with open('/proc/meminfo') as f:
+        for line in f:
+            if line.startswith('MemAvailable:'):
+                return int(line.split()[1]) * 1024
+    return 0
+
+
+def _estimate_bytes(compressed_layer_bytes: int) -> tuple[int, int]:
+    '''Return (estimated_disk_bytes, estimated_mem_bytes) for one syft invocation.'''
+    return (
+        int(compressed_layer_bytes * _DISK_FACTOR),
+        int(_MEM_BASE + compressed_layer_bytes * _MEM_FACTOR),
+    )
+
+
+def _compressed_layer_bytes(image_ref: str | om.OciImageReference, oci_client: oc.Client) -> int:
+    '''
+    Fetch the manifest (resolving multi-arch to linux/amd64) and return the sum of
+    compressed layer sizes.  Returns 0 on error (scan will still be admitted with force=True).
+    '''
+    try:
+        manifest = oci_client.manifest(
+            image_ref,
+            accept=om.MimeTypes.prefer_multiarch,
+        )
+        if isinstance(manifest, om.OciImageManifestList):
+            # pick linux/amd64 or fall back to first entry
+            entries = [
+                e for e in manifest.manifests
+                if e.platform and e.platform.os == 'linux'
+                and e.platform.architecture == 'amd64'
+            ]
+            entry = entries[0] if entries else (
+                manifest.manifests[0] if manifest.manifests else None
+            )
+            if entry is None:
+                return 0
+            manifest = oci_client.manifest(
+                f'{om.OciImageReference.to_image_ref(image_ref).ref_without_tag}@{entry.digest}',
+            )
+        return sum(layer.size for layer in manifest.layers)
+    except Exception:  # nosec
+        return 0
+
+
+def lookup_sbom_referrers(
+    image_ref: str | om.OciImageReference,
+    oci_client: oc.Client,
+) -> tuple[bytes, bytes, str, str] | None:
+    '''
+    Check the target for existing SPDX + CycloneDX referrer manifests.
+
+    Returns (spdx_bytes, cdx_bytes, spdx_referrer_digest, cdx_referrer_digest)
+    if both are present, otherwise None.
+    `image_ref` should already be digest-addressed.
+    '''
+    image_ref = om.OciImageReference.to_image_ref(image_ref)
+    repo_ref = image_ref.ref_without_tag
+
+    spdx_referrers = oci_client.referrers(
+        image_reference=image_ref,
+        artifact_type=osbom.SPDX_JSON_MEDIA_TYPE,
+        absent_ok=True,
+    )
+    cdx_referrers = oci_client.referrers(
+        image_reference=image_ref,
+        artifact_type=osbom.CYCLONEDX_JSON_MEDIA_TYPE,
+        absent_ok=True,
+    )
+
+    # None means the referrers API is not supported; () means supported but no entries
+    if not spdx_referrers or not cdx_referrers:
+        return None
+
+    spdx_descriptor = spdx_referrers[0]
+    cdx_descriptor = cdx_referrers[0]
+
+    try:
+        spdx_manifest_digest = spdx_descriptor['digest']
+        cdx_manifest_digest = cdx_descriptor['digest']
+
+        def _download_sbom_blob(manifest_digest: str) -> bytes:
+            manifest_bytes = oci_client.manifest_raw(
+                f'{repo_ref}@{manifest_digest}',
+            ).content
+            manifest = json.loads(manifest_bytes)
+            blob_digest = manifest['layers'][0]['digest']
+            return oci_client.blob(
+                image_reference=repo_ref,
+                digest=blob_digest,
+            ).content
+
+        spdx_bytes = _download_sbom_blob(spdx_manifest_digest)
+        cdx_bytes = _download_sbom_blob(cdx_manifest_digest)
+        return spdx_bytes, cdx_bytes, spdx_manifest_digest, cdx_manifest_digest
+    except Exception as e:
+        logger.warning(f'failed to download existing SBOM blobs from {repo_ref}: {e}')
+        return None
+
+
+def _syft_docker_config_dir(tmpdir: str) -> str:
+    '''
+    Write a docker config without credHelpers (syft uses Docker credential helpers
+    which may require interactive auth).  Returns a dir suitable for DOCKER_CONFIG.
+    '''
+    try:
+        with open(_DOCKER_CONFIG_PATH) as f:
+            cfg = json.load(f)
+    except Exception:
+        return os.path.dirname(_DOCKER_CONFIG_PATH)
+
+    cfg.pop('credHelpers', None)
+    cfg.pop('credsStore', None)
+
+    cfg_dir = tempfile.mkdtemp(dir=tmpdir)
+    with open(os.path.join(cfg_dir, 'config.json'), 'w') as f:
+        json.dump(cfg, f)
+    return cfg_dir
+
+
+def scan_image(
+    image_ref: str | om.OciImageReference,
+    oci_client: oc.Client,
+    tmpdir: str,
+    tool_ver: str | None = None,
+) -> tuple[bytes, bytes, str | None, str, str]:
+    '''
+    Scan the image with syft, push both referrer manifests to the target, and return
+    (spdx_bytes, cdx_bytes, tool_ver, spdx_referrer_digest, cdx_referrer_digest).
+
+    `image_ref` should be digest-addressed.
+    '''
+    image_ref = om.OciImageReference.to_image_ref(image_ref)
+    env = os.environ.copy()
+    env['TMPDIR'] = tmpdir
+    env['DOCKER_CONFIG'] = _syft_docker_config_dir(tmpdir)
+
+    with tempfile.TemporaryDirectory(dir=tmpdir) as tmp:
+        spdx_path = os.path.join(tmp, 'sbom.spdx.json')
+        cdx_path = os.path.join(tmp, 'sbom.cdx.json')
+
+        subprocess.run(  # nosec B607
+            [
+                'syft', 'scan', str(image_ref),
+                '-o', f'spdx-json={spdx_path}',
+                '-o', f'cyclonedx-json@1.6={cdx_path}',
+            ],
+            check=True,
+            env=env,
+        )
+
+        with open(spdx_path, 'rb') as f:
+            spdx_bytes = f.read()
+        with open(cdx_path, 'rb') as f:
+            cdx_bytes = f.read()
+
+    resolved_tool_ver = tool_ver or _syft_version_from_spdx(spdx_bytes)
+
+    spdx_referrer_digest, cdx_referrer_digest = osbom.push_sbom_referrers(
+        spdx_bytes=spdx_bytes,
+        cdx_bytes=cdx_bytes,
+        image_reference=image_ref,
+        oci_client=oci_client,
+        tool_version=resolved_tool_ver,
+    )
+
+    return spdx_bytes, cdx_bytes, resolved_tool_ver, spdx_referrer_digest, cdx_referrer_digest
+
+
+def run_injections_resource_aware(
+    items: list[tuple[str, str | om.OciImageReference]],
+    oci_client: oc.Client,
+    tmpdir: str,
+    tool_ver: str | None = None,
+) -> list[tuple[str, bytes, bytes, str | None, str, str, str]]:
+    '''
+    Scan images with resource-aware admission control.
+
+    `items` is a sequence of (resource_name, digest_image_ref) pairs for images that
+    had a cache miss (no existing referrers).
+
+    Returns a list of
+      (resource_name, spdx_bytes, cdx_bytes, tool_ver,
+       spdx_referrer_digest, cdx_referrer_digest, status)
+    where status is 'scanned' or 'failed'.  Failed entries have None for bytes/digests.
+    '''
+    results = []
+    reserved_disk = 0
+    reserved_mem = 0
+
+    # pre-fetch layer sizes in parallel
+    def _fetch_size(item):
+        name, ref = item
+        return name, ref, _compressed_layer_bytes(ref, oci_client)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        pending = list(executor.map(_fetch_size, items))
+
+    def _can_admit(est_disk: int, est_mem: int, force: bool) -> bool:
+        if force:
+            return True
+        avail_disk = _available_disk_bytes(tmpdir) - reserved_disk
+        avail_mem = _available_mem_bytes() - reserved_mem
+        return (
+            avail_disk - est_disk >= _DISK_HEADROOM
+            and avail_mem - est_mem >= _MEM_HEADROOM
+        )
+
+    def _do_scan(name, ref, est_disk, est_mem):
+        try:
+            spdx, cdx, ver, spdx_dig, cdx_dig = scan_image(
+                image_ref=ref,
+                oci_client=oci_client,
+                tmpdir=tmpdir,
+                tool_ver=tool_ver,
+            )
+            return name, spdx, cdx, ver, spdx_dig, cdx_dig, 'scanned'
+        except Exception as e:
+            logger.warning(f'{name!r}: scan failed: {e}')
+            return name, None, None, None, None, None, 'failed'
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        running: dict[concurrent.futures.Future, tuple[int, int]] = {}
+
+        while pending or running:
+            while pending:
+                name, ref, clb = pending[0]
+                est_disk, est_mem = _estimate_bytes(clb)
+                force = not running
+                if not _can_admit(est_disk, est_mem, force):
+                    break
+                pending.pop(0)
+                reserved_disk += est_disk
+                reserved_mem += est_mem
+                f = executor.submit(_do_scan, name, ref, est_disk, est_mem)
+                running[f] = (est_disk, est_mem)
+                logger.info(
+                    f'admitted SBOM scan for {name!r} '
+                    f'(est disk={est_disk // 1024 // 1024} MB '
+                    f'mem={est_mem // 1024 // 1024} MB, '
+                    f'{len(running)} running, {len(pending)} pending)'
+                )
+
+            if not running:
+                break
+
+            done, _ = concurrent.futures.wait(
+                running,
+                return_when=concurrent.futures.FIRST_COMPLETED,
+            )
+            for f in done:
+                est_disk, est_mem = running.pop(f)
+                reserved_disk -= est_disk
+                reserved_mem -= est_mem
+                results.append(f.result())
+
+    return results
+
+
+def build_sbom_ocm_resources(
+    resource_name: str,
+    version: str,
+    source_image_ref: str,
+    source_digest: str,
+    repo_ref: str,
+    spdx_referrer_digest: str,
+    cdx_referrer_digest: str,
+    tool_ver: str | None,
+) -> tuple[ocm.Resource, ocm.Resource]:
+    '''
+    Build (spdx_resource, cdx_resource) OCM Resource objects for CTT-injected SBOMs.
+
+    Uses OciAccess pointing at the referrer manifest digest already pushed to the target.
+    '''
+    def _make(media_type, sbom_format, referrer_digest):
+        label_value = {
+            'data-source': {
+                'kind': 'local-scan',
+                'tool': 'syft',
+                'tool-version': tool_ver,
+            },
+            'format': sbom_format,
+        } if tool_ver else None
+        labels = [
+            ocm.Label(name='gardener.cloud/sbom/source-image',        value=source_image_ref),
+            ocm.Label(name='gardener.cloud/sbom/source-image-digest', value=source_digest),
+        ]
+        if label_value:
+            labels.append(ocm.Label(name='gardener.cloud/sbom', value=label_value))
+        return ocm.Resource(
+            name=resource_name,
+            version=version,
+            type=media_type,
+            relation=ocm.ResourceRelation.EXTERNAL,
+            extraIdentity={'sbom-format': sbom_format},
+            access=ocm.OciAccess(
+                imageReference=f'{repo_ref}@{referrer_digest}',
+            ),
+            labels=labels,
+        )
+
+    return (
+        _make(osbom.SPDX_JSON_MEDIA_TYPE,     'spdx-2.3',      spdx_referrer_digest),
+        _make(osbom.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_referrer_digest),
+    )

--- a/ctt/test/test_ctt_sbom_inject.py
+++ b/ctt/test/test_ctt_sbom_inject.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Integration test for CTT SBOM injection.
+
+Constructs a synthetic three-component OCM tree, pushes its component descriptors to a
+per-run source prefix, runs the full CTT replication pipeline with SbomInjectionProcessor,
+and asserts SPDX + CycloneDX resources were injected for every OCI image resource.
+
+Cleanup of source + destination artefacts is attempted at the end (best-effort).
+
+Environment:
+  RUN_ID   override the run-id used for registry path isolation (default: generated uuid4 hex)
+
+  Registry credentials are read from ~/.docker/config.json (base64 auth entries).
+  The credHelpers entry for europe-docker.pkg.dev is intentionally stripped so that
+  syft can use the static credentials without requiring an interactive gcloud session.
+'''
+import dataclasses
+import hashlib
+import json
+import logging
+import os
+import sys
+import tempfile
+
+import yaml
+
+import oci.auth as oa
+import oci.client as oc
+import oci.model as om
+import ocm
+import ocm.oci
+import ocm.iter
+import cnudie.retrieve
+import ctt.process_dependencies as pdeps
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger('ctt-sbom-inttest')
+
+_REGISTRY = 'europe-docker.pkg.dev/gardener-project/snapshots'
+_INTTEST_PREFIX = 'cicd/integrationtest'
+
+# public images used as resource targets (small, well-known)
+_ALPINE_REF = 'alpine:3.21'
+_WOLFI_REF = 'cgr.dev/chainguard/wolfi-base:latest'
+_BUSYBOX_REF = 'busybox:stable'
+
+# synthetic component names/versions
+_ROOT_NAME = 'github.com/gardener/test/ctt-sbom-inttest/root'
+_CHILD_A_NAME = 'github.com/gardener/test/ctt-sbom-inttest/child-a'
+_CHILD_B_NAME = 'github.com/gardener/test/ctt-sbom-inttest/child-b'
+_VERSION = 'v0.0.0-inttest'
+
+
+def _make_resource(name: str, image_ref: str) -> ocm.Resource:
+    return ocm.Resource(
+        name=name,
+        version=_VERSION,
+        type='ociImage',
+        relation=ocm.ResourceRelation.EXTERNAL,
+        access=ocm.OciAccess(imageReference=image_ref),
+    )
+
+
+def _make_component(
+    name: str,
+    ocm_repo: ocm.OciOcmRepository,
+    resources: list[ocm.Resource],
+    refs: list[ocm.ComponentReference] | None = None,
+) -> ocm.ComponentDescriptor:
+    component = ocm.Component(
+        name=name,
+        version=_VERSION,
+        repositoryContexts=[ocm_repo],
+        provider='gardener',
+        sources=[],
+        componentReferences=refs or [],
+        resources=resources,
+    )
+    return ocm.ComponentDescriptor(
+        meta=ocm.Metadata(schemaVersion=ocm.SchemaVersion.V2),
+        component=component,
+    )
+
+
+def push_component_descriptor(
+    component_descriptor: ocm.ComponentDescriptor,
+    oci_client: oc.Client,
+) -> str:
+    '''
+    Push a component descriptor as a fresh OCI artefact.  Returns the pushed image reference.
+    '''
+    repo: ocm.OciOcmRepository = component_descriptor.component.current_ocm_repo
+    image_ref = repo.component_version_oci_ref(component_descriptor.component)
+
+    tar_fobj = ocm.oci.component_descriptor_to_tarfileobj(component_descriptor)
+    tar_bytes = tar_fobj.read()
+
+    cd_digest = f'sha256:{hashlib.sha256(tar_bytes).hexdigest()}'
+    cd_size = len(tar_bytes)
+
+    cfg = ocm.oci.ComponentDescriptorOciCfg(
+        componentDescriptorLayer=ocm.oci.ComponentDescriptorOciBlobRef(
+            digest=cd_digest,
+            size=cd_size,
+            mediaType=ocm.oci.component_descriptor_mimetype,
+        ),
+    )
+    cfg_bytes = json.dumps(dataclasses.asdict(cfg)).encode('utf-8')
+    cfg_digest = f'sha256:{hashlib.sha256(cfg_bytes).hexdigest()}'
+    cfg_size = len(cfg_bytes)
+
+    oci_client.put_blob(
+        image_reference=image_ref,
+        digest=cd_digest,
+        octets_count=cd_size,
+        data=tar_bytes,
+        mimetype=ocm.oci.component_descriptor_mimetype,
+    )
+    oci_client.put_blob(
+        image_reference=image_ref,
+        digest=cfg_digest,
+        octets_count=cfg_size,
+        data=cfg_bytes,
+        mimetype=ocm.oci.component_descriptor_cfg_mimetype,
+    )
+
+    manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest=cfg_digest,
+            mediaType=ocm.oci.component_descriptor_cfg_mimetype,
+            size=cfg_size,
+        ),
+        layers=[om.OciBlobRef(
+            digest=cd_digest,
+            mediaType=ocm.oci.component_descriptor_mimetype,
+            size=cd_size,
+        )],
+    )
+    manifest_bytes = json.dumps(manifest.as_dict()).encode('utf-8')
+
+    oci_client.put_manifest(
+        image_reference=image_ref,
+        manifest=manifest_bytes,
+    )
+
+    return image_ref
+
+
+def _purge_ref(oci_client: oc.Client, image_ref: str):
+    try:
+        oci_client.delete_manifest(
+            image_reference=image_ref,
+            purge=True,
+            absent_ok=True,
+        )
+    except Exception as e:
+        logger.warning(f'cleanup: failed to delete {image_ref}: {e}')
+
+
+def run(run_id: str):
+    oci_client = oc.Client(
+        credentials_lookup=oa.docker_credentials_lookup(),
+    )
+
+    run_prefix = f'{_REGISTRY}/{_INTTEST_PREFIX}/{run_id}'
+    src_repo_url = f'{run_prefix}/src'
+    dst_repo_url = f'{run_prefix}/dst'
+
+    src_ocm_repo = ocm.OciOcmRepository(baseUrl=src_repo_url)
+    dst_ocm_repo = ocm.OciOcmRepository(baseUrl=dst_repo_url)
+
+    # --- build synthetic component tree ---
+    child_a_cd = _make_component(
+        name=_CHILD_A_NAME,
+        ocm_repo=src_ocm_repo,
+        resources=[_make_resource('wolfi-base', _WOLFI_REF)],
+    )
+    child_b_cd = _make_component(
+        name=_CHILD_B_NAME,
+        ocm_repo=src_ocm_repo,
+        resources=[_make_resource('busybox', _BUSYBOX_REF)],
+    )
+    root_cd = _make_component(
+        name=_ROOT_NAME,
+        ocm_repo=src_ocm_repo,
+        resources=[_make_resource('alpine', _ALPINE_REF)],
+        refs=[
+            ocm.ComponentReference(
+                name='child-a',
+                componentName=_CHILD_A_NAME,
+                version=_VERSION,
+            ),
+            ocm.ComponentReference(
+                name='child-b',
+                componentName=_CHILD_B_NAME,
+                version=_VERSION,
+            ),
+        ],
+    )
+
+    # --- push source component descriptors ---
+    src_refs = []
+    for cd in (child_a_cd, child_b_cd, root_cd):
+        ref = push_component_descriptor(cd, oci_client)
+        src_refs.append(ref)
+        logger.info(f'pushed src CD: {ref}')
+
+    src_lookup = cnudie.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(src_repo_url),
+        oci_client=oci_client,
+    )
+    dst_lookup = cnudie.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(dst_repo_url),
+        oci_client=oci_client,
+    )
+
+    processing_cfg = {
+        'targets': {
+            'default': {
+                'type': 'RegistriesTarget',
+                'kwargs': {
+                    'registries': [dst_repo_url],
+                    'ocm_repository': dst_repo_url,
+                },
+            },
+        },
+        'processors': {
+            'sbom': {
+                'type': 'SbomInjectionProcessor',
+            },
+        },
+        'uploaders': {
+            'prepend': {
+                'type': 'PrependTargetUploader',
+                'kwargs': {
+                    'remove_prefixes': [
+                        'docker.io',
+                        'index.docker.io',
+                        'cgr.dev',
+                        'registry-1.docker.io',
+                    ],
+                },
+            },
+        },
+        'image_processing_cfg': [
+            {
+                'name': 'sbom-inject',
+                'filter': [{'type': 'MatchAllFilter'}],
+                'processor': 'sbom',
+                'target': 'default',
+                'upload': ['prepend'],
+            },
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg_path = os.path.join(tmpdir, 'processing.cfg')
+        with open(cfg_path, 'w') as f:
+            yaml.safe_dump(processing_cfg, f)
+
+        os.environ['TMPDIR'] = tmpdir
+        parsed_cfg = pdeps.parse_processing_cfg(cfg_path)
+
+        replication_plan_step = pdeps.create_replication_plan_step(
+            processing_cfg=parsed_cfg,
+            root_component_descriptor=root_cd,
+            src_component_descriptor_lookup=src_lookup,
+            tgt_component_descriptor_lookup=dst_lookup,
+            ocm_repository=dst_repo_url,
+            tgt_oci_registries=[dst_repo_url],
+            oci_client=oci_client,
+        )
+
+        logger.info(replication_plan_step)
+
+        nodes = list(pdeps.process_replication_plan_step(
+            replication_plan_step=replication_plan_step,
+            root_component_descriptor=root_cd,
+            oci_client=oci_client,
+            tgt_component_descriptor_lookup=dst_lookup,
+            skip_cd_validation=True,
+        ))
+
+    # --- collect pushed refs for cleanup ---
+    dst_image_refs = []
+
+    # component descriptor refs (deterministic)
+    for name in (_ROOT_NAME, _CHILD_A_NAME, _CHILD_B_NAME):
+        cd_ref = dst_ocm_repo.component_version_oci_ref(name=name, version=_VERSION)
+        dst_image_refs.append(cd_ref)
+
+    # image resource refs from replicated nodes
+    resource_nodes = [n for n in nodes if ocm.iter.Filter.resources(n)]
+    all_resources = [n.resource for n in resource_nodes]
+
+    for resource in all_resources:
+        if resource.access and hasattr(resource.access, 'imageReference'):
+            dst_image_refs.append(resource.access.imageReference)
+
+    # --- assertions ---
+    sbom_resources = [
+        r for r in all_resources
+        if isinstance(r.extraIdentity, dict) and r.extraIdentity.get('sbom-format')
+    ]
+    oci_image_resources = [
+        r for r in all_resources
+        if r.access.type is ocm.AccessType.OCI_REGISTRY
+        and not (isinstance(r.extraIdentity, dict) and r.extraIdentity.get('sbom-format'))
+    ]
+
+    logger.info(
+        f'{len(oci_image_resources)} OCI image resource(s) replicated, '
+        f'{len(sbom_resources)} SBOM resource(s) injected'
+    )
+
+    assert sbom_resources, (
+        f'no SBOM resources injected; all resources: '
+        f'{[(r.name, r.type, r.extraIdentity) for r in all_resources]}'
+    )
+
+    # expect 2 SBOM resources per OCI image resource
+    assert len(sbom_resources) == len(oci_image_resources) * 2, (
+        f'expected {len(oci_image_resources) * 2} SBOM resources '
+        f'(2 per image), got {len(sbom_resources)}'
+    )
+
+    formats_found = {r.extraIdentity['sbom-format'] for r in sbom_resources}
+    assert 'spdx-2.3' in formats_found, f'spdx-2.3 missing from {formats_found}'
+    assert 'cyclonedx-1.6' in formats_found, f'cyclonedx-1.6 missing from {formats_found}'
+
+    for r in sbom_resources:
+        assert r.access.type is ocm.AccessType.OCI_REGISTRY, (
+            f'{r.extraIdentity["sbom-format"]}: expected ociRegistry access, got {r.access.type}'
+        )
+        img_ref = r.access.imageReference
+        assert '@sha256:' in img_ref, (
+            f'{r.extraIdentity["sbom-format"]}: imageReference {img_ref!r} has no digest'
+        )
+        assert img_ref.startswith(dst_repo_url), (
+            f'{r.extraIdentity["sbom-format"]}: imageReference {img_ref!r} '
+            f'should start with {dst_repo_url!r}'
+        )
+        labels = {l.name: l.value for l in r.labels}
+        assert 'gardener.cloud/sbom/source-image' in labels, (
+            f'{r.extraIdentity["sbom-format"]}: missing source-image label'
+        )
+        assert 'gardener.cloud/sbom/source-image-digest' in labels, (
+            f'{r.extraIdentity["sbom-format"]}: missing source-image-digest label'
+        )
+        fmt = r.extraIdentity['sbom-format']
+        logger.info(f'  {r.name} ({fmt}): {img_ref}')
+
+    logger.info('all assertions passed')
+
+    # --- best-effort cleanup ---
+    logger.info('cleaning up pushed artefacts (best-effort)...')
+    for ref in src_refs + dst_image_refs:
+        _purge_ref(oci_client, ref)
+
+
+if __name__ == '__main__':
+    import uuid
+    run_id = os.environ.get('RUN_ID') or uuid.uuid4().hex[:8]
+    logger.info(f'using {run_id=}')
+    run(run_id)

--- a/ctt/test/test_sbom_inject_integration.py
+++ b/ctt/test/test_sbom_inject_integration.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Ad-hoc integration test for CTT SBOM injection — full pipeline.
+
+Requires:
+  - write access to europe-docker.pkg.dev/gardener-project/snapshots/ctt-test
+  - read access to europe-docker.pkg.dev/gardener-project/releases
+  - syft on PATH
+  - docker credentials for both registries
+
+Fetches the real component-descriptor for
+  github.com/gardener/gardener-extension-provider-openstack:v1.55.3
+from the /releases registry, runs the full CTT replication pipeline with
+SbomInjectionProcessor targeting /snapshots/ctt-test/<run_id>, then asserts
+that SBOM resources (spdx-2.3 + cyclonedx-1.6) were injected.
+'''
+import logging
+import os
+import sys
+import tempfile
+
+import yaml
+
+import cnudie.retrieve
+import ctt.process_dependencies as pdeps
+import oci.auth as oa
+import oci.client as oc
+import ocm
+import ocm.iter
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger('sbom-inject-inttest')
+
+RELEASES_REGISTRY = 'europe-docker.pkg.dev/gardener-project/releases'
+SNAPSHOTS_REGISTRY = 'europe-docker.pkg.dev/gardener-project/snapshots'
+TGT_REGISTRY = f'{SNAPSHOTS_REGISTRY}/ctt-test'
+
+COMPONENT_NAME = 'github.com/gardener/gardener-extension-provider-openstack'
+COMPONENT_VERSION = 'v1.55.3'
+
+
+def _oci_lookup(ocm_repo_url: str, oci_client: oc.Client):
+    '''Build a lightweight OCI-only component descriptor lookup (no ctx/config system).'''
+    return cnudie.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo_url),
+        oci_client=oci_client,
+    )
+
+
+def _processing_cfg(tgt: str) -> dict:
+    return {
+        'targets': {
+            'default': {
+                'type': 'RegistriesTarget',
+                'kwargs': {
+                    'registries': [tgt],
+                    'ocm_repository': tgt,
+                },
+            },
+        },
+        'processors': {
+            'sbom': {
+                'type': 'SbomInjectionProcessor',
+            },
+        },
+        'uploaders': {
+            'prepend': {
+                'type': 'PrependTargetUploader',
+                'kwargs': {
+                    'remove_prefixes': [RELEASES_REGISTRY, 'registry.k8s.io'],
+                },
+            },
+        },
+        'image_processing_cfg': [
+            {
+                'name': 'sbom-inject',
+                'filter': [{'type': 'MatchAllFilter'}],
+                'processor': 'sbom',
+                'target': 'default',
+                'upload': ['prepend'],
+            },
+        ],
+    }
+
+
+def run(run_id: str):
+    oci_client = oc.Client(
+        credentials_lookup=oa.docker_credentials_lookup(),
+    )
+
+    src_lookup = _oci_lookup(RELEASES_REGISTRY, oci_client)
+
+    root_cd = src_lookup(ocm.ComponentIdentity(
+        name=COMPONENT_NAME,
+        version=COMPONENT_VERSION,
+    ))
+    logger.info(
+        f'fetched root component: {root_cd.component.name}:{root_cd.component.version} '
+        f'({len(root_cd.component.resources)} resources)'
+    )
+
+    tgt = f'{TGT_REGISTRY}/{run_id}'
+    cfg = _processing_cfg(tgt)
+    tgt_lookup = _oci_lookup(tgt, oci_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg_path = os.path.join(tmpdir, 'processing.cfg')
+        with open(cfg_path, 'w') as f:
+            yaml.safe_dump(cfg, f)
+
+        os.environ['TMPDIR'] = tmpdir
+
+        processing_cfg = pdeps.parse_processing_cfg(cfg_path)
+
+        replication_plan_step = pdeps.create_replication_plan_step(
+            processing_cfg=processing_cfg,
+            root_component_descriptor=root_cd,
+            src_component_descriptor_lookup=src_lookup,
+            tgt_component_descriptor_lookup=tgt_lookup,
+            ocm_repository=tgt,
+            tgt_oci_registries=[tgt],
+            oci_client=oci_client,
+        )
+
+        logger.info(replication_plan_step)
+
+        nodes = list(pdeps.process_replication_plan_step(
+            replication_plan_step=replication_plan_step,
+            root_component_descriptor=root_cd,
+            oci_client=oci_client,
+            tgt_component_descriptor_lookup=tgt_lookup,
+            skip_cd_validation=True,
+        ))
+
+    logger.info(f'process_replication_plan_step yielded {len(nodes)} node(s)')
+
+    resource_nodes = [n for n in nodes if ocm.iter.Filter.resources(n)]
+    all_resources = [n.resource for n in resource_nodes]
+
+    sbom_resources = [
+        r for r in all_resources
+        if isinstance(r.extraIdentity, dict) and r.extraIdentity.get('sbom-format')
+    ]
+    oci_resources = [
+        r for r in all_resources
+        if r.access.type is ocm.AccessType.OCI_REGISTRY
+        and not (isinstance(r.extraIdentity, dict) and r.extraIdentity.get('sbom-format'))
+    ]
+
+    logger.info(
+        f'{len(oci_resources)} OCI image(s) replicated, '
+        f'{len(sbom_resources)} SBOM resource(s) injected'
+    )
+
+    assert sbom_resources, (
+        f'no SBOM resources injected; all resources: '
+        f'{[(r.name, r.type, r.extraIdentity) for r in all_resources]}'
+    )
+
+    formats_found = {r.extraIdentity['sbom-format'] for r in sbom_resources}
+    assert 'spdx-2.3' in formats_found, f'spdx-2.3 missing from {formats_found}'
+    assert 'cyclonedx-1.6' in formats_found, f'cyclonedx-1.6 missing from {formats_found}'
+
+    for r in sbom_resources:
+        assert r.access.type is ocm.AccessType.OCI_REGISTRY, (
+            f'{r.extraIdentity["sbom-format"]}: expected ociRegistry access, got {r.access.type}'
+        )
+        img_ref = r.access.imageReference
+        assert '@sha256:' in img_ref, (
+            f'{r.extraIdentity["sbom-format"]}: imageReference {img_ref!r} has no digest'
+        )
+        assert img_ref.startswith(tgt), (
+            f'{r.extraIdentity["sbom-format"]}: imageReference {img_ref!r} '
+            f'should start with {tgt!r}'
+        )
+        labels = {l.name: l.value for l in r.labels}
+        assert 'gardener.cloud/sbom/source-image' in labels, (
+            f'{r.extraIdentity["sbom-format"]}: missing source-image label'
+        )
+        assert 'gardener.cloud/sbom/source-image-digest' in labels, (
+            f'{r.extraIdentity["sbom-format"]}: missing source-image-digest label'
+        )
+        logger.info(f'  {r.extraIdentity["sbom-format"]}: {img_ref}')
+
+    logger.info('all assertions passed')
+
+
+if __name__ == '__main__':
+    import uuid
+    run_id = os.environ.get('RUN_ID') or uuid.uuid4().hex[:8]
+    logger.info(f'using {run_id=}')
+    run(run_id)

--- a/oci/client.py
+++ b/oci/client.py
@@ -219,6 +219,17 @@ class OciRoutes:
             tag,
         )
 
+    def referrers_url(
+        self,
+        image_reference: str | om.OciImageReference,
+        digest: str,
+    ) -> str:
+        return urljoin(
+            self.artifact_base_url(image_reference=image_reference),
+            'referrers',
+            digest,
+        )
+
 
 def _retry_after_seconds(res: requests.models.Response, fallback: float) -> float:
     try:
@@ -1022,6 +1033,53 @@ class Client:
             accept=om.MimeTypes.single_image,
         )
         return False
+
+    def referrers(
+        self,
+        image_reference: str | om.OciImageReference,
+        artifact_type: str | None = None,
+        absent_ok: bool = False,
+    ) -> tuple[dict, ...] | None:
+        '''
+        Return referrer descriptors for the given image (OCI 1.1 referrers API).
+
+        `image_reference` must be digest-addressed (e.g. repo@sha256:...).
+        If `artifact_type` is given, only referrers with a matching artifactType are returned.
+
+        Returns None if the registry returns 404 (referrers API not supported) and
+        `absent_ok` is True; an empty tuple if the index exists but has no matching entries;
+        otherwise a tuple of referrer descriptor dicts.
+
+        Raises HTTPError on 404 when `absent_ok` is False.
+        '''
+        image_reference = om.OciImageReference.to_image_ref(image_reference)
+        digest = image_reference.tag  # sha256:<hex> from a digest ref
+        scope = _scope(image_reference=image_reference, action='pull')
+
+        params = {}
+        if artifact_type:
+            params['artifactType'] = artifact_type
+
+        res = self._request(
+            url=self.routes.referrers_url(
+                image_reference=image_reference,
+                digest=digest,
+            ),
+            image_reference=image_reference,
+            scope=scope,
+            method='GET',
+            raise_for_status=False,
+            warn_if_not_ok=not absent_ok,
+            **({'params': params} if params else {}),
+        )
+
+        if res.status_code == 404:
+            if absent_ok:
+                return None
+            res.raise_for_status()
+
+        res.raise_for_status()
+        return tuple(res.json().get('manifests') or ())
 
     @initialise_repository_if_required
     def put_manifest(

--- a/oci/sbom.py
+++ b/oci/sbom.py
@@ -1,5 +1,6 @@
 '''
-Utilities for pushing SBOM documents as OCI referrers (OCI 1.1).
+Utilities for pushing SBOM documents as OCI referrers (OCI 1.1) and building
+OCM resource descriptors for SBOM artefacts.
 
 An SBOM is stored as a single-layer OCI manifest whose `subject` field points
 to the image it describes.  The referrer manifest is pushed by digest; registries
@@ -11,6 +12,7 @@ import logging
 
 import oci.client as oc
 import oci.model as om
+import ocm
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,61 @@ _EMPTY_CONFIG_DIGEST = f'sha256:{hashlib.sha256(_EMPTY_CONFIG).hexdigest()}'
 SPDX_JSON_MEDIA_TYPE = 'application/spdx+json'
 CYCLONEDX_JSON_MEDIA_TYPE = 'application/vnd.cyclonedx+json'
 OCI_EMPTY_CONFIG_MEDIA_TYPE = 'application/vnd.oci.empty.v1+json'
+
+# (sbom_format_id, media_type) pairs in canonical order
+SBOM_FORMATS: tuple[tuple[str, str], ...] = (
+    ('spdx-2.3',       SPDX_JSON_MEDIA_TYPE),
+    ('cyclonedx-1.6',  CYCLONEDX_JSON_MEDIA_TYPE),
+)
+
+
+def _build_sbom_referrer_manifest(
+    sbom_bytes: bytes,
+    sbom_media_type: str,
+    subject_digest: str,
+    subject_media_type: str,
+    subject_size: int,
+    tool_version: str | None = None,
+) -> tuple[bytes, str]:
+    '''
+    Build an OCI referrer manifest for the given SBOM bytes and subject descriptor.
+
+    Pure function — no I/O.  Returns (manifest_bytes, manifest_digest).
+
+    The caller is responsible for pushing the SBOM blob and the empty config blob
+    before pushing the returned manifest.
+    '''
+    sbom_digest = f'sha256:{hashlib.sha256(sbom_bytes).hexdigest()}'
+    sbom_size = len(sbom_bytes)
+
+    manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest=_EMPTY_CONFIG_DIGEST,
+            mediaType=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+            size=len(_EMPTY_CONFIG),
+        ),
+        layers=[
+            om.OciBlobRef(
+                digest=sbom_digest,
+                mediaType=sbom_media_type,
+                size=sbom_size,
+            ),
+        ],
+        subject=om.OciBlobRef(
+            digest=subject_digest,
+            mediaType=subject_media_type,
+            size=subject_size,
+        ),
+        artifactType=sbom_media_type,
+        annotations={
+            'org.opencontainers.image.created': _utcnow_iso(),
+            **({'gardener.cloud/sbom/tool-version': tool_version} if tool_version else {}),
+        },
+    )
+
+    manifest_bytes = json.dumps(manifest.as_dict()).encode()
+    manifest_digest = f'sha256:{hashlib.sha256(manifest_bytes).hexdigest()}'
+    return manifest_bytes, manifest_digest
 
 
 def push_sbom_referrer(
@@ -46,22 +103,21 @@ def push_sbom_referrer(
 
     # resolve to digest so subject.digest is canonical
     digest_ref = oci_client.to_digest_hash(image_ref)
-    # to_digest_hash returns a full ref like repo@sha256:...
     digest_image_ref = om.OciImageReference.to_image_ref(digest_ref)
     subject_digest = digest_image_ref.tag  # 'sha256:<hex>'
 
-    # retrieve the manifest to get its size and mediaType for the subject descriptor
     manifest_raw_res = oci_client.manifest_raw(digest_image_ref)
-    manifest_bytes_for_subject = manifest_raw_res.content
-    subject_media_type = manifest_raw_res.headers.get('Content-Type', om.OCI_MANIFEST_SCHEMA_V2_MIME)
-    subject_size = len(manifest_bytes_for_subject)
+    subject_media_type = manifest_raw_res.headers.get(
+        'Content-Type', om.OCI_MANIFEST_SCHEMA_V2_MIME,
+    )
+    subject_size = len(manifest_raw_res.content)
 
     with open(sbom_path, 'rb') as f:
         sbom_bytes = f.read()
 
     sbom_digest = f'sha256:{hashlib.sha256(sbom_bytes).hexdigest()}'
     sbom_size = len(sbom_bytes)
-    repo_ref = image_ref.ref_without_tag  # push blobs/manifest to same repo
+    repo_ref = image_ref.ref_without_tag
 
     logger.info(f'pushing SBOM blob {sbom_digest} ({sbom_size} bytes) to {repo_ref}')
     oci_client.put_blob(
@@ -72,7 +128,6 @@ def push_sbom_referrer(
         mimetype=sbom_media_type,
     )
 
-    # empty config blob (required by OCI image manifest structure)
     oci_client.put_blob(
         image_reference=repo_ref,
         digest=_EMPTY_CONFIG_DIGEST,
@@ -81,44 +136,149 @@ def push_sbom_referrer(
         mimetype=OCI_EMPTY_CONFIG_MEDIA_TYPE,
     )
 
-    referrer_manifest = om.OciImageManifest(
-        config=om.OciBlobRef(
-            digest=_EMPTY_CONFIG_DIGEST,
-            mediaType=OCI_EMPTY_CONFIG_MEDIA_TYPE,
-            size=len(_EMPTY_CONFIG),
-        ),
-        layers=[
-            om.OciBlobRef(
-                digest=sbom_digest,
-                mediaType=sbom_media_type,
-                size=sbom_size,
-            ),
-        ],
-        subject=om.OciBlobRef(
-            digest=subject_digest,
-            mediaType=subject_media_type,
-            size=subject_size,
-        ),
-        artifactType=sbom_media_type,
-        annotations={
-            'org.opencontainers.image.created': _utcnow_iso(),
-            **({'gardener.cloud/sbom/tool-version': tool_version} if tool_version else {}),
-        },
+    manifest_bytes, referrer_digest = _build_sbom_referrer_manifest(
+        sbom_bytes=sbom_bytes,
+        sbom_media_type=sbom_media_type,
+        subject_digest=subject_digest,
+        subject_media_type=subject_media_type,
+        subject_size=subject_size,
+        tool_version=tool_version,
     )
 
-    referrer_manifest_bytes = json.dumps(referrer_manifest.as_dict()).encode()
-    referrer_digest = f'sha256:{hashlib.sha256(referrer_manifest_bytes).hexdigest()}'
-
-    # push manifest addressed by digest (no symbolic tag needed for referrers API)
     referrer_ref = f'{repo_ref}@{referrer_digest}'
     logger.info(f'pushing SBOM referrer manifest to {referrer_ref}')
     oci_client.put_manifest(
         image_reference=referrer_ref,
-        manifest=referrer_manifest_bytes,
+        manifest=manifest_bytes,
     )
 
     logger.info(f'SBOM referrer pushed: {referrer_digest}')
     return referrer_digest
+
+
+def push_sbom_referrers(
+    spdx_bytes: bytes,
+    cdx_bytes: bytes,
+    image_reference: str | om.OciImageReference,
+    oci_client: oc.Client,
+    tool_version: str | None = None,
+) -> tuple[str, str]:
+    '''
+    Push SPDX and CycloneDX SBOM documents as OCI referrer manifests for the given image.
+
+    Resolves the subject descriptor once and reuses it for both manifests.
+    Pushes three blobs (spdx, cdx, empty config) and two manifests.
+
+    Returns (spdx_referrer_digest, cdx_referrer_digest).
+    '''
+    image_ref = om.OciImageReference.to_image_ref(image_reference)
+    repo_ref = image_ref.ref_without_tag
+
+    digest_ref = oci_client.to_digest_hash(image_ref)
+    digest_image_ref = om.OciImageReference.to_image_ref(digest_ref)
+    subject_digest = digest_image_ref.tag
+
+    manifest_raw_res = oci_client.manifest_raw(digest_image_ref)
+    subject_media_type = manifest_raw_res.headers.get(
+        'Content-Type', om.OCI_MANIFEST_SCHEMA_V2_MIME,
+    )
+    subject_size = len(manifest_raw_res.content)
+
+    # push shared empty config once
+    oci_client.put_blob(
+        image_reference=repo_ref,
+        digest=_EMPTY_CONFIG_DIGEST,
+        octets_count=len(_EMPTY_CONFIG),
+        data=_EMPTY_CONFIG,
+        mimetype=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+    )
+
+    digests = []
+    for sbom_bytes, sbom_media_type in (
+        (spdx_bytes, SPDX_JSON_MEDIA_TYPE),
+        (cdx_bytes, CYCLONEDX_JSON_MEDIA_TYPE),
+    ):
+        sbom_digest = f'sha256:{hashlib.sha256(sbom_bytes).hexdigest()}'
+        sbom_size = len(sbom_bytes)
+        logger.info(f'pushing SBOM blob {sbom_digest} ({sbom_size} bytes) to {repo_ref}')
+        oci_client.put_blob(
+            image_reference=repo_ref,
+            digest=sbom_digest,
+            octets_count=sbom_size,
+            data=sbom_bytes,
+            mimetype=sbom_media_type,
+        )
+        manifest_bytes, referrer_digest = _build_sbom_referrer_manifest(
+            sbom_bytes=sbom_bytes,
+            sbom_media_type=sbom_media_type,
+            subject_digest=subject_digest,
+            subject_media_type=subject_media_type,
+            subject_size=subject_size,
+            tool_version=tool_version,
+        )
+        referrer_ref = f'{repo_ref}@{referrer_digest}'
+        logger.info(f'pushing SBOM referrer manifest to {referrer_ref}')
+        oci_client.put_manifest(
+            image_reference=referrer_ref,
+            manifest=manifest_bytes,
+        )
+        digests.append(referrer_digest)
+
+    return digests[0], digests[1]
+
+
+def build_sbom_ocm_resources(
+    resource_name: str,
+    version: str,
+    source_image_ref: str,
+    source_digest: str,
+    spdx_bytes: bytes,
+    cdx_bytes: bytes,
+    spdx_blob_digest: str,
+    cdx_blob_digest: str,
+    tool_ver: str | None,
+) -> tuple[dict, dict]:
+    '''
+    Build (spdx_resource, cdx_resource) OCM resource dicts for one scanned image.
+
+    Both resources use the source image's resource name with extraIdentity.sbom-format
+    to distinguish them, matching the convention established in the upstream pipeline.
+    '''
+    def _make(media_type, sbom_format, blob_digest, sbom_bytes):
+        label_value = {
+            'data-source': {
+                'kind': 'local-scan',
+                'tool': 'syft',
+                'tool-version': tool_ver,
+            },
+            'format': sbom_format,
+        } if tool_ver else None
+        return {
+            'name': resource_name,
+            'version': version,
+            'type': media_type,
+            'relation': str(ocm.ResourceRelation.EXTERNAL),
+            'extraIdentity': {'sbom-format': sbom_format},
+            'access': {
+                'type': str(ocm.AccessType.LOCAL_BLOB),
+                'localReference': blob_digest,
+                'mediaType': media_type,
+                'size': len(sbom_bytes),
+            },
+            'labels': [
+                {'name': 'gardener.cloud/sbom/source-image',        'value': source_image_ref},
+                {'name': 'gardener.cloud/sbom/source-image-digest', 'value': source_digest},
+                *(
+                    [{'name': 'gardener.cloud/sbom', 'value': label_value}]
+                    if label_value else []
+                ),
+            ],
+        }
+
+    return (
+        _make(SPDX_JSON_MEDIA_TYPE,      'spdx-2.3',      spdx_blob_digest, spdx_bytes),
+        _make(CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_blob_digest,  cdx_bytes),
+    )
 
 
 def _utcnow_iso() -> str:


### PR DESCRIPTION
add `SbomInjectionProcessor` to CTT: scans each replicated OCI image with syft and
injects SPDX-2.3 + CycloneDX-1.6 SBOMs as OCI referrer manifests and OCM resources
into the replicated component descriptors.

- `ctt/sbom_inject.py`: syft invocation, OCI referrer push, referrer cache lookup,
  resource-aware admission control (disk + memory headroom)
- `SbomInjectionProcessor` in `ctt/processors.py`
- `ctt/process_dependencies.py`: injection runs between Phase 1 (image upload) and
  Phase 2 (descriptor patching)
- `oci/sbom.py`: `push_sbom_referrers()` (batched, single subject-resolve);
  `build_sbom_ocm_resources()` extracted so `spdx_external.py` and CTT share it
- `oci/client.py`: fix `referrers()` null-manifests handling for non-OCI-1.1 registries
- integration test: synthetic 3-component OCM tree, full pipeline run, best-effort cleanup

**Release note**:
```feature developer
CTT: add `SbomInjectionProcessor` — configure it in the CTT processing config to
automatically scan replicated OCI images with syft and inject SPDX-2.3 + CycloneDX-1.6
SBOMs as OCI referrer manifests and OCM resources into replicated component descriptors.
```