### PR TITLE
workflows: add missing permissions blocks

### DIFF
--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -256,6 +256,7 @@ jobs:
   preprocess:
     environment: ${{ inputs.github-environment }}
     runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
+    permissions: {}
     outputs:
       args: ${{ steps.preprocess.outputs.args }}
       target-image-ref: ${{ steps.preprocess.outputs.target-image-ref }}

--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -217,6 +217,7 @@ jobs:
   repo-metadata:
     environment: ${{ inputs.github-environment }}
     runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
+    permissions: {}
     outputs:
       fork: ${{ steps.repo-metadata.outputs.fork }}
     steps:


### PR DESCRIPTION
Fixes two GHAS alerts (actions/missing-workflow-permissions):

- `oci-ocm.yaml` `preprocess` job: add `permissions: {}`
- `post-build.yaml` `repo-metadata` job: add `permissions: {}`

Both jobs are read-only and require no token permissions.