### PR TITLE
ocm: fix identity() version-fallback skipped when extraIdentity is set

### DIFF
--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -411,8 +411,8 @@ class Artifact(LabelMethodsMixin):
         returns the identity-object for this artifact (component-ref, resource, or source).
 
         Note that, the `version` attribute is implicitly added iff
-        there would otherwise be a conflict, iff this artifact only uses its `name` as
-        identity-attr (which is the default).
+        there would otherwise be a conflict among peers (i.e. two or more artifacts share
+        the same name and extraIdentity).
 
         In future versions of component-descriptor, this behaviour will be discontinued. It will
         instead be regarded as an error if the IDs of a given sequence of artifacts (declared by
@@ -439,9 +439,6 @@ class Artifact(LabelMethodsMixin):
         )
 
         if not peers:
-            return identity
-
-        if len(identity) > 1:  # special-case-handling not required if there are additional-id-attrs
             return identity
 
         # check whether there are collissions


### PR DESCRIPTION
## Summary

- `Artifact.identity()` had an early-return for resources with `extraIdentity` (`len(identity) > 1`), skipping the peer-collision check that auto-adds `version` when two artefacts share the same identity
- This caused false duplicate-resource validation errors for resources that share `name+extraIdentity` but differ in version (e.g. SBOM resources injected for multiple versions of `hyperkube`)
- Fix: remove the early-return so the version-fallback applies consistently regardless of whether `extraIdentity` is set