### PR TITLE
ctt: fix duplicate SBOM resource identity for same-named resources

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -931,13 +931,15 @@ def process_replication_plan_step(
                 spdx_referrer_digest=spdx_ref_digest,
                 cdx_referrer_digest=cdx_ref_digest,
                 tool_ver=tool_ver,
+                source_extra_identity=rre.source.extraIdentity or None,
             )
             sbom_extra_resources[rre.component_id].extend((spdx_res, cdx_res))
 
         # process cache misses (resource-aware scans)
         if misses and processing_mode is not ProcessingMode.DRY_RUN:
-            miss_items = [(rre.source.name, dref) for rre, dref in misses]
-            miss_map = {rre.source.name: (rre, dref) for rre, dref in misses}
+            # key by digest-ref string (unique per image) to avoid name collisions
+            miss_items = [(str(dref), dref) for rre, dref in misses]
+            miss_map = {str(dref): (rre, dref) for rre, dref in misses}
 
             scan_results = ctt.sbom_inject.run_injections_resource_aware(
                 items=miss_items,
@@ -945,10 +947,10 @@ def process_replication_plan_step(
                 tmpdir=tmpdir or '/tmp',  # nosec B108
                 tool_ver=syft_ver,
             )
-            for name, spdx_bytes, cdx_bytes, tool_ver, spdx_dig, cdx_dig, status in scan_results:
+            for key, spdx_bytes, cdx_bytes, tool_ver, spdx_dig, cdx_dig, status in scan_results:
                 if status != 'scanned':
                     continue
-                rre, dref = miss_map[name]
+                rre, dref = miss_map[key]
                 repo_ref = dref.ref_without_tag
                 source_digest = dref.tag
                 spdx_res, cdx_res = ctt.sbom_inject.build_sbom_ocm_resources(
@@ -960,6 +962,7 @@ def process_replication_plan_step(
                     spdx_referrer_digest=spdx_dig,
                     cdx_referrer_digest=cdx_dig,
                     tool_ver=tool_ver,
+                    source_extra_identity=rre.source.extraIdentity or None,
                 )
                 sbom_extra_resources[rre.component_id].extend((spdx_res, cdx_res))
 

--- a/ctt/sbom_inject.py
+++ b/ctt/sbom_inject.py
@@ -355,11 +355,15 @@ def build_sbom_ocm_resources(
     spdx_referrer_digest: str,
     cdx_referrer_digest: str,
     tool_ver: str | None,
+    source_extra_identity: dict | None = None,
 ) -> tuple[ocm.Resource, ocm.Resource]:
     '''
     Build (spdx_resource, cdx_resource) OCM Resource objects for CTT-injected SBOMs.
 
     Uses OciAccess pointing at the referrer manifest digest already pushed to the target.
+    `source_extra_identity` is merged into the SBOM resource's extraIdentity so that SBOM
+    resources derived from same-named source resources with different extraIdentity (e.g.
+    different platforms) remain distinguishable.
     '''
     def _make(media_type, sbom_format, referrer_digest):
         label_value = {
@@ -376,12 +380,13 @@ def build_sbom_ocm_resources(
         ]
         if label_value:
             labels.append(ocm.Label(name='gardener.cloud/sbom', value=label_value))
+        extra_id = {**(source_extra_identity or {}), 'sbom-format': sbom_format}
         return ocm.Resource(
             name=resource_name,
             version=version,
             type=media_type,
             relation=ocm.ResourceRelation.EXTERNAL,
-            extraIdentity={'sbom-format': sbom_format},
+            extraIdentity=extra_id,
             access=ocm.OciAccess(
                 imageReference=f'{repo_ref}@{referrer_digest}',
             ),

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ctt.process_dependencies as process_dependencies
+import ctt.sbom_inject as sbom_inject
+import ocm
 
 
 def test_processor_instantiation(tmpdir):
@@ -58,3 +60,72 @@ def test_processor_instantiation(tmpdir):
     cfg['upload'] = 'shared_u'
 
     _ = process_dependencies.processing_pipeline(cfg, shared_uploaders=shared_upld)
+
+
+def _fake_resource(name, version='1.0', extra_identity=None):
+    return ocm.Resource(
+        name=name,
+        version=version,
+        type='ociImage',
+        relation=ocm.ResourceRelation.EXTERNAL,
+        access=ocm.OciAccess(imageReference=f'registry.example.com/{name}:{version}'),
+        extraIdentity=extra_identity or {},
+    )
+
+
+def test_build_sbom_ocm_resources_distinct_identity_for_same_name():
+    '''
+    Two source resources sharing a name but different extraIdentity must produce
+    SBOM resources with distinct OCM identities.
+    '''
+    common_kwargs = dict(
+        version='1.0',
+        source_image_ref='registry.example.com/foo:1.0',
+        source_digest='sha256:aabbcc',
+        repo_ref='registry.example.com/foo',
+        spdx_referrer_digest='sha256:spdx1',
+        cdx_referrer_digest='sha256:cdx1',
+        tool_ver='1.0.0',
+    )
+
+    spdx_amd64, cdx_amd64 = sbom_inject.build_sbom_ocm_resources(
+        resource_name='hyperkube',
+        source_extra_identity={'arch': 'amd64'},
+        **common_kwargs,
+    )
+    spdx_arm64, cdx_arm64 = sbom_inject.build_sbom_ocm_resources(
+        resource_name='hyperkube',
+        source_extra_identity={'arch': 'arm64'},
+        **common_kwargs,
+    )
+
+    all_resources = [spdx_amd64, cdx_amd64, spdx_arm64, cdx_arm64]
+
+    # each resource must have a unique identity among its peers
+    identities = [r.identity(peers=all_resources) for r in all_resources]
+    assert len(set(map(str, identities))) == 4, (
+        f'expected 4 distinct identities, got: {identities}'
+    )
+
+    # arch must be present in extra_identity
+    assert spdx_amd64.extraIdentity.get('arch') == 'amd64'
+    assert spdx_arm64.extraIdentity.get('arch') == 'arm64'
+    assert spdx_amd64.extraIdentity.get('sbom-format') == 'spdx-2.3'
+    assert cdx_amd64.extraIdentity.get('sbom-format') == 'cyclonedx-1.6'
+
+
+def test_build_sbom_ocm_resources_no_source_extra_identity():
+    '''Without source_extra_identity the only distinguisher is sbom-format.'''
+    spdx, cdx = sbom_inject.build_sbom_ocm_resources(
+        resource_name='myimage',
+        version='2.0',
+        source_image_ref='registry.example.com/myimage:2.0',
+        source_digest='sha256:ddeeff',
+        repo_ref='registry.example.com/myimage',
+        spdx_referrer_digest='sha256:spdxref',
+        cdx_referrer_digest='sha256:cdxref',
+        tool_ver=None,
+    )
+    assert spdx.extraIdentity == {'sbom-format': 'spdx-2.3'}
+    assert cdx.extraIdentity == {'sbom-format': 'cyclonedx-1.6'}
+    assert spdx.identity(peers=[spdx, cdx]) != cdx.identity(peers=[spdx, cdx])


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Two bugs caused duplicate OCM resource identities during SBOM injection:

1. `build_sbom_ocm_resources` set `extraIdentity={'sbom-format': ...}` only, ignoring the source resource's own `extraIdentity`. Resources derived from same-named source resources that differ only in `extraIdentity` (e.g. different platforms) therefore produced identical SBOM resource identities.

2. `miss_map` in `process_replication_plan_step` was keyed by `rre.source.name` only, so multiple source resources sharing a name caused earlier entries to be silently clobbered.

**Fix:**
- `build_sbom_ocm_resources` accepts an optional `source_extra_identity` dict and merges it into the SBOM resource's `extraIdentity`.
- `miss_map` is now keyed by the unique digest-ref string instead of the resource name.
- Both call sites in `process_replication_plan_step` pass `source_extra_identity=rre.source.extraIdentity`.

**Release note**:
```bugfix operator
ctt: fix duplicate SBOM OCM resource identities when multiple source resources share the same name but differ in extraIdentity (e.g. platform) or when the miss-map clobbered same-named resources
```