### PR TITLE
ocm: identity() version-fallback must preserve extraIdentity

### DIFF
--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -129,3 +129,38 @@ def test_build_sbom_ocm_resources_no_source_extra_identity():
     assert spdx.extraIdentity == {'sbom-format': 'spdx-2.3'}
     assert cdx.extraIdentity == {'sbom-format': 'cyclonedx-1.6'}
     assert spdx.identity(peers=[spdx, cdx]) != cdx.identity(peers=[spdx, cdx])
+
+
+def test_build_sbom_ocm_resources_version_and_format_both_unique():
+    '''
+    Same name, different versions, no source extraIdentity: SPDX and CycloneDX
+    resources for the same source version must have distinct identities even
+    after the version-fallback fires (because other versions trigger it).
+
+    This is the scenario that caused the LSS release failure (run 6894333):
+    many hyperkube resources at different k8s versions produce SBOM resources
+    all named 'hyperkube' with extraIdentity={sbom-format: ...}.  The
+    version-fallback must preserve sbom-format so SPDX and CycloneDX at the
+    same version remain distinguishable.
+    '''
+    def _make(version):
+        return sbom_inject.build_sbom_ocm_resources(
+            resource_name='hyperkube',
+            version=version,
+            source_image_ref=f'registry.example.com/hyperkube:{version}',
+            source_digest='sha256:aabbcc',
+            repo_ref='registry.example.com/hyperkube',
+            spdx_referrer_digest='sha256:spdxref',
+            cdx_referrer_digest='sha256:cdxref',
+            tool_ver=None,
+        )
+
+    spdx_135, cdx_135 = _make('1.35.3')
+    spdx_133, cdx_133 = _make('1.33.8')
+
+    all_resources = [spdx_135, cdx_135, spdx_133, cdx_133]
+    identities = [r.identity(peers=all_resources) for r in all_resources]
+
+    assert len(set(map(str, identities))) == 4, (
+        f'expected 4 distinct identities, got duplicates: {[str(i) for i in identities]}'
+    )

--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -446,11 +446,14 @@ class Artifact(LabelMethodsMixin):
             if peer is self:
                 continue
             if peer.identity(peers=()) == identity:
-                # there is at least one collision (id est: another artifact w/ same name)
+                # there is at least one collision — add version as tiebreaker while
+                # preserving extraIdentity so resources with the same name+version but
+                # different extraIdentity (e.g. different SBOM formats) remain distinct.
                 # pylint: disable=E1101
-                return ArtifactIdentity(
+                return IdCtor(
                     name=self.name,
                     version=self.version,
+                    **(self.extraIdentity or {}),
                 )
         # there were no collisions
         return identity

--- a/ocm/validate.py
+++ b/ocm/validate.py
@@ -220,9 +220,12 @@ def iter_results_for_component_node(
             for idx, a in enumerate(artefacts):
                 aid = a.identity(artefacts)
                 if aid in seen_ids:
-                    duplicate_resources.append(
-                        f'{idx=}: {aid}'
+                    detail = (
+                        f'idx={idx}: {aid}'
+                        f' (name={a.name!r}, version={getattr(a, "version", "?")!r}'
+                        f', extraIdentity={getattr(a, "extraIdentity", None)!r})'
                     )
+                    duplicate_resources.append(detail)
                 else:
                     seen_ids.add(aid)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

The version-fallback in `Artifact.identity()` returned `ArtifactIdentity(name, version)`,
dropping `extraIdentity` entirely.  When multiple resources share the same name but differ
in both version *and* extraIdentity (e.g. SPDX and CycloneDX SBOM resources for multiple
hyperkube versions), the fallback would produce identical identities for the two formats
at the same version — a false duplicate.

**Fix:** use `IdCtor(name, version, **extraIdentity)` so the version-fallback identity
retains all original extra attributes alongside the version tiebreaker.

Also improves the duplicate-resource error message in `ocm/validate.py` to include
`name`, `version`, and `extraIdentity` per duplicate entry, making the root cause
immediately visible without having to reconstruct it from just the stringified identity.

**Release note**:
```bugfix operator
ocm: fix identity() version-fallback dropping extraIdentity, causing false duplicate-resource
validation errors when resources share name+extraIdentity-keys but differ in version
(e.g. SPDX and CycloneDX SBOM resources for multiple versions of the same image)
```