### PR TITLE
ocm: fix TypeError when extraIdentity contains 'version' in identity() version-fallback

### DIFF
--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -164,3 +164,21 @@ def test_build_sbom_ocm_resources_version_and_format_both_unique():
     assert len(set(map(str, identities))) == 4, (
         f'expected 4 distinct identities, got duplicates: {[str(i) for i in identities]}'
     )
+
+
+def test_identity_version_fallback_with_version_in_extra_identity():
+    '''
+    version-fallback must not raise TypeError when a resource already has
+    'version' in its extraIdentity (unusual but valid in the wild).
+    '''
+    r1 = _fake_resource('foo', version='1.0', extra_identity={'version': 'v2', 'arch': 'amd64'})
+    r2 = _fake_resource('foo', version='1.0', extra_identity={'version': 'v2', 'arch': 'arm64'})
+    # triggers version-fallback: same name+extraIdentity base among peers
+    r3 = _fake_resource('foo', version='2.0', extra_identity={'version': 'v2', 'arch': 'amd64'})
+
+    all_resources = [r1, r2, r3]
+    # must not raise
+    identities = [r.identity(peers=all_resources) for r in all_resources]
+    assert len(set(map(str, identities))) == 3, (
+        f'expected 3 distinct identities, got: {[str(i) for i in identities]}'
+    )

--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -449,11 +449,17 @@ class Artifact(LabelMethodsMixin):
                 # there is at least one collision — add version as tiebreaker while
                 # preserving extraIdentity so resources with the same name+version but
                 # different extraIdentity (e.g. different SBOM formats) remain distinct.
+                # Strip 'name'/'version' from extraIdentity to avoid duplicate-keyword errors
+                # if a resource happens to carry those keys there (unusual but valid).
                 # pylint: disable=E1101
+                extra = {
+                    k: v for k, v in (self.extraIdentity or {}).items()
+                    if k not in ('name', 'version')
+                }
                 return IdCtor(
                     name=self.name,
                     version=self.version,
-                    **(self.extraIdentity or {}),
+                    **extra,
                 )
         # there were no collisions
         return identity


### PR DESCRIPTION
## Summary

- `Artifact.identity()` version-fallback now strips `'name'` and `'version'` from `extraIdentity` before splatting into the `IdCtor` call
- Prevents `TypeError: got multiple values for keyword argument 'version'` for resources that carry `version` in their `extraIdentity` (triggered in LSS run 6896500)
- Regression test added

## Root cause

PR #1614 introduced `**(self.extraIdentity or {})` in the version-fallback path. If any resource has `'version'` as a key in `extraIdentity`, Python raises TypeError because `version` is passed both as an explicit kwarg and via the splat.

## Test plan

- [ ] `pytest ctt/test/process_deps_test.py::test_identity_version_fallback_with_version_in_extra_identity`
- [ ] LSS release run completes `replicate-and-sign` without TypeError