### PR TITLE
ctt/ocm: do not rely on version being implicitly added to identity

### DIFF
--- a/ctt/sbom_inject.py
+++ b/ctt/sbom_inject.py
@@ -380,7 +380,7 @@ def build_sbom_ocm_resources(
         ]
         if label_value:
             labels.append(ocm.Label(name='gardener.cloud/sbom', value=label_value))
-        extra_id = {**(source_extra_identity or {}), 'sbom-format': sbom_format}
+        extra_id = {**(source_extra_identity or {}), 'version': version, 'sbom-format': sbom_format}
         return ocm.Resource(
             name=resource_name,
             version=version,

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -126,8 +126,8 @@ def test_build_sbom_ocm_resources_no_source_extra_identity():
         cdx_referrer_digest='sha256:cdxref',
         tool_ver=None,
     )
-    assert spdx.extraIdentity == {'sbom-format': 'spdx-2.3'}
-    assert cdx.extraIdentity == {'sbom-format': 'cyclonedx-1.6'}
+    assert spdx.extraIdentity == {'version': '2.0', 'sbom-format': 'spdx-2.3'}
+    assert cdx.extraIdentity == {'version': '2.0', 'sbom-format': 'cyclonedx-1.6'}
     assert spdx.identity(peers=[spdx, cdx]) != cdx.identity(peers=[spdx, cdx])
 
 

--- a/oci/sbom.py
+++ b/oci/sbom.py
@@ -258,7 +258,7 @@ def build_sbom_ocm_resources(
             'version': version,
             'type': media_type,
             'relation': str(ocm.ResourceRelation.EXTERNAL),
-            'extraIdentity': {'sbom-format': sbom_format},
+            'extraIdentity': {'version': version, 'sbom-format': sbom_format},
             'access': {
                 'type': str(ocm.AccessType.LOCAL_BLOB),
                 'localReference': blob_digest,


### PR DESCRIPTION
Copy \`version\` explicitly into \`extraIdentity\` of SBOM resources (in both
\`ctt/sbom_inject.py\` and \`oci/sbom.py\`) so their OCM identity is unambiguous
without relying on the spec's implicit version-fallback disambiguation.

The \`version\` field on the toplevel resource remains (it is mandatory per spec);
this change merely mirrors it into \`extraIdentity\` so the full identity is
self-contained and not dependent on the peer-resource context required to trigger
the fallback.

**Release note**:
\`\`\`bugfix developer
ctt/ocm: SBOM resources now carry \`version\` explicitly in \`extraIdentity\`,
making their OCM identity unambiguous without relying on the spec's implicit
version-fallback disambiguation.
\`\`\`