### PR TITLE
refactor: extract top-level sbom package

### DIFF
--- a/.github/actions/merge-ocm-fragments/spdx_external.py
+++ b/.github/actions/merge-ocm-fragments/spdx_external.py
@@ -58,7 +58,7 @@ import yaml
 import oci.auth as oa
 import oci.client as oc
 import oci.model as om
-import oci.sbom as osbom
+import sbom.oci as osbom
 import ocm
 
 logger = logging.getLogger(__name__)

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -546,7 +546,7 @@ jobs:
           import oci.auth
           import oci.client
           import oci.model
-          import oci.sbom
+          import sbom.oci
 
           oci_client = oci.client.Client(
               credentials_lookup=oci.auth.docker_credentials_lookup(),
@@ -563,7 +563,7 @@ jobs:
           with open('sbom.cdx.json', 'rb') as f:
               cdx_bytes = f.read()
 
-          spdx_digest, cdx_digest = oci.sbom.push_sbom_referrers(
+          spdx_digest, cdx_digest = sbom.oci.push_sbom_referrers(
               spdx_bytes=spdx_bytes,
               cdx_bytes=cdx_bytes,
               image_reference=image_ref,

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -23,7 +23,7 @@ import yaml
 import cnudie.retrieve
 import ctt.oci_util
 import ctt.replicate
-import ctt.sbom_inject
+import sbom.inject as sbom_inject
 import oci
 import oci.client
 import oci.model as om
@@ -862,10 +862,10 @@ def process_replication_plan_step(
     ]
     if sbom_candidates:
         if processing_mode is not ProcessingMode.DRY_RUN:
-            ctt.sbom_inject.check_syft()
+            sbom_inject.check_syft()
 
         tmpdir = os.environ.get('TMPDIR') or os.environ.get('RUNNER_TEMP') or None
-        syft_ver = ctt.sbom_inject._syft_version()
+        syft_ver = sbom_inject._syft_version()
 
         # parallel referrer lookup
         def _lookup(rre):
@@ -899,7 +899,7 @@ def process_replication_plan_step(
             except Exception:  # nosec B110
                 pass  # keep the index digest ref; scan will fail gracefully
 
-            hit = ctt.sbom_inject.lookup_sbom_referrers(
+            hit = sbom_inject.lookup_sbom_referrers(
                 image_ref=digest_ref,
                 oci_client=oci_client,
             )
@@ -918,11 +918,11 @@ def process_replication_plan_step(
         # process cache hits
         for rre, dref, hit in hits:
             spdx_bytes, cdx_bytes, spdx_ref_digest, cdx_ref_digest = hit
-            tool_ver = ctt.sbom_inject._syft_version_from_spdx(spdx_bytes)
+            tool_ver = sbom_inject._syft_version_from_spdx(spdx_bytes)
             repo_ref = dref.ref_without_tag
             source_image_ref = str(rre.src_ref)
             source_digest = dref.tag  # sha256:<hex>
-            spdx_res, cdx_res = ctt.sbom_inject.build_sbom_ocm_resources(
+            spdx_res, cdx_res = sbom_inject.build_sbom_ocm_resources(
                 resource_name=rre.source.name,
                 version=rre.source.version,
                 source_image_ref=source_image_ref,
@@ -941,7 +941,7 @@ def process_replication_plan_step(
             miss_items = [(str(dref), dref) for rre, dref in misses]
             miss_map = {str(dref): (rre, dref) for rre, dref in misses}
 
-            scan_results = ctt.sbom_inject.run_injections_resource_aware(
+            scan_results = sbom_inject.run_injections_resource_aware(
                 items=miss_items,
                 oci_client=oci_client,
                 tmpdir=tmpdir or '/tmp',  # nosec B108
@@ -953,7 +953,7 @@ def process_replication_plan_step(
                 rre, dref = miss_map[key]
                 repo_ref = dref.ref_without_tag
                 source_digest = dref.tag
-                spdx_res, cdx_res = ctt.sbom_inject.build_sbom_ocm_resources(
+                spdx_res, cdx_res = sbom_inject.build_sbom_ocm_resources(
                     resource_name=rre.source.name,
                     version=rre.source.version,
                     source_image_ref=str(rre.src_ref),

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ctt.process_dependencies as process_dependencies
-import ctt.sbom_inject as sbom_inject
+import sbom.inject as sbom_inject
 import ocm
 
 

--- a/sbom/README.md
+++ b/sbom/README.md
@@ -1,0 +1,63 @@
+# SBOM Documents — Storage Convention
+
+SBOM documents are generated for every OCI image resource and stored in two ways:
+as **OCI referrer manifests** (primary, for direct OCI consumers) and as **OCM resources**
+(for consumers working through component descriptors).
+
+## OCI referrers
+
+Each image gets two referrer manifests stored in the same OCI repository, linked to the
+image by digest via the [OCI 1.1 referrers API][oci-referrers]:
+
+| Format | `artifactType` |
+|--------|----------------|
+| SPDX 2.3 | `application/spdx+json` |
+| CycloneDX 1.6 | `application/vnd.cyclonedx+json` |
+
+Retrieve with [`oras`][oras]:
+
+```sh
+oras discover --artifact-type application/spdx+json <image-ref>
+oras blob fetch <repo>@<referrer-digest> --output sbom.spdx.json
+```
+
+Or directly via the registry API:
+
+```
+GET /v2/<repo>/referrers/<digest>?artifactType=application%2Fspdx%2Bjson
+```
+
+The SBOM document is the single layer of the referrer manifest
+(`manifest.layers[0].digest`).
+
+The referrer manifest carries two annotations:
+- `org.opencontainers.image.created` — scan timestamp (ISO 8601)
+- `gardener.cloud/sbom/tool-version` — syft version used (if available)
+
+## OCM resources
+
+In OCM component descriptors the SBOM documents appear as additional resources alongside
+the image resource they describe.  Both share the image resource's `name` and `version`;
+the `extraIdentity` field distinguishes them:
+
+| Field | Value |
+|-------|-------|
+| `sbom-format` | `spdx-2.3` or `cyclonedx-1.6` |
+| `version` | same as the source image resource |
+| platform fields | `os`, `architecture` (present when the source image is platform-specific) |
+
+The resource `type` matches the SBOM media type above.
+
+Labels on each SBOM resource:
+
+| Label | Content |
+|-------|---------|
+| `gardener.cloud/sbom/source-image` | original image reference |
+| `gardener.cloud/sbom/source-image-digest` | digest of the scanned image manifest |
+| `gardener.cloud/sbom` | `{data-source: {tool, tool-version}, format}` |
+
+Access is either `localBlob` (SBOM inlined into the component descriptor blob store) or
+`ociRegistry` pointing at the referrer manifest digest.
+
+[oci-referrers]: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+[oras]: https://oras.land/

--- a/sbom/__init__.py
+++ b/sbom/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+SBOM (Software Bill of Materials) support for OCI images and OCM components.
+
+Sub-modules:
+  sbom.oci     — OCI 1.1 referrer push/lookup mechanics and media-type constants
+  sbom.inject  — syft-based scanning, resource-aware injection, OCM resource construction
+'''
+from sbom.oci import (  # noqa: F401
+    SPDX_JSON_MEDIA_TYPE,
+    CYCLONEDX_JSON_MEDIA_TYPE,
+    OCI_EMPTY_CONFIG_MEDIA_TYPE,
+    SBOM_FORMATS,
+    push_sbom_referrer,
+    push_sbom_referrers,
+)

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 '''
-SBOM injection for CTT replication.
+Syft-based SBOM scanning and injection for OCI images.
 
-For each replicated OCI image that has `inject_sboms=True`:
+For each image:
   1. Check the target registry for existing SPDX + CycloneDX referrer manifests.
   2. Cache hit: download both SBOM blobs from the target.
   3. Cache miss: run syft, push both referrer manifests to the target.
 
-Scan admission mirrors the resource-aware approach in spdx_external.py:
+Scan admission mirrors a resource-aware approach:
   disk:   compressed_layer_bytes * 5.0
   memory: 200 MiB + compressed_layer_bytes * 2.0
 Minimum headroom: 2 GiB disk, 1 GiB memory.  At least one scan is always admitted.
@@ -23,8 +23,8 @@ import tempfile
 
 import oci.client as oc
 import oci.model as om
-import oci.sbom as osbom
 import ocm
+import sbom.oci as soci
 
 _DOCKER_CONFIG_PATH = os.path.expanduser('~/.docker/config.json')
 
@@ -148,12 +148,12 @@ def lookup_sbom_referrers(
 
     spdx_referrers = oci_client.referrers(
         image_reference=image_ref,
-        artifact_type=osbom.SPDX_JSON_MEDIA_TYPE,
+        artifact_type=soci.SPDX_JSON_MEDIA_TYPE,
         absent_ok=True,
     )
     cdx_referrers = oci_client.referrers(
         image_reference=image_ref,
-        artifact_type=osbom.CYCLONEDX_JSON_MEDIA_TYPE,
+        artifact_type=soci.CYCLONEDX_JSON_MEDIA_TYPE,
         absent_ok=True,
     )
 
@@ -245,7 +245,7 @@ def scan_image(
 
     resolved_tool_ver = tool_ver or _syft_version_from_spdx(spdx_bytes)
 
-    spdx_referrer_digest, cdx_referrer_digest = osbom.push_sbom_referrers(
+    spdx_referrer_digest, cdx_referrer_digest = soci.push_sbom_referrers(
         spdx_bytes=spdx_bytes,
         cdx_bytes=cdx_bytes,
         image_reference=image_ref,
@@ -358,7 +358,7 @@ def build_sbom_ocm_resources(
     source_extra_identity: dict | None = None,
 ) -> tuple[ocm.Resource, ocm.Resource]:
     '''
-    Build (spdx_resource, cdx_resource) OCM Resource objects for CTT-injected SBOMs.
+    Build (spdx_resource, cdx_resource) OCM Resource objects for injected SBOMs.
 
     Uses OciAccess pointing at the referrer manifest digest already pushed to the target.
     `source_extra_identity` is merged into the SBOM resource's extraIdentity so that SBOM
@@ -394,6 +394,6 @@ def build_sbom_ocm_resources(
         )
 
     return (
-        _make(osbom.SPDX_JSON_MEDIA_TYPE,     'spdx-2.3',      spdx_referrer_digest),
-        _make(osbom.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_referrer_digest),
+        _make(soci.SPDX_JSON_MEDIA_TYPE,     'spdx-2.3',      spdx_referrer_digest),
+        _make(soci.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_referrer_digest),
     )

--- a/sbom/oci.py
+++ b/sbom/oci.py
@@ -1,10 +1,12 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 '''
-Utilities for pushing SBOM documents as OCI referrers (OCI 1.1) and building
-OCM resource descriptors for SBOM artefacts.
+OCI 1.1 referrer mechanics for SBOM documents.
 
-An SBOM is stored as a single-layer OCI manifest whose `subject` field points
-to the image it describes.  The referrer manifest is pushed by digest; registries
-that implement the OCI 1.1 referrers API expose it via GET /v2/<repo>/referrers/<digest>.
+An SBOM is stored as a single-layer OCI manifest whose `subject` field points to the image it
+describes.  The referrer manifest is pushed by digest; registries that implement the OCI 1.1
+referrers API expose it via GET /v2/<repo>/referrers/<digest>.
 '''
 import hashlib
 import json
@@ -241,8 +243,8 @@ def build_sbom_ocm_resources(
     '''
     Build (spdx_resource, cdx_resource) OCM resource dicts for one scanned image.
 
-    Both resources use the source image's resource name with extraIdentity.sbom-format
-    to distinguish them, matching the convention established in the upstream pipeline.
+    Resources use localBlob access (SBOM inlined into the component descriptor blob store).
+    Both share the source image's resource name; extraIdentity.sbom-format distinguishes them.
     '''
     def _make(media_type, sbom_format, blob_digest, sbom_bytes):
         label_value = {


### PR DESCRIPTION
## Summary

- Move `oci/sbom.py` → `sbom/oci.py` (OCI 1.1 referrer mechanics, media-type constants)
- Move `ctt/sbom_inject.py` → `sbom/inject.py` (syft scanning, resource-aware admission, OCM resource construction)
- Add `sbom/__init__.py` re-exporting the push surface
- Add `sbom/README.md` with consumer-facing storage-convention documentation
- Update all callers (`ctt/process_dependencies`, `ctt/test`, `spdx_external.py`, `oci-ocm.yaml`)