### PR TITLE
sbom: add iter module (SbomMapping, iter_sboms, fetch_sbom_document)

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -1039,7 +1039,7 @@ class Client:
         image_reference: str | om.OciImageReference,
         artifact_type: str | None = None,
         absent_ok: bool = False,
-    ) -> tuple[dict, ...] | None:
+    ) -> tuple[om.OciReferrer, ...] | None:
         '''
         Return referrer descriptors for the given image (OCI 1.1 referrers API).
 
@@ -1048,7 +1048,7 @@ class Client:
 
         Returns None if the registry returns 404 (referrers API not supported) and
         `absent_ok` is True; an empty tuple if the index exists but has no matching entries;
-        otherwise a tuple of referrer descriptor dicts.
+        otherwise a tuple of OciReferrer descriptors.
 
         Raises HTTPError on 404 when `absent_ok` is False.
         '''
@@ -1079,7 +1079,14 @@ class Client:
             res.raise_for_status()
 
         res.raise_for_status()
-        return tuple(res.json().get('manifests') or ())
+        return tuple(
+            om.OciReferrer(
+                digest=entry['digest'],
+                artifact_type=entry.get('artifactType', ''),
+                annotations=entry.get('annotations', {}),
+            )
+            for entry in (res.json().get('manifests') or ())
+        )
 
     @initialise_repository_if_required
     def put_manifest(

--- a/oci/model.py
+++ b/oci/model.py
@@ -491,12 +491,7 @@ class OciImageManifestList:
 
 @dataclasses.dataclass(frozen=True)
 class OciReferrer:
-    '''
-    Descriptor of an OCI referrer manifest as returned by the OCI 1.1 referrers API.
-
-    Represents any artefact that declares a `subject` pointing at a given image digest —
-    not limited to SBOMs (signatures, attestations, etc. are also referrers).
-    '''
+    '''Descriptor of an OCI referrer manifest as returned by the OCI 1.1 referrers API.'''
     digest: str           # sha256:<hex> of the referrer manifest
     artifact_type: str    # artifactType field of the referrer manifest
     annotations: dict     # annotations from the referrer manifest

--- a/oci/model.py
+++ b/oci/model.py
@@ -489,6 +489,19 @@ class OciImageManifestList:
         return raw
 
 
+@dataclasses.dataclass(frozen=True)
+class OciReferrer:
+    '''
+    Descriptor of an OCI referrer manifest as returned by the OCI 1.1 referrers API.
+
+    Represents any artefact that declares a `subject` pointing at a given image digest —
+    not limited to SBOMs (signatures, attestations, etc. are also referrers).
+    '''
+    digest: str           # sha256:<hex> of the referrer manifest
+    artifact_type: str    # artifactType field of the referrer manifest
+    annotations: dict     # annotations from the referrer manifest
+
+
 def as_manifest(
     manifest: str | bytes | dict | OciImageManifest | OciImageManifestList,
     media_type: str=None,

--- a/sbom/__init__.py
+++ b/sbom/__init__.py
@@ -7,6 +7,7 @@ SBOM (Software Bill of Materials) support for OCI images and OCM components.
 Sub-modules:
   sbom.oci     — OCI 1.1 referrer push/lookup mechanics and media-type constants
   sbom.inject  — syft-based scanning, resource-aware injection, OCM resource construction
+  sbom.iter    — iterate and retrieve SBOM documents across OCM component trees
 '''
 from sbom.oci import (  # noqa: F401
     SPDX_JSON_MEDIA_TYPE,
@@ -15,4 +16,11 @@ from sbom.oci import (  # noqa: F401
     SBOM_FORMATS,
     push_sbom_referrer,
     push_sbom_referrers,
+)
+from sbom.iter import (  # noqa: F401
+    SbomSource,
+    SbomMapping,
+    iter_sboms_for_resource,
+    iter_sboms,
+    fetch_sbom_document,
 )

--- a/sbom/__main__.py
+++ b/sbom/__main__.py
@@ -98,8 +98,18 @@ def _fetch_sboms(parsed):
 
     format_prefixes: list[str] = parsed.sbom_formats
 
-    lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(parsed.ocm_repository),
+    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(parsed.ocm_repository)
+    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+        lookups=(
+            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+            ),
+            cnudie.retrieve.oci_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+                oci_client=oci_client,
+            ),
+        ),
+        ocm_repository_lookup=ocm_repo_lookup,
     )
 
     root_component = lookup(

--- a/sbom/__main__.py
+++ b/sbom/__main__.py
@@ -118,6 +118,7 @@ def _fetch_sboms(parsed):
 
     written = 0
     missing = 0
+    errors = 0
 
     for node in ocm_iter.iter_resources(component=root_component, lookup=lookup):
         component = node.component
@@ -147,7 +148,11 @@ def _fetch_sboms(parsed):
             try:
                 doc_bytes = si.fetch_sbom_document(mapping, oci_client)
             except Exception as e:
-                print(f'warning: failed to fetch SBOM for {resource.name!r} ({fmt_id}): {e}')
+                print(
+                    f'error: failed to fetch SBOM for {resource.name!r} ({fmt_id}): {e}',
+                    file=sys.stderr,
+                )
+                errors += 1
                 continue
             with open(outpath, 'wb') as f:
                 f.write(doc_bytes)
@@ -164,10 +169,15 @@ def _fetch_sboms(parsed):
                 )
                 missing += 1
 
+    parts = [f'{written} written']
     if missing:
-        print(f'{written} SBOM(s) written, {missing} missing.', file=sys.stderr)
+        parts.append(f'{missing} missing')
+    if errors:
+        parts.append(f'{errors} fetch error(s)')
+    print(', '.join(parts) + '.', file=sys.stderr)
+
+    if errors:
         sys.exit(1)
-    print(f'{written} SBOM(s) written.', file=sys.stderr)
 
 
 def main():

--- a/sbom/__main__.py
+++ b/sbom/__main__.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import os
+import sys
+
+import cnudie.retrieve
+import oci.auth
+import oci.client
+import ocm
+import ocm.iter as ocm_iter
+import sbom.iter as si
+import sbom.oci as soci
+
+
+def _oci_client(parsed) -> oci.client.Client:
+    docker_cfg = parsed.docker_cfg
+    if docker_cfg and not os.path.exists(docker_cfg):
+        print(f'Error: not an existing file: {docker_cfg=}')
+        sys.exit(1)
+
+    if not docker_cfg:
+        for candidate in (
+            os.path.expandvars('$HOME/.docker/config.json'),
+            '/docker-cfg.json',
+        ):
+            if os.path.exists(candidate):
+                docker_cfg = candidate
+                break
+
+    return oci.client.Client(
+        credentials_lookup=oci.auth.docker_credentials_lookup(
+            docker_cfg=docker_cfg,
+            absent_ok=True,
+        ),
+    )
+
+
+def _mangle(name: str) -> str:
+    return name.replace('/', '_')
+
+
+def _sbom_format_id(mapping: si.SbomMapping) -> str | None:
+    '''Derive the sbom format identifier (e.g. "spdx-2.3") from a SbomMapping.'''
+    if mapping.source is si.SbomSource.OCM:
+        return (mapping.sbom.extraIdentity or {}).get('sbom-format')
+    # OCI_REFERRER: reverse-map artifact_type -> format_id via SBOM_FORMATS
+    for fmt_id, media_type in soci.SBOM_FORMATS:
+        if mapping.sbom.artifact_type == media_type:
+            return fmt_id
+    return None
+
+
+def _sbom_filename(
+    component: ocm.Component,
+    resource: ocm.Resource,
+    format_id: str,
+) -> str:
+    '''
+    Build the output filename for one SBOM document.
+
+    Convention:
+      {component-name:version}_{resource-name:version}[-extra-val…].sbom.{format-id}
+
+    Extra-identity values are taken from the payload resource (not the SBOM artefact),
+    excluding 'sbom-format' and 'version', sorted by key for stability, joined with '-'.
+    Name components have '/' replaced with '_'.
+    '''
+    extra_vals = [
+        v for k, v in sorted((resource.extraIdentity or {}).items())
+        if k not in ('sbom-format', 'version')
+    ]
+    extra_suffix = ('-' + '-'.join(extra_vals)) if extra_vals else ''
+    return (
+        f'{_mangle(component.name)}:{component.version}'
+        f'_{_mangle(resource.name)}:{resource.version}'
+        f'{extra_suffix}'
+        f'.sbom.{format_id}'
+    )
+
+
+def _fetch_sboms(parsed):
+    oci_client = _oci_client(parsed)
+
+    component_ref = parsed.component
+    try:
+        name, version = component_ref.rsplit(':', 1)
+    except ValueError:
+        print(f'Error: component must be in name:version format, got {component_ref!r}')
+        sys.exit(1)
+
+    outdir = parsed.outdir
+    if not os.path.isdir(outdir):
+        print(f'Error: not an existing directory: {outdir!r}')
+        sys.exit(1)
+
+    format_prefixes: list[str] = parsed.sbom_formats
+
+    lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(parsed.ocm_repository),
+    )
+
+    root_component = lookup(
+        ocm.ComponentIdentity(name=name, version=version),
+    ).component
+
+    written = 0
+    missing = 0
+
+    for node in ocm_iter.iter_resources(component=root_component, lookup=lookup):
+        component = node.component
+        resource = node.resource
+
+        # for each resource, collect one mapping per format-prefix (lazy)
+        found: dict[str, si.SbomMapping] = {}  # prefix -> mapping
+
+        for mapping in si.iter_sboms_for_resource(
+            resource=resource,
+            component=component,
+            oci_client=oci_client,
+        ):
+            fmt_id = _sbom_format_id(mapping)
+            if fmt_id is None:
+                continue
+            for prefix in format_prefixes:
+                if prefix not in found and fmt_id.startswith(prefix):
+                    found[prefix] = mapping
+            if len(found) == len(format_prefixes):
+                break  # all formats satisfied — skip remaining (OCI referrer calls avoided)
+
+        for prefix, mapping in found.items():
+            fmt_id = _sbom_format_id(mapping)
+            filename = _sbom_filename(component, resource, fmt_id)
+            outpath = os.path.join(outdir, filename)
+            try:
+                doc_bytes = si.fetch_sbom_document(mapping, oci_client)
+            except Exception as e:
+                print(f'warning: failed to fetch SBOM for {resource.name!r} ({fmt_id}): {e}')
+                continue
+            with open(outpath, 'wb') as f:
+                f.write(doc_bytes)
+            print(outpath)
+            written += 1
+
+        for prefix in format_prefixes:
+            if prefix not in found:
+                print(
+                    f'warning: no {prefix!r} SBOM found for '
+                    f'{component.name}:{component.version} '
+                    f'/ {resource.name}:{resource.version}',
+                    file=sys.stderr,
+                )
+                missing += 1
+
+    if missing:
+        print(f'{written} SBOM(s) written, {missing} missing.', file=sys.stderr)
+        sys.exit(1)
+    print(f'{written} SBOM(s) written.', file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fetch SBOM documents for all resources in an OCM component tree.',
+    )
+    parser.add_argument(
+        '--docker-cfg',
+        default=None,
+        help='path to docker config.json for OCI registry auth (default: ~/.docker/config.json)',
+    )
+    parser.add_argument(
+        '--ocm-repository',
+        required=True,
+        help='OCM repository base URL (e.g. europe-docker.pkg.dev/gardener-project/releases)',
+    )
+    parser.add_argument(
+        'component',
+        help='root component in name:version format',
+    )
+    parser.add_argument(
+        '--outdir',
+        default='.',
+        help='directory to write SBOM files into (default: current directory)',
+    )
+    parser.add_argument(
+        '--sbom-formats',
+        nargs='+',
+        default=['spdx', 'cyclonedx'],
+        metavar='FORMAT',
+        help=(
+            'SBOM format prefixes to retrieve per resource. '
+            'Use exact version (e.g. spdx-2.3) or prefix (e.g. spdx) to match any version. '
+            'Default: spdx cyclonedx'
+        ),
+    )
+
+    parsed = parser.parse_args()
+    _fetch_sboms(parsed)
+
+
+if __name__ == '__main__':
+    main()

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -165,8 +165,8 @@ def lookup_sbom_referrers(
     cdx_descriptor = cdx_referrers[0]
 
     try:
-        spdx_manifest_digest = spdx_descriptor['digest']
-        cdx_manifest_digest = cdx_descriptor['digest']
+        spdx_manifest_digest = spdx_descriptor.digest
+        cdx_manifest_digest = cdx_descriptor.digest
 
         def _download_sbom_blob(manifest_digest: str) -> bytes:
             manifest_bytes = oci_client.manifest_raw(

--- a/sbom/iter.py
+++ b/sbom/iter.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Iteration and retrieval utilities for SBOM documents attached to OCM resources.
+
+Yield order — callers may use early-exit to avoid OCI I/O:
+  1. SbomSource.OCM      — matched from the component descriptor in-memory; no network I/O.
+  2. SbomSource.OCI_REFERRER — queried live from the OCI referrers API; only emitted when
+                               `oci_client` is provided and the resource is OCI-addressable.
+'''
+import collections.abc
+import dataclasses
+import enum
+import logging
+
+import oci.client as oc
+import oci.model as om
+import ocm
+import ocm.iter as ocm_iter
+import sbom.oci as soci
+
+logger = logging.getLogger(__name__)
+
+
+class SbomSource(enum.StrEnum):
+    OCM          = 'ocm'
+    OCI_REFERRER = 'oci-referrer'
+
+
+@dataclasses.dataclass
+class SbomMapping:
+    '''
+    Associates one SBOM artefact with the payload resource it describes.
+
+    `source` indicates how the SBOM was discovered:
+      OCM          — `sbom` is an ocm.Resource from the component descriptor.
+      OCI_REFERRER — `sbom` is an OciReferrer descriptor from the referrers API.
+
+    `component` is included so callers can resolve LocalBlobAccess references back to
+    the correct OCI repository (via component.current_ocm_repo).
+    '''
+    source:    SbomSource
+    component: ocm.Component
+    resource:  ocm.Resource           # payload resource the SBOM describes
+    sbom:      ocm.Resource | om.OciReferrer
+
+
+_SBOM_MEDIA_TYPES = frozenset(mt for _, mt in soci.SBOM_FORMATS)
+
+
+def _is_sbom_resource(resource: ocm.Resource) -> bool:
+    return resource.type in _SBOM_MEDIA_TYPES
+
+
+def _oci_ref_for_resource(resource: ocm.Resource) -> str | None:
+    '''Return the OCI image reference for a resource, or None if not OCI-addressable.'''
+    access = resource.access
+    if isinstance(access, ocm.OciAccess):
+        return access.imageReference
+    return None
+
+
+def iter_sboms_for_resource(
+    resource: ocm.Resource,
+    component: ocm.Component,
+    oci_client: oc.Client | None = None,
+    ignore_unsupported: bool = True,
+) -> collections.abc.Generator['SbomMapping', None, None]:
+    '''
+    Yield SbomMapping entries for all SBOM artefacts associated with the given resource.
+
+    Yield order (see module docstring):
+      1. OCM-registered SBOM resources (no I/O).
+      2. OCI referrer manifests (requires oci_client; skipped otherwise).
+
+    @param resource:           the payload resource to find SBOMs for
+    @param component:          the component containing the resource (needed to resolve
+                               LocalBlobAccess refs and for OCI repo derivation)
+    @param oci_client:         if provided, also query the OCI referrers API
+    @param ignore_unsupported: if True, silently skip resources whose access type cannot
+                               be resolved to an OCI reference (relevant for OCI_REFERRER
+                               path); if False, raise ValueError instead
+    '''
+    # --- phase 1: OCM resources from the component descriptor (in-memory, no I/O) ---
+    resource_name = resource.name
+    # SBOM resources share name (and non-sbom extraIdentity keys) with their source resource
+    source_extra = {
+        k: v for k, v in (resource.extraIdentity or {}).items()
+        if k not in ('sbom-format', 'version')
+    }
+    for candidate in component.resources:
+        if not _is_sbom_resource(candidate):
+            continue
+        if candidate.name != resource_name:
+            continue
+        # platform keys from source must be present in candidate extraIdentity
+        candidate_extra = candidate.extraIdentity or {}
+        if any(candidate_extra.get(k) != v for k, v in source_extra.items()):
+            continue
+        yield SbomMapping(
+            source=SbomSource.OCM,
+            component=component,
+            resource=resource,
+            sbom=candidate,
+        )
+
+    # --- phase 2: OCI referrers (live I/O) ---
+    if oci_client is None:
+        return
+
+    image_ref = _oci_ref_for_resource(resource)
+    if image_ref is None:
+        if not ignore_unsupported:
+            raise ValueError(
+                f'resource {resource.name!r} access type {type(resource.access).__name__!r} '
+                'cannot be resolved to an OCI reference; '
+                'pass ignore_unsupported=True to skip silently'
+            )
+        return
+
+    for _, media_type in soci.SBOM_FORMATS:
+        referrers = oci_client.referrers(
+            image_reference=image_ref,
+            artifact_type=media_type,
+            absent_ok=True,
+        )
+        if not referrers:
+            continue
+        for ref in referrers:
+            yield SbomMapping(
+                source=SbomSource.OCI_REFERRER,
+                component=component,
+                resource=resource,
+                sbom=om.OciReferrer(
+                    digest=ref['digest'],
+                    artifact_type=ref.get('artifactType', media_type),
+                    annotations=ref.get('annotations', {}),
+                ),
+            )
+
+
+def iter_sboms(
+    component: ocm.Component | ocm.ComponentDescriptor,
+    lookup: ocm.ComponentDescriptorLookup,
+    oci_client: oc.Client | None = None,
+    ignore_unsupported: bool = True,
+    **kwargs,
+) -> collections.abc.Generator['SbomMapping', None, None]:
+    '''
+    Yield SbomMapping entries for all resources in the transitive component tree.
+
+    Iterates the full component tree via ocm.iter.iter_resources and calls
+    iter_sboms_for_resource for each resource node.  All kwargs are forwarded
+    to ocm.iter.iter_resources (e.g. recursion_depth, component_filter).
+
+    Yield order within each resource follows iter_sboms_for_resource (OCM first,
+    then OCI referrers).
+    '''
+    for node in ocm_iter.iter_resources(component, lookup, **kwargs):
+        yield from iter_sboms_for_resource(
+            resource=node.resource,
+            component=node.component,
+            oci_client=oci_client,
+            ignore_unsupported=ignore_unsupported,
+        )
+
+
+def fetch_sbom_document(
+    mapping: 'SbomMapping',
+    oci_client: oc.Client,
+) -> bytes:
+    '''
+    Fetch and return the raw SBOM document bytes for the given SbomMapping.
+
+    Delegates to the appropriate retrieval path based on mapping.source:
+
+      OCM / OciAccess:
+        The sbom resource's imageReference points at a referrer manifest digest.
+        Fetch the manifest, then retrieve layer[0] blob.
+
+      OCM / LocalBlobAccess:
+        The sbom resource's localReference is a blob digest stored in the component's
+        OCI repository (derived from component.current_ocm_repo).
+        Fetch the blob directly.
+
+      OCI_REFERRER:
+        The OciReferrer.digest identifies the referrer manifest.
+        Fetch the manifest from the payload resource's repository, then retrieve layer[0].
+    '''
+    sbom = mapping.sbom
+
+    if mapping.source is SbomSource.OCM:
+        access = sbom.access
+        if isinstance(access, ocm.OciAccess):
+            return _fetch_blob_from_referrer_manifest(
+                repo_and_digest=access.imageReference,
+                oci_client=oci_client,
+            )
+        if isinstance(access, ocm.LocalBlobAccess):
+            repo = mapping.component.current_ocm_repo.component_oci_ref(mapping.component)
+            return oci_client.blob(
+                image_reference=repo,
+                digest=access.localReference,
+            ).content
+        raise ValueError(
+            f'unsupported access type for SBOM fetch: {type(access).__name__!r}'
+        )
+
+    # SbomSource.OCI_REFERRER
+    image_ref = _oci_ref_for_resource(mapping.resource)
+    if image_ref is None:
+        raise ValueError(
+            f'cannot fetch OCI referrer SBOM: resource {mapping.resource.name!r} '
+            'has no OCI-addressable access'
+        )
+    repo = om.OciImageReference.to_image_ref(image_ref).ref_without_tag
+    return _fetch_blob_from_referrer_manifest(
+        repo_and_digest=f'{repo}@{sbom.digest}',
+        oci_client=oci_client,
+    )
+
+
+def _fetch_blob_from_referrer_manifest(
+    repo_and_digest: str,
+    oci_client: oc.Client,
+) -> bytes:
+    '''Fetch a referrer manifest by digest and return its single layer blob.'''
+    import json
+    manifest_bytes = oci_client.manifest_raw(repo_and_digest).content
+    manifest = json.loads(manifest_bytes)
+    blob_digest = manifest['layers'][0]['digest']
+    repo = om.OciImageReference.to_image_ref(repo_and_digest).ref_without_tag
+    return oci_client.blob(
+        image_reference=repo,
+        digest=blob_digest,
+    ).content

--- a/sbom/iter.py
+++ b/sbom/iter.py
@@ -132,11 +132,7 @@ def iter_sboms_for_resource(
                 source=SbomSource.OCI_REFERRER,
                 component=component,
                 resource=resource,
-                sbom=om.OciReferrer(
-                    digest=ref['digest'],
-                    artifact_type=ref.get('artifactType', media_type),
-                    annotations=ref.get('annotations', {}),
-                ),
+                sbom=ref,
             )
 
 


### PR DESCRIPTION
## Summary

- Add `oci.model.OciReferrer` — typed descriptor for OCI 1.1 referrer manifests
- Add `sbom/iter.py`:
  - `SbomSource` enum (`ocm`, `oci-referrer`)
  - `SbomMapping(source, component, resource, sbom)` — pairs a payload resource with one SBOM artefact; includes `component` for resolving `LocalBlobAccess` refs via `component.current_ocm_repo`
  - `iter_sboms_for_resource` — OCM-registered SBOMs first (in-memory, no I/O), OCI referrers second (lazy, requires `oci_client`); `ignore_unsupported` controls behaviour for non-OCI-addressable resources
  - `iter_sboms` — tree-level wrapper over `ocm.iter.iter_resources`
  - `fetch_sbom_document` — retrieves raw SBOM bytes on demand, delegating to the correct path per source/access type

**Release note**:
```feature developer
sbom: add `iter_sboms` / `iter_sboms_for_resource` to enumerate SBOM artefacts across
an OCM component tree. Yields `SbomMapping` records pairing each payload resource with
its discovered SBOMs — OCM-registered ones first (no I/O), then OCI referrers on demand
(requires an `oci_client`). Use `fetch_sbom_document(mapping, oci_client)` to retrieve
the raw SBOM bytes lazily.
```