### PR TITLE
set delay to be min backoff_base and not 1

### DIFF
--- a/.github/actions/github-auth/get-token.py
+++ b/.github/actions/github-auth/get-token.py
@@ -68,7 +68,7 @@ def _open_with_retry(
                     file=sys.stderr,
                 )
                 sys.exit(1)
-            delay = min(backoff_base ** attempt, backoff_cap)
+            delay = min(backoff_base ** (attempt+1), backoff_cap)
             print(
                 f'WARNING: HTTP {e.code} from {url}, '
                 f'retrying in {delay:.0f}s ({attempt + 1}/{retries})...',
@@ -79,7 +79,7 @@ def _open_with_retry(
             if attempt == retries:
                 print(f'ERROR: Request to {url} failed: {e.reason}', file=sys.stderr)
                 sys.exit(1)
-            delay = min(backoff_base ** attempt, backoff_cap)
+            delay = min(backoff_base ** (attempt+1), backoff_cap)
             print(
                 f'WARNING: Request to {url} failed: {e.reason}, '
                 f'retrying in {delay:.0f}s ({attempt + 1}/{retries})...',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
I saw that we are retrying on timeout issues after 1sec when retry is set to 1. 
Its because `backoff_base ** attempt = 1` on the zeroth attempt 

I think its best to wait a bit longer than 1sec. 
We can either set this to be backoff_base= 3 sec which is a tiny bit better but maybe increasing the wait-period when we retry so little would make sense (like 10 sec)


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
