### PR TITLE
release: upgrade slackapi/slack-github-action v2 -> v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -470,7 +470,7 @@ jobs:
           OEOF
       - name: publish-release-notes-to-slack
         if: ${{ inputs.slack-channel-id != '' }}
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           method: files.uploadV2
           token: ${{ secrets.slack-token || secrets.SLACK_APP_TOKEN_GARDENER_CICD }}


### PR DESCRIPTION
**Release note**:
```other operator
Upgrade `slackapi/slack-github-action` from `v2` to `v3` in the release workflow.
v3 targets Node.js 24 (v2 targeted Node.js 20, which is deprecated on GitHub-hosted runners).
No input changes — `method`, `token`, and `payload` are fully compatible.
```