### PR TITLE
sbom-upload: fix wrong input name systems->scopes

### DIFF
--- a/.github/workflows/sbom-upload.yaml
+++ b/.github/workflows/sbom-upload.yaml
@@ -86,7 +86,7 @@ jobs:
           oidc-audience: ${{ inputs.token-exchange-audience }}
           pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
           pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
-          systems: ${{ inputs.token-exchange-scope }}
+          scopes: ${{ inputs.token-exchange-scope }}
           token-env-prefix: 'GCS_'
         # exports GCS_<SCOPE_UPPER>_TOKEN into $GITHUB_ENV
 


### PR DESCRIPTION
**Release note**:
```bugfix operator
Fix `sbom-upload` reusable workflow passing wrong input name `systems` (should be `scopes`) to the `oidc-gcp-token-exchange` action, causing GCS tokens to never be fetched and SBOM uploads to fail.
```