### PR TITLE
merge-ocm-fragments: fix extract step to filter by *.ocm-artefacts.tar.gz

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -188,20 +188,11 @@ runs:
         set -eu
         cd "${{ inputs.outdir }}"
 
-        # workaround: download-artifact@v3 does not allow merging. hence, flatten directories
-        for d in $(find -type d); do
-          if [ "$d" == "." ]; then
-            continue
-          fi
-          echo "debug: sub-directory $d contains:"
-          ls $d
-          mv $d/* .
-        done
-
-        echo "extracting files with pattern *.tar.gz"
-        for tf in $(find -name "*.tar.gz"); do
-          tf=$(basename $tf)
-          echo "extracting ${tf} into $PWD"
+        # download-artifact@v3 (used on GHE) ignores `pattern`, so non-OCM artifacts may land
+        # here too; filter by naming convention to avoid processing unrelated files/directories
+        echo "extracting ocm-fragment archives"
+        for tf in $(find . -name "*.ocm-artefacts.tar.gz"); do
+          echo "extracting ${tf}"
           tar xf "${tf}"
           unlink "${tf}"
         done


### PR DESCRIPTION
Supersedes / replaces #1597.

## Problem

`download-artifact@v3` (used on GHE, where v4+ is unsupported) ignores the `pattern` input, so
all workflow artifacts land in `outdir` — not just `*.ocm-artefacts` ones. The existing flatten
loop then fails on artifacts containing nested directories.

## Fix

Drop the two-phase flatten-then-extract loop entirely. Instead, use `find . -name "*.ocm-artefacts.tar.gz"` which:

- recurses into per-artifact subdirectories naturally (no flattening needed)
- ignores non-OCM artifacts by matching the exact filename convention used by `export-ocm-fragments`

The naming convention (`<hexdigest>.ocm-artefacts.tar.gz`) is already the agreed filtering
approach from the discussion in #1597.