### PR TITLE
merge-ocm-fragments: fix tar conflict when extracting into pre-existing subdir

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -189,12 +189,17 @@ runs:
         cd "${{ inputs.outdir }}"
 
         # download-artifact@v3 (used on GHE) ignores `pattern`, so non-OCM artifacts may land
-        # here too; filter by naming convention to avoid processing unrelated files/directories
+        # here too; filter by naming convention to avoid processing unrelated files/directories.
+        # extract into the subdir where the tarball lives (avoids conflicts with the subdir name
+        # itself), then move extracted files up to outdir.
         echo "extracting ocm-fragment archives"
         for tf in $(find . -name "*.ocm-artefacts.tar.gz"); do
           echo "extracting ${tf}"
-          tar xf "${tf}"
+          subdir=$(dirname "${tf}")
+          tar xf "${tf}" -C "${subdir}"
           unlink "${tf}"
+          # move extracted contents up to outdir; subdir itself stays (and is harmless)
+          find "${subdir}" -maxdepth 1 -mindepth 1 -exec mv -t . {} +
         done
     - name: merge-fragments
       id: merge


### PR DESCRIPTION
## Summary

- `download-artifact@v3` places each artifact into a subdirectory named after the artifact
- the tarball contains a file of the same name → `tar xf` into `outdir` fails with `Cannot open: File exists`
- fix: extract into the artifact's own subdir, then move contents up to `outdir`

## Test plan

- [ ] trigger a workflow using `merge-ocm-fragments` and confirm the extract step succeeds
- [ ] confirm `merge-fragments` step still picks up all `.ocm-artefacts` files correctly