### PR TITLE
pullrequest: fix race between checkout and tmp-branch creation

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -330,7 +330,6 @@ def create_upgrade_pullrequest(
         repository=repository,
         git_helper=git_helper,
         commit_message=commit_message,
-        target_branch=branch,
         delete_on_exit=auto_merge,
     ) as upgrade_branch_name:
         pull_request = repository.create_pull(

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -417,7 +417,6 @@ def commit_and_push_to_tmp_branch(
     repository: github3.repos.repo.Repository,
     git_helper: gitutil.GitHelper,
     commit_message: str,
-    target_branch: str,
     delete_on_exit: bool=False,
 ):
     '''
@@ -429,7 +428,11 @@ def commit_and_push_to_tmp_branch(
     commit = git_helper.index_to_commit(message=commit_message)
     logger.info(f'commit for upgrade-PR: {commit.hexsha=}')
     new_branch_name = ci.util.random_str(prefix='ci-', length=12)
-    head_sha = repository.ref(f'heads/{target_branch}').object.sha
+    # use the local commit's parent rather than a live API call to heads/{target_branch}:
+    # if master advances between checkout and here (e.g. during a long set_dependency_version
+    # callback), the API would return a newer SHA that is not an ancestor of our local commit,
+    # making the push a non-fast-forward → rejected.
+    head_sha = commit.parents[0].hexsha
     repository.create_ref(f'refs/heads/{new_branch_name}', head_sha)
 
     try:


### PR DESCRIPTION
## Problem

`commit_and_push_to_tmp_branch` called `repository.ref(f'heads/{target_branch}').object.sha`
(a live GitHub API call) to determine the SHA at which to create the temporary branch, then
pushed a local commit on top of it.

If the target branch advances between the job's `actions/checkout` and this API call (e.g.
during a `set_dependency_version` callback that runs ~90s of codegen/make), the API returns
a SHA that is *not* an ancestor of the local commit. The subsequent push is then a
non-fast-forward and GitHub rejects it with `error: failed to push some refs`.

Seen in practice: `gardener/gardener-extension-shoot-dns-service` `upgrade-pullrequests`
run 27811907485, all 3 attempts, where master advanced 19 minutes before the job ran.

## Fix

Use `commit.parents[0].hexsha` instead — the SHA the local commit was actually built on
top of. The remote branch is always created at the right base, making the push a guaranteed
fast-forward regardless of concurrent activity on the target branch.

`target_branch` parameter removed from `commit_and_push_to_tmp_branch` as it was only
used for that API call.