### PR TITLE
merge-ocm-fragments: fix mv conflict between subdir and same-named extracted file

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -184,27 +184,7 @@ runs:
         merge-multiple: true
     - name: extract-ocm-fragments
       shell: bash
-      run: |
-        set -eu
-        cd "${{ inputs.outdir }}"
-
-        # download-artifact@v3 (used on GHE) ignores `pattern`, so non-OCM artifacts may land
-        # here too; filter by naming convention to avoid processing unrelated files/directories.
-        echo "extracting ocm-fragment archives"
-        for tf in $(find . -name "*.ocm-artefacts.tar.gz"); do
-          echo "extracting ${tf}"
-          subdir=$(dirname "${tf}")
-          if [ "${subdir}" = "." ]; then
-            tar xf "${tf}"
-          else
-            # artifact landed in a named subdir (download-artifact@v3 on GHE); extract there to
-            # avoid conflict between the tarball's top-level entry and the pre-existing subdir,
-            # then move contents up to outdir
-            tar xf "${tf}" -C "${subdir}"
-            find "${subdir}" -maxdepth 1 -mindepth 1 -exec mv -t . {} +
-          fi
-          unlink "${tf}"
-        done
+      run: '"${{ github.action_path }}/extract.sh" "${{ inputs.outdir }}"'
     - name: merge-fragments
       id: merge
       shell: python

--- a/.github/actions/merge-ocm-fragments/extract.sh
+++ b/.github/actions/merge-ocm-fragments/extract.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Extracts *.ocm-artefacts.tar.gz files from the given directory (default: $PWD).
+# Handles both artifact layouts produced by actions/download-artifact:
+#   v3 (GHE): each tarball sits in a named subdir matching the artifact name
+#   v6+ (github.com): tarballs are placed directly in outdir
+set -eu
+
+cd "${1:-$PWD}"
+
+echo 'extracting ocm-fragment archives'
+for tf in $(find . -name '*.ocm-artefacts.tar.gz'); do
+    echo "extracting ${tf}"
+    subdir=$(dirname "${tf}")
+    if [ "${subdir}" = '.' ]; then
+        tar xf "${tf}"
+        unlink "${tf}"
+    else
+        # artifact landed in a named subdir (download-artifact@v3 on GHE). the tarball
+        # contains a file with the same name as the subdir, so we cannot mv it to outdir
+        # while the subdir exists. extract to tmpdir, remove (now empty) subdir, mv to outdir.
+        tmpdir=$(mktemp -d -p .)
+        tar xf "${tf}" -C "${tmpdir}"
+        unlink "${tf}"
+        rmdir "${subdir}"
+        find "${tmpdir}" -maxdepth 1 -mindepth 1 -exec mv -t . {} +
+        rmdir "${tmpdir}"
+    fi
+done

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -293,6 +293,18 @@ jobs:
                   value:
                     - test
 
+  test-merge-ocm-fragments-extract:
+    name: integration-test merge-ocm-fragments extract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false
+      - name: run
+        run: test/actions/test-extract-ocm-fragments.sh
+
   test-actions:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -282,7 +282,21 @@ on:
           The component-version (for convenience)
         value: ${{ jobs.release-and-bump.outputs.version }}
 jobs:
+  test-merge-ocm-fragments-extract:
+    name: integration-test merge-ocm-fragments extract
+    runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false
+      - name: run
+        run: test/actions/test-extract-ocm-fragments.sh
+
   release-and-bump:
+    needs:
+      - test-merge-ocm-fragments-extract
     environment: ${{ inputs.github-environment }}
     runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
     permissions:

--- a/test/actions/test-extract-ocm-fragments.sh
+++ b/test/actions/test-extract-ocm-fragments.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Tests .github/actions/merge-ocm-fragments/extract.sh directly.
+# Pre-fills the filesystem layout that download-artifact produces and verifies extraction.
+set -euo pipefail
+
+repo_root="$(readlink -f "$(dirname "$0")/../..")"
+extract="${repo_root}/.github/actions/merge-ocm-fragments/extract.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Creates a realistic .ocm-artefacts tarball (matching export-ocm-fragments output format).
+# Writes the tarball to dest_dir; echoes the fragment filename (the file the tarball contains).
+make_tarball() {
+    local dest_dir="$1"
+    local fragment_digest='aabbccdd1234567890aabbccdd1234567890abcd'
+    local tarball_digest='1234567890aabbccdd1234567890aabbccddee00'
+    local fragment_file="${fragment_digest}.ocm-artefacts"
+
+    local tmpdir; tmpdir=$(mktemp -d)
+    printf 'resources: [{name: test-resource, version: 1.0.0}]\n' \
+        > "${tmpdir}/${fragment_file}"
+    tar czf "${dest_dir}/${tarball_digest}.ocm-artefacts.tar.gz" \
+        -C "${tmpdir}" "${fragment_file}"
+    rm -rf "${tmpdir}"
+    echo "${fragment_file}"
+}
+
+echo '==> v6 layout: tarball flat in outdir'
+outdir=$(mktemp -d)
+fragment=$(make_tarball "${outdir}")
+"${extract}" "${outdir}"
+[ -f "${outdir}/${fragment}" ] || fail "expected ${fragment} in outdir"
+[ -z "$(find "${outdir}" -name '*.tar.gz')" ] || fail 'leftover tarball'
+echo '    PASS'
+rm -rf "${outdir}"
+
+echo '==> v3 layout: tarball in named subdir (subdir name == fragment file name)'
+outdir=$(mktemp -d)
+fragment=$(make_tarball /tmp)
+# download-artifact@v3 creates a subdir named after the artifact;
+# artifact name == fragment file name (e.g. aabbccdd...ocm-artefacts)
+subdir="${outdir}/${fragment}"
+mkdir "${subdir}"
+mv /tmp/*.ocm-artefacts.tar.gz "${subdir}/"
+"${extract}" "${outdir}"
+[ -f "${outdir}/${fragment}" ] || fail "expected ${fragment} in outdir"
+[ ! -d "${outdir}/${fragment}" ] || fail "${fragment} is a dir, not a file"
+[ -z "$(find "${outdir}" -name '*.tar.gz')" ] || fail 'leftover tarball'
+echo '    PASS'
+rm -rf "${outdir}"
+
+echo '==> v3 layout: multiple fragments'
+outdir=$(mktemp -d)
+n=3
+for i in $(seq 1 "${n}"); do
+    frag_digest="$(printf '%040d' "${i}")"
+    tar_digest="$(printf 'tar%037d' "${i}")"
+    tmpdir=$(mktemp -d)
+    printf 'resources: [{name: resource-%s, version: 1.0.0}]\n' "${i}" \
+        > "${tmpdir}/${frag_digest}.ocm-artefacts"
+    tar czf "/tmp/${tar_digest}.ocm-artefacts.tar.gz" \
+        -C "${tmpdir}" "${frag_digest}.ocm-artefacts"
+    rm -rf "${tmpdir}"
+    mkdir "${outdir}/${frag_digest}.ocm-artefacts"
+    mv "/tmp/${tar_digest}.ocm-artefacts.tar.gz" \
+        "${outdir}/${frag_digest}.ocm-artefacts/"
+done
+"${extract}" "${outdir}"
+found=$(find "${outdir}" -maxdepth 1 -name '*.ocm-artefacts' -type f | wc -l)
+[ "${found}" -eq "${n}" ] || fail "expected ${n} fragment files, found ${found}"
+[ -z "$(find "${outdir}" -name '*.tar.gz')" ] || fail 'leftover tarballs'
+echo '    PASS'
+rm -rf "${outdir}"
+
+echo ''
+echo 'all tests passed'


### PR DESCRIPTION
## Summary

The tarball inside each artifact subdir extracts a file with the **same name** as the subdir
itself. Previous fix tried `mv` from subdir to outdir, which fails with
"cannot overwrite directory with non-directory".

Fix: extract into a fresh `tmpdir`, unlink the tarball, `rmdir` the now-empty artifact subdir
(freeing the name), then move extracted contents from `tmpdir` to outdir.

## Test plan

- [ ] verify extract step succeeds on GHE (artifacts in named subdirs)
- [ ] verify extract step succeeds on github.com (artifacts flat in outdir)