### PR TITLE
release: remove test job that doesn't apply to reusable workflow callers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -282,21 +282,7 @@ on:
           The component-version (for convenience)
         value: ${{ jobs.release-and-bump.outputs.version }}
 jobs:
-  test-merge-ocm-fragments-extract:
-    name: integration-test merge-ocm-fragments extract
-    runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
-    permissions:
-      contents: read
-    steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
-        with:
-          remove-trusted-label: false
-      - name: run
-        run: test/actions/test-extract-ocm-fragments.sh
-
   release-and-bump:
-    needs:
-      - test-merge-ocm-fragments-extract
     environment: ${{ inputs.github-environment }}
     runs-on: ${{ inputs.github-runs-on || vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
The integration test job added in #1636 checks out the *calling* repo via
`trusted-checkout`, then tries to run `test/actions/test-extract-ocm-fragments.sh`
— which only exists in cc-utils, not in repos that call this reusable workflow.

The test already runs in `build-and-test.yaml` on every cc-utils push, which is
the correct place for it. Remove it from `release.yaml`.