### PR TITLE
increase default retries to get token from 1 to 3

### DIFF
--- a/.github/actions/github-auth/action.yaml
+++ b/.github/actions/github-auth/action.yaml
@@ -57,7 +57,7 @@ inputs:
     default: github-oidc-federation
   retries:
     type: number
-    default: 1
+    default: 3
     description: |
       Number of retry attempts on transient errors (5xx, 408, 429, network failures).
   backoff-base:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
See: https://github.com/gardener/cc-utils/pull/1623


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
