### PR TITLE
pass component-descriptor via artifact to avoid GITHUB_OUTPUT size limit

### DIFF
--- a/.github/actions/component-diff/action.yaml
+++ b/.github/actions/component-diff/action.yaml
@@ -6,10 +6,21 @@ description: |
 
 inputs:
   component-descriptor:
-    required: true
+    required: false
     type: string
     description: |
       An OCM-Component-Descriptor in YAML form.
+
+      Either this input or `component-descriptor-artifact` must be provided.
+  component-descriptor-artifact:
+    required: false
+    type: string
+    description: |
+      Name of a GHA artifact containing the component-descriptor, as produced by
+      `merge-ocm-fragments` (output `component-descriptor-artifact`).  The artifact must contain
+      `component-descriptor.tar.gz`, which in turn must contain `component-descriptor.yaml`.
+
+      Preferred over the inline `component-descriptor` input for large descriptors.
   ocm-repositories:
     required: true
     type: string
@@ -33,6 +44,17 @@ runs:
     - uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.ocm-repositories }} # only the first entry will be used
+    - name: download-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
+      with:
+        name: ${{ inputs.component-descriptor-artifact }}
+    - name: extract-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      shell: bash
+      run: |
+        set -eu
+        tar xf component-descriptor.tar.gz component-descriptor.yaml
     - name: Create component diff
       id: component-diff
       shell: python
@@ -48,9 +70,14 @@ runs:
         import ocm
         import version
 
+        if '${{ inputs.component-descriptor-artifact }}':
+          with open('component-descriptor.yaml') as f:
+            raw = yaml.safe_load(f)
+        else:
+          raw = yaml.safe_load('''${{ inputs.component-descriptor}}''')
 
         current_component_descriptor = ocm.ComponentDescriptor.from_dict(
-          component_descriptor_dict=yaml.safe_load('''${{ inputs.component-descriptor}}'''),
+          component_descriptor_dict=raw,
         )
         component_name = current_component_descriptor.component.name
         component_version = current_component_descriptor.component.version

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -101,8 +101,17 @@ inputs:
 outputs:
   component-descriptor:
     description: |
-      the resulting component-descriptor
+      the resulting component-descriptor (inline YAML).
+
+      Deprecated for large descriptors: GHA silently aborts a job once
+      GITHUB_OUTPUT exceeds 1 MiB.  Prefer `component-descriptor-artifact`.
     value: ${{ steps.output.outputs.component-descriptor }}
+  component-descriptor-artifact:
+    description: |
+      name of the GHA artifact containing the merged component-descriptor.
+      The artifact holds a single file `component-descriptor.tar.gz` which
+      in turn contains `component-descriptor.yaml`.
+    value: merged-component-descriptor
   name:
     description: |
       the component-name (for convenience)
@@ -364,3 +373,14 @@ runs:
         echo "component-descriptor<<EOF" >> "${GITHUB_OUTPUT}"
         cat "${{ inputs.outdir }}/component-descriptor.yaml" >> "${GITHUB_OUTPUT}"
         echo EOF >> ${GITHUB_OUTPUT}
+
+    - name: upload-component-descriptor-artifact
+      shell: bash
+      run: |
+        set -eu
+        tar czf /tmp/merged-component-descriptor.tar.gz \
+          -C "${{ inputs.outdir }}" component-descriptor.yaml
+    - uses: gardener/cc-utils/.github/actions/upload-artifact@master
+      with:
+        name: merged-component-descriptor
+        path: /tmp/merged-component-descriptor.tar.gz

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -8,7 +8,17 @@ inputs:
       effective OCM component-descriptor. It is sufficient to pass a `base component-descriptor`,
       as output by `base-component-descriptor` workflow. Its version must be set to next planned
       version (e.g. `1.2.0-dev`, if greatest released version was `1.1.0`).
-    required: true
+
+      Either this input or `component-descriptor-artifact` must be provided.
+    required: false
+  component-descriptor-artifact:
+    description: |
+      Name of a GHA artifact containing the component-descriptor, as produced by
+      `merge-ocm-fragments` (output `component-descriptor-artifact`).  The artifact must contain
+      `component-descriptor.tar.gz`, which in turn must contain `component-descriptor.yaml`.
+
+      Preferred over the inline `component-descriptor` input for large descriptors.
+    required: false
   ocm-repositories:
     description: |
       a (commaseparated) list of ocm-repository-URLs where component-versions are to be looked up
@@ -73,6 +83,18 @@ runs:
       with:
         oci-image-reference: ${{ inputs.ocm-repositories }} # only the first entry will be used
 
+    - name: download-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
+      with:
+        name: ${{ inputs.component-descriptor-artifact }}
+    - name: extract-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      shell: bash
+      run: |
+        set -eu
+        tar xf component-descriptor.tar.gz component-descriptor.yaml
+
     - name: Prepare release-notes variants cfg
       id: prep-releaes-notes-variants-cfg
       shell: python
@@ -101,9 +123,11 @@ runs:
       run: |
         set -eu
 
-        cat <<EOF > component-descriptor.yaml
-        ${{ inputs.component-descriptor }}
-        EOF
+        if [ -z "${{ inputs.component-descriptor-artifact }}" ]; then
+          cat <<EOF > component-descriptor.yaml
+          ${{ inputs.component-descriptor }}
+          EOF
+        fi
 
         echo 'Component-Descriptor:'
         cat component-descriptor.yaml

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -18,7 +18,17 @@ inputs:
     description: |
       Effective Component-Descriptor to publish. Any local-blobs are assumed to already be
       present in target-OCI-Repository.
-    required: true
+
+      Either this input or `component-descriptor-artifact` must be provided.
+    required: false
+  component-descriptor-artifact:
+    description: |
+      Name of a GHA artifact containing the component-descriptor, as produced by
+      `merge-ocm-fragments` (output `component-descriptor-artifact`).  The artifact must contain
+      `component-descriptor.tar.gz`, which in turn must contain `component-descriptor.yaml`.
+
+      Preferred over the inline `component-descriptor` input for large descriptors.
+    required: false
   component-descriptor-blobs-dir:
     description: |
       Directory containing blobfiles referenced as local-blobs in component-descriptor
@@ -188,6 +198,18 @@ runs:
     - uses: actions/checkout@v6
       with:
         token: ${{ inputs.git-push-token || inputs.github-token }}
+    - name: download-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
+      with:
+        name: ${{ inputs.component-descriptor-artifact }}
+    - name: extract-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      shell: bash
+      run: |
+        set -eu
+        tar xf component-descriptor.tar.gz component-descriptor.yaml
+        mv component-descriptor.yaml /tmp/component-descriptor.yaml
     - name: import-release-commit
       uses: gardener/cc-utils/.github/actions/import-commit@master
       with:
@@ -201,9 +223,11 @@ runs:
       shell: bash
       run: |
         # pass to next steps
-        cat <<"EOF" > /tmp/component-descriptor.yaml
-        ${{ inputs.component-descriptor }}
-        EOF
+        if [ -z "${{ inputs.component-descriptor-artifact }}" ]; then
+          cat <<"EOF" > /tmp/component-descriptor.yaml
+          ${{ inputs.component-descriptor }}
+          EOF
+        fi
         version=$(yq .component.version /tmp/component-descriptor.yaml)
         echo "version=${version}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/component-diff.yaml
+++ b/.github/workflows/component-diff.yaml
@@ -63,5 +63,5 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/component-diff@master
         id: component-diff
         with:
-          component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
+          component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
           ocm-repositories: ${{ steps.prepare.outputs.ocm-repositories }}

--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -322,7 +322,7 @@ jobs:
         if: ${{ steps.preprocess.outputs.create-draft-release == 'true' }}
         uses: gardener/cc-utils/.github/actions/release-notes@master
         with:
-          component-descriptor: ${{ needs.component-descriptor.outputs.component-descriptor }}
+          component-descriptor-artifact: component-descriptor
           ocm-repositories: ${{ steps.prep.outputs.ocm-repositories }}
           github-token: ${{ steps.fed-token.outputs.token || secrets.GITHUB_TOKEN }}
           draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -394,7 +394,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/release-notes@master
         id: release-notes
         with:
-          component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
+          component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
           ocm-repositories: ${{ steps.prep.outputs.ocm-repositories }}
           github-token: ${{ steps.fed-token.outputs.token }}
           draft: false
@@ -418,7 +418,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/release@master
         id: release
         with:
-          component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
+          component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
           component-descriptor-blobs-dir: /tmp/ocm/blobs.d
           release-commit-objects: ${{ inputs.release-commit-objects }}
           release-commit-objects-artefact: release-commit-objects


### PR DESCRIPTION
## Summary

- `merge-ocm-fragments` now uploads the merged component-descriptor as a GHA artifact (`merged-component-descriptor`) and exposes its name via a new `component-descriptor-artifact` output. The existing inline `component-descriptor` output is preserved for backward compatibility.
- `release-notes`, `release`, and `component-diff` actions each gain an optional `component-descriptor-artifact` input; when set they download+extract the descriptor from the artifact instead of reading it from the (potentially large) inline input.
- `release.yaml`, `post-build.yaml`, and `component-diff.yaml` workflows are updated to wire `component-descriptor-artifact` through, avoiding any writes of large YAML blobs to `GITHUB_OUTPUT`.

## Motivation

GHA silently aborts a job when `GITHUB_OUTPUT` exceeds 1 MiB. For large component-descriptors (e.g. landscape-setup, ~1 MiB on its own), writing the full YAML into `GITHUB_OUTPUT` pushes the total over the limit, causing downstream jobs to never run with no step marked as failed.

## Backward compatibility

All existing callers passing `component-descriptor` as an inline input continue to work unchanged. The new artifact-based path is opt-in.