### PR TITLE
stop writing component-descriptor to GITHUB_OUTPUT

### DIFF
--- a/.github/actions/base-component-descriptor/action.yaml
+++ b/.github/actions/base-component-descriptor/action.yaml
@@ -78,10 +78,11 @@ inputs:
       configures how generated base-component-descriptor should be post-processed
 
 outputs:
-  component-descriptor:
+  component-descriptor-artifact:
     description: |
-      the base-component-descriptor
-    value: ${{ steps.base-component-descriptor.outputs.component-descriptor }}
+      name of the GHA artifact containing the base-component-descriptor
+      (artifact name: `base-component-descriptor`).
+    value: base-component-descriptor
 
 runs:
   using: composite
@@ -224,11 +225,6 @@ runs:
           tf.add(
             name='base-component.yaml',
           )
-
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-          f.write('component-descriptor<<EOF\n')
-          f.write(component_descriptor_str)
-          f.write('EOF\n')
 
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
           f.write(textwrap.dedent(f'''\

--- a/.github/actions/helmchart/action.yaml
+++ b/.github/actions/helmchart/action.yaml
@@ -52,13 +52,16 @@ inputs:
       whether or not to push the built helmchart.
 
   component-descriptor:
-    required: true
+    required: false
     type: string
     description: |
-      An OCM-Component-Descriptor in YAML form. It may be incomplete, but must contain at least:
-      - component.version attribute
-      - component.name attribute
-      - all resources referenced in helmchart
+      An OCM-Component-Descriptor in YAML form (inline). Prefer `component-descriptor-artifact`.
+
+  component-descriptor-artifact:
+    required: false
+    type: string
+    description: |
+      Name of a GHA artifact containing the component-descriptor (preferred over inline input).
 
   mappings:
     required: true
@@ -97,14 +100,31 @@ runs:
   steps:
     - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - uses: azure/setup-helm@v4
+    - name: download-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
+      with:
+        name: ${{ inputs.component-descriptor-artifact }}
+        path: /tmp/cd-artifact
+    - name: extract-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      shell: bash
+      run: |
+        set -eu
+        tar xf /tmp/cd-artifact/component-descriptor.tar.gz \
+          -C /tmp component-descriptor.yaml
+    - name: write-component-descriptor-from-input
+      if: ${{ inputs.component-descriptor-artifact == '' }}
+      shell: bash
+      run: |
+        cat <<'EOF' > /tmp/component-descriptor.yaml
+        ${{ inputs.component-descriptor }}
+        EOF
     - name: preprocess-inputs
       shell: bash
       run: |
         cat <<EOF > /tmp/mappings.yaml
         ${{ inputs.mappings }}
-        EOF
-        cat <<EOF > /tmp/component-descriptor.yaml
-        ${{ inputs.component-descriptor }}
         EOF
     - name: authenticate
       if: ${{ inputs.push == 'true' }}

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -99,13 +99,6 @@ inputs:
       Useful when a newer syft version is desired. Defaults to `false`.
 
 outputs:
-  component-descriptor:
-    description: |
-      the resulting component-descriptor (inline YAML).
-
-      Deprecated for large descriptors: GHA silently aborts a job once
-      GITHUB_OUTPUT exceeds 1 MiB.  Prefer `component-descriptor-artifact`.
-    value: ${{ steps.output.outputs.component-descriptor }}
   component-descriptor-artifact:
     description: |
       name of the GHA artifact containing the merged component-descriptor.
@@ -169,9 +162,6 @@ runs:
           echo "Error: archive did not contain expected ${component_descriptor_path} file"
           exit 1
         fi
-        echo "component-descriptor<<EOF" >> "${GITHUB_OUTPUT}"
-        cat "${component_descriptor_path}" >> ${GITHUB_OUTPUT}
-        echo EOF >> "${GITHUB_OUTPUT}"
         mv "${component_descriptor_path}" "${{ inputs.outdir }}/base-component-descriptor.yaml"
     - name: prepare-component-descriptor
       shell: bash
@@ -364,15 +354,6 @@ runs:
             cache_repo_prefix='${{ inputs.sbom-cache-repo-prefix }}',
             force_rescan='${{ inputs.spdx-force-rescan }}' == 'true',
         )
-
-    - name: output-component-descriptor
-      id: output
-      shell: bash
-      run: |
-        set -eu
-        echo "component-descriptor<<EOF" >> "${GITHUB_OUTPUT}"
-        cat "${{ inputs.outdir }}/component-descriptor.yaml" >> "${GITHUB_OUTPUT}"
-        echo EOF >> ${GITHUB_OUTPUT}
 
     - name: upload-component-descriptor-artifact
       shell: bash

--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -25,9 +25,14 @@ inputs:
   component-descriptor:
     description: |
       The effective OCM-Component-Descriptor based on which Upgrade-Pullrequests should be
-      created.
+      created. Prefer `component-descriptor-artifact`.
     type: string
-    required: true
+    required: false
+  component-descriptor-artifact:
+    description: |
+      Name of a GHA artifact containing the component-descriptor (preferred over inline input).
+    type: string
+    required: false
   ocm-repositories:
     description: |
       A comma-separated list of OCM-Repositories that should be used to lookup Component-Versions.
@@ -107,12 +112,29 @@ runs:
       with:
         token: ${{ inputs.github-token }}
     - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
-    - name: write-component-descriptor
+    - name: download-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
+      with:
+        name: ${{ inputs.component-descriptor-artifact }}
+        path: /tmp/cd-artifact
+    - name: extract-component-descriptor-artifact
+      if: ${{ inputs.component-descriptor-artifact != '' }}
       shell: bash
       run: |
-        cat <<EOF > /tmp/component-descriptor.yaml
+        set -eu
+        tar xf /tmp/cd-artifact/component-descriptor.tar.gz \
+          -C /tmp component-descriptor.yaml
+    - name: write-component-descriptor-from-input
+      if: ${{ inputs.component-descriptor-artifact == '' }}
+      shell: bash
+      run: |
+        cat <<'EOF' > /tmp/component-descriptor.yaml
         ${{ inputs.component-descriptor }}
         EOF
+    - name: write-ocm-repositories
+      shell: bash
+      run: |
         cat <<EOF > /tmp/ocm-repositories
         ${{ inputs.ocm-repositories }}
         EOF

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -180,11 +180,11 @@ inputs:
       The relative path (from repository root) to the directory containing the release-notes docs.
 
 outputs:
-  component-descriptor:
+  component-descriptor-artifact:
     description: |
-      the Component-Descriptor as it was published (which may contain modifications compared
-      to the component-descriptor that was passed-in as input).
-    value: ${{ steps.publish-component-descriptor.outputs.component-descriptor }}
+      name of the GHA artifact containing the published component-descriptor
+      (same artifact as uploaded by the `release` action: `component-descriptor`).
+    value: component-descriptor
 
 defaults:
   run:
@@ -376,10 +376,6 @@ runs:
           --on-exist ${{ inputs.on-existing-component-descriptor }}
 
         tar czf /tmp/component-descriptor.tar.gz -C/tmp component-descriptor.yaml
-
-        echo "component-descriptor<<EOF" >> "${GITHUB_OUTPUT}"
-        cat /tmp/component-descriptor.yaml >> "${GITHUB_OUTPUT}"
-        echo EOF >> "${GITHUB_OUTPUT}"
 
     - name: upload OCM Component-Descriptor as artifact
       uses: gardener/cc-utils/.github/actions/upload-artifact@master

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,8 +19,8 @@ on:
         value: ${{ jobs.prepare.outputs.version }}
       base-component-descriptor:
         description: |
-          the base OCM Component-Descriptor in YAML-format (use `merge-ocm-fragments`-action
-          to collect full component-descriptor):
+          name of the GHA artifact holding the base OCM Component-Descriptor
+          (use `merge-ocm-fragments` action to collect full component-descriptor):
         value: ${{ jobs.prepare.outputs.component-descriptor }}
 
 jobs:

--- a/.github/workflows/helmchart-ocm.yaml
+++ b/.github/workflows/helmchart-ocm.yaml
@@ -163,6 +163,6 @@ jobs:
           oci-registry: ${{ inputs.oci-registry }}
           oci-repository: ${{ inputs.oci-repository }}
           push: ${{ steps.check.outputs.push == 'true' }}
-          component-descriptor: ${{ steps.fetch-ocm.outputs.component-descriptor }}
+          component-descriptor-artifact: ${{ steps.fetch-ocm.outputs.component-descriptor-artifact }}
           mappings: ${{ inputs.ocm-mappings }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -188,11 +188,6 @@ on:
           `import-commit` action.
         value: release-commit-objects
 
-      component-descriptor:
-        description: |
-          A base-component-descriptor, as output by `base-component-descriptor` action.
-        value: ${{ jobs.version-and-ocm.outputs.component-descriptor }}
-
 jobs:
   version-and-ocm:
     environment: ${{ inputs.github-environment }}
@@ -209,7 +204,7 @@ jobs:
       can-push: ${{ steps.params.outputs.can-push }}
       version: ${{ steps.version.outputs.version }}
       commit-digest: ${{ steps.version.outputs.commit-digest }}
-      component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor }}
+      component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
     steps:
       - name: params
         id: params
@@ -295,9 +290,7 @@ jobs:
           # version-and-ocm
           echo "${{ steps.version.outputs.version }}" > $p/version
           echo "${{ steps.version.outputs.commit-digest }}" > $p/commit-digest
-          cat <<EOF > $p/component-descriptor
-          ${{ steps.component-descriptor.outputs.component-descriptor }}
-          EOF
+          # component-descriptor is passed via the `base-component-descriptor` artifact
 
           tar cf "${{ inputs.output-artefact-filename }}" $p
           tar tf "${{ inputs.output-artefact-filename }}" # debug

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -273,10 +273,10 @@ on:
           published as part of component-descriptor, as well as via slack, if `slack-channel-id`
           input is specified).
         value: ${{ jobs.release-and-bump.outputs.release-notes }}
-      component-descriptor:
+      component-descriptor-artifact:
         description: |
-          The component-descriptor document, as it was uploaded during release
-        value: ${{ jobs.release-and-bump.outputs.component-descriptor }}
+          Name of the GHA artifact containing the component-descriptor as published during release.
+        value: ${{ jobs.release-and-bump.outputs.component-descriptor-artifact }}
       version:
         description: |
           The component-version (for convenience)
@@ -292,7 +292,7 @@ jobs:
 
     outputs:
       release-notes: ${{ steps.release-notes.outputs.release-notes }}
-      component-descriptor: ${{ steps.release.outputs.component-descriptor }}
+      component-descriptor-artifact: ${{ steps.release.outputs.component-descriptor-artifact }}
       version: ${{ steps.component-descriptor.outputs.version }}
 
     steps:

--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -149,8 +149,8 @@ jobs:
             pull-requests: write
       - uses: gardener/cc-utils/.github/actions/ocm-upgrade@master
         with:
-          component-descriptor: |
-            ${{ inputs.component-descriptor || needs.prepare.outputs.component-descriptor }}
+          component-descriptor: ${{ inputs.component-descriptor }}
+          component-descriptor-artifact: ${{ inputs.component-descriptor == '' && needs.prepare.outputs.component-descriptor || '' }}
           ocm-repositories: |
             ${{ needs.prepare.outputs.ocm-repositories || inputs.ocm-repositories }}
           github-token: ${{ steps.checkout.outputs.token }}


### PR DESCRIPTION
## Summary

- Remove all inline writes of OCM Component-Descriptors to `GITHUB_OUTPUT`
- All CDs now flow exclusively via GHA artifacts (no size limit)
- Affected: `merge-ocm-fragments`, `release`, `base-component-descriptor`, `helmchart`, `ocm-upgrade` actions; `prepare`, `release`, `build-and-test`, `helmchart-ocm`, `upgrade-dependencies` workflows

## Background

`GITHUB_OUTPUT` has a 1 MiB hard limit. Large CDs (~1 MiB) written twice per job (once by `merge-ocm-fragments`, once by `release` action) would silently abort the job.

## Test plan

- [ ] CI pipeline passes on this PR