### PR TITLE
prepare: rename output component-descriptor to component-descriptor-artefact

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,7 +21,7 @@ on:
         description: |
           name of the GHA artifact holding the base OCM Component-Descriptor
           (use `merge-ocm-fragments` action to collect full component-descriptor):
-        value: ${{ jobs.prepare.outputs.component-descriptor }}
+        value: ${{ jobs.prepare.outputs.component-descriptor-artefact }}
 
 jobs:
   prepare:

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -187,10 +187,10 @@ on:
           It is output using the `capture-commit` action, and can be imported using the
           `import-commit` action.
         value: release-commit-objects
-      component-descriptor:
+      component-descriptor-artefact:
         description: |
           The name of the GHA artifact holding the base OCM Component-Descriptor.
-        value: ${{ jobs.version-and-ocm.outputs.component-descriptor }}
+        value: ${{ jobs.version-and-ocm.outputs.component-descriptor-artefact }}
 
 jobs:
   version-and-ocm:
@@ -208,7 +208,7 @@ jobs:
       can-push: ${{ steps.params.outputs.can-push }}
       version: ${{ steps.version.outputs.version }}
       commit-digest: ${{ steps.version.outputs.commit-digest }}
-      component-descriptor: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
+      component-descriptor-artefact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
     steps:
       - name: params
         id: params

--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -150,7 +150,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/ocm-upgrade@master
         with:
           component-descriptor: ${{ inputs.component-descriptor }}
-          component-descriptor-artifact: ${{ inputs.component-descriptor == '' && needs.prepare.outputs.component-descriptor || '' }}
+          component-descriptor-artifact: ${{ inputs.component-descriptor == '' && needs.prepare.outputs.component-descriptor-artefact || '' }}
           ocm-repositories: |
             ${{ needs.prepare.outputs.ocm-repositories || inputs.ocm-repositories }}
           github-token: ${{ steps.checkout.outputs.token }}


### PR DESCRIPTION
## Summary

- Renames the `component-descriptor` workflow output of `prepare.yaml` to
  `component-descriptor-artefact` to make it unambiguous that the value is an artifact
  name, not inline YAML (incompatible change)
- Updates internal consumers (`build-and-test.yaml`, `upgrade-dependencies.yaml`)

## Notes

Consumers outside this repo must be updated separately. The companion fix for
`landscape-dev-garden/testrunner.yaml` already handles both the old and new name via
a shell fallback expression, so the rename can land independently.