### PR TITLE
sbom: S3-bucket scanning support (gardenlinux)

### DIFF
--- a/.github/actions/sbom-upload/upload.py
+++ b/.github/actions/sbom-upload/upload.py
@@ -31,7 +31,11 @@ def _mangle(s: str) -> str:
 
 def _fmt_id(mapping: si.SbomMapping) -> str | None:
     if mapping.source is si.SbomSource.OCM:
-        return (mapping.sbom.extraIdentity or {}).get('sbom-format')
+        ei = mapping.sbom.extraIdentity or {}
+        # SBOM resources use 'sbom-format'; CBOM resources use 'cbom-format'
+        return ei.get('sbom-format') or (
+            f'cbom-{ei["cbom-format"]}' if ei.get('cbom-format') else None
+        )
     for fid, media_type in soci.SBOM_FORMATS:
         if mapping.sbom.artifact_type == media_type:
             return fid
@@ -45,7 +49,7 @@ def _filename(
 ) -> str:
     extra_vals = [
         v for k, v in sorted((resource.extraIdentity or {}).items())
-        if k not in ('sbom-format', 'version')
+        if k not in ('sbom-format', 'cbom-format', 'version')
     ]
     extra = ('-' + '-'.join(extra_vals)) if extra_vals else ''
     return (

--- a/ctt/__main__.py
+++ b/ctt/__main__.py
@@ -79,6 +79,13 @@ def configure_parser(parser):
         ),
     )
 
+    parser.add_argument(
+        '--inject-s3-sboms',
+        action='store_true',
+        default=False,
+        help='scan S3-backed resources and inject SBOM/CBOM documents into replicated descriptors',
+    )
+
 
 def replicate(parsed):
     _init_logging()
@@ -125,6 +132,7 @@ def replicate(parsed):
         processing_mode=processing_mode,
         max_workers=max_workers,
         pruning_mode=parsed.pruning_mode,
+        inject_s3_sboms=parsed.inject_s3_sboms,
     ):
         pass
 

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -26,6 +26,7 @@ import ctt.oci_util
 import ctt.replicate
 import sbom.cbom as sbom_cbom
 import sbom.inject as sbom_inject
+import sbom.s3 as sbom_s3
 import oci
 import oci.client
 import oci.model as om
@@ -635,6 +636,7 @@ def process_images(
     max_workers: int=16,
     tgt_ocm_repo_path: str | None=None, # deprecated -> specify `ocm_repository` in tgt-cfg instead
     pruning_mode: PruningMode=PruningMode.PRUNE_SUBTREES,
+    inject_s3_sboms: bool=False,
 ) -> collections.abc.Generator[ocm.iter.Node, None, None]:
     '''
     note: Passing a filter to prevent component descriptors from being replicated using the
@@ -731,6 +733,7 @@ def process_images(
             skip_component_upload=skip_component_upload,
             overwrite_descriptors=pruning_mode is PruningMode.FORCE_OVERWRITE_DESCRIPTORS,
             max_workers=max_workers,
+            inject_s3_sboms=inject_s3_sboms,
         )
 
 
@@ -749,6 +752,7 @@ def process_replication_plan_step(
     skip_component_upload: collections.abc.Callable[[ocm.Component], bool] | None=None,
     overwrite_descriptors: bool=False,
     max_workers: int=16,
+    inject_s3_sboms: bool=False,
 ) -> collections.abc.Generator[ocm.iter.Node, None, None]:
     def process_replication_resource_element(
         replication_resource_element: ctt.model.ReplicationResourceElement,
@@ -865,7 +869,6 @@ def process_replication_plan_step(
     if sbom_candidates:
         if processing_mode is not ProcessingMode.DRY_RUN:
             sbom_inject.check_syft()
-            sbom_inject.check_cbomkit_theia()
 
         tmpdir = os.environ.get('TMPDIR') or os.environ.get('RUNNER_TEMP') or None
         syft_ver = sbom_inject._syft_version()
@@ -1005,6 +1008,78 @@ def process_replication_plan_step(
                     source_extra_identity=rre.source.extraIdentity or None,
                 )
                 sbom_extra_resources[rre.component_id].extend((spdx_res, cdx_res, cbom_res))
+
+    # --- S3 SBOM injection ---
+    # Scans S3-backed resources from the component descriptors and injects SBOM/CBOM resources.
+    # Enabled only when inject_s3_sboms=True (default: False).
+    if inject_s3_sboms:
+        if processing_mode is not ProcessingMode.DRY_RUN:
+            sbom_inject.check_syft()
+
+        tmpdir = os.environ.get('TMPDIR') or os.environ.get('RUNNER_TEMP') or '/tmp'  # nosec B108
+        syft_ver = sbom_inject._syft_version()
+        registry_base = replication_plan_step.target_ocm_repository
+
+        # collect all S3 resources across all components in this replication step
+        s3_candidates = [
+            (rce.target.component, resource)
+            for rce in replication_plan_step.components
+            for resource in rce.target.component.resources
+            if isinstance(resource.access, (ocm.S3Access, ocm.LegacyS3Access))
+        ]
+
+        logger.info(f'S3 SBOM injection: {len(s3_candidates)} S3 resource(s) to process')
+
+        for component, resource in s3_candidates:
+            component_id = component.identity()
+            access = resource.access
+
+            if isinstance(access, ocm.LegacyS3Access):
+                s3_url = sbom_s3.s3_url(access.bucketName, access.objectKey, access.region)
+            else:
+                s3_url = sbom_s3.s3_url(access.bucket, access.key, access.region)
+
+            if processing_mode is ProcessingMode.DRY_RUN:
+                logger.info(
+                    f'dry-run: would scan S3 resource {resource.name!r} ({s3_url})'
+                )
+                continue
+
+            try:
+                (spdx_bytes, cdx_bytes, cbom_bytes,
+                 tool_ver, cbom_tool_ver,
+                 spdx_digest, cdx_digest, cbom_digest,
+                 repo_ref, content_digest) = sbom_inject.scan_s3_resource(
+                    access=access,
+                    oci_client=oci_client,
+                    registry_base=registry_base,
+                    tmpdir=tmpdir,
+                    tool_ver=syft_ver,
+                )
+            except Exception as e:
+                logger.warning(
+                    f'{resource.name!r}: S3 SBOM scan failed: {e}'
+                )
+                continue
+
+            spdx_res, cdx_res, cbom_res = sbom_inject.build_s3_sbom_ocm_resources(
+                resource_name=resource.name,
+                version=resource.version,
+                s3_url=s3_url,
+                content_digest=content_digest,
+                repo_ref=repo_ref,
+                spdx_manifest_digest=spdx_digest,
+                cdx_manifest_digest=cdx_digest,
+                cbom_manifest_digest=cbom_digest,
+                tool_ver=tool_ver,
+                cbom_tool_ver=cbom_tool_ver,
+                source_extra_identity=resource.extraIdentity or None,
+            )
+            sbom_extra_resources[component_id].extend((spdx_res, cdx_res, cbom_res))
+            logger.info(
+                f'{resource.name!r}: S3 SBOM/CBOM injected '
+                f'(spdx={spdx_digest[:16]}... cdx={cdx_digest[:16]}...)'
+            )
 
     # --- Phase 2: component-descriptor patching ---
     is_root_component_descriptor = lambda component_descriptor: (

--- a/sbom/__init__.py
+++ b/sbom/__init__.py
@@ -9,6 +9,7 @@ Sub-modules:
   sbom.cbom    — OCI referrer mechanics and OCM resource construction for CBOM documents
   sbom.inject  — syft/cbomkit-theia scanning, resource-aware injection, OCM resource construction
   sbom.iter    — iterate and retrieve SBOM documents across OCM component trees
+  sbom.s3      — S3 download helper for public-bucket resources
 '''
 from sbom.oci import (  # noqa: F401
     SPDX_JSON_MEDIA_TYPE,
@@ -17,6 +18,7 @@ from sbom.oci import (  # noqa: F401
     SBOM_FORMATS,
     push_sbom_referrer,
     push_sbom_referrers,
+    push_sbom_standalone,
 )
 from sbom.cbom import (  # noqa: F401
     CBOM_ARTIFACT_TYPE,
@@ -30,4 +32,13 @@ from sbom.iter import (  # noqa: F401
     iter_sboms_for_resource,
     iter_sboms,
     fetch_sbom_document,
+)
+from sbom.inject import (  # noqa: F401
+    scan_s3_resource,
+    build_s3_sbom_ocm_resources,
+)
+from sbom.s3 import (  # noqa: F401
+    iter_s3_object,
+    s3_url,
+    synthetic_oci_ref,
 )

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -17,6 +17,7 @@ Scan admission mirrors a resource-aware approach:
 Minimum headroom: 2 GiB disk, 1 GiB memory.  At least one scan is always admitted.
 '''
 import concurrent.futures
+import hashlib
 import json
 import logging
 import os
@@ -28,6 +29,7 @@ import oci.model as om
 import ocm
 import sbom.cbom as scbom
 import sbom.oci as soci
+import sbom.s3 as ss3
 
 _DOCKER_CONFIG_PATH = os.path.expanduser('~/.docker/config.json')
 
@@ -53,22 +55,6 @@ def check_syft():
             'syft is not installed or not on PATH. '
             'Please install syft (https://github.com/anchore/syft) before running CTT '
             'with SBOM injection enabled.'
-        )
-
-
-def check_cbomkit_theia():
-    '''Verify cbomkit-theia is on PATH; raise RuntimeError with a friendly message if not.'''
-    try:
-        subprocess.run(  # nosec B607
-            ['cbomkit-theia', '--help'],
-            check=True,
-            capture_output=True,
-        )
-    except FileNotFoundError:
-        raise RuntimeError(
-            'cbomkit-theia is not installed or not on PATH. '
-            'Please install cbomkit-theia (https://github.com/IBM/cbomkit-theia) before '
-            'running CTT with SBOM/CBOM injection enabled.'
         )
 
 
@@ -301,22 +287,26 @@ def scan_image(
             env=env,
         )
 
-        _run_cbomkit_theia(
-            image_ref=str(image_ref),
-            cdx_bom_path=cdx_path,
-            out_path=cbom_path,
-            tmpdir=tmpdir,
-        )
-
         with open(spdx_path, 'rb') as f:
             spdx_bytes = f.read()
         with open(cdx_path, 'rb') as f:
             cdx_bytes = f.read()
-        with open(cbom_path, 'rb') as f:
-            cbom_bytes = f.read()
+
+        try:
+            _run_cbomkit_theia(
+                image_ref=str(image_ref),
+                cdx_bom_path=cdx_path,
+                out_path=cbom_path,
+                tmpdir=tmpdir,
+            )
+            with open(cbom_path, 'rb') as f:
+                cbom_bytes = f.read()
+        except Exception as e:
+            logger.warning('cbomkit-theia failed for %r: %s', str(image_ref), e)
+            cbom_bytes = None
 
     resolved_tool_ver = tool_ver or _syft_version_from_spdx(spdx_bytes)
-    cbom_tool_ver = _cbomkit_theia_version()
+    cbom_tool_ver = _cbomkit_theia_version() if cbom_bytes is not None else None
 
     spdx_referrer_digest, cdx_referrer_digest = soci.push_sbom_referrers(
         spdx_bytes=spdx_bytes,
@@ -330,7 +320,7 @@ def scan_image(
         image_reference=image_ref,
         oci_client=oci_client,
         tool_version=cbom_tool_ver,
-    )
+    ) if cbom_bytes is not None else None
 
     return (
         spdx_bytes, cdx_bytes, cbom_bytes,
@@ -513,5 +503,267 @@ def build_sbom_ocm_resources(
     return (
         _make_sbom(soci.SPDX_JSON_MEDIA_TYPE,     'spdx-2.3',      spdx_referrer_digest),
         _make_sbom(soci.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_referrer_digest),
+        cbom_resource,
+    )
+
+
+def _push_cbom_standalone(
+    cbom_bytes: bytes,
+    repo_ref: str,
+    oci_client: oc.Client,
+    tool_version: str | None = None,
+) -> str:
+    '''
+    Push a CBOM document as a standalone OCI manifest (no subject). Returns manifest digest.
+    '''
+    doc_digest = f'sha256:{hashlib.sha256(cbom_bytes).hexdigest()}'
+    oci_client.put_blob(
+        image_reference=repo_ref,
+        digest=doc_digest,
+        octets_count=len(cbom_bytes),
+        data=cbom_bytes,
+        mimetype=scbom.CBOM_LAYER_MEDIA_TYPE,
+    )
+    oci_client.put_blob(
+        image_reference=repo_ref,
+        digest=soci._EMPTY_CONFIG_DIGEST,
+        octets_count=len(soci._EMPTY_CONFIG),
+        data=soci._EMPTY_CONFIG,
+        mimetype=soci.OCI_EMPTY_CONFIG_MEDIA_TYPE,
+    )
+    manifest = om.OciImageManifest(
+        config=om.OciBlobRef(
+            digest=soci._EMPTY_CONFIG_DIGEST,
+            mediaType=soci.OCI_EMPTY_CONFIG_MEDIA_TYPE,
+            size=len(soci._EMPTY_CONFIG),
+        ),
+        layers=[om.OciBlobRef(
+            digest=doc_digest,
+            mediaType=scbom.CBOM_LAYER_MEDIA_TYPE,
+            size=len(cbom_bytes),
+        )],
+        artifactType=scbom.CBOM_ARTIFACT_TYPE,
+        annotations={
+            'org.opencontainers.image.created': soci._utcnow_iso(),
+            **({'gardener.cloud/cbom/tool-version': tool_version} if tool_version else {}),
+        },
+    )
+    manifest_bytes = json.dumps(manifest.as_dict()).encode()
+    manifest_digest = f'sha256:{hashlib.sha256(manifest_bytes).hexdigest()}'
+    oci_client.put_manifest(
+        image_reference=f'{repo_ref}@{manifest_digest}',
+        manifest=manifest_bytes,
+    )
+    return manifest_digest
+
+
+def scan_s3_resource(
+    access: 'ocm.S3Access | ocm.LegacyS3Access',
+    oci_client: oc.Client,
+    registry_base: str,
+    tmpdir: str,
+    tool_ver: str | None = None,
+) -> tuple[bytes, bytes, bytes, str | None, str | None, str, str, str, str, str]:
+    '''
+    Scan an S3-backed OCM resource with syft + cbomkit-theia.
+
+    Downloads the object from the public S3 bucket, runs syft on the local file, then runs
+    cbomkit-theia on the CycloneDX output.  All three SBOM/CBOM documents are pushed as
+    standalone OCI manifests (no subject) to a content-addressed synthetic OCI ref under
+    `registry_base/sbom-s3/...`.
+
+    Returns:
+      (spdx_bytes, cdx_bytes, cbom_bytes,
+       tool_ver, cbom_tool_ver,
+       spdx_manifest_digest, cdx_manifest_digest, cbom_manifest_digest,
+       repo_ref, content_digest)
+
+    where:
+      content_digest  = sha256 of the downloaded S3 object (used for OCM resource labels)
+      repo_ref        = the synthetic OCI repo path (without digest/tag)
+    '''
+    if isinstance(access, ocm.LegacyS3Access):
+        bucket, key, region = access.bucketName, access.objectKey, access.region
+    else:
+        bucket, key, region = access.bucket, access.key, access.region
+
+    logger.info(f'downloading S3 object s3://{bucket}/{key}')
+
+    env = os.environ.copy()
+    env['TMPDIR'] = tmpdir
+
+    with tempfile.TemporaryDirectory(dir=tmpdir) as tmp:
+        blob_path = os.path.join(tmp, 'blob')
+        h = hashlib.sha256()
+        size = 0
+        with open(blob_path, 'wb') as f:
+            for chunk in ss3.iter_s3_object(bucket=bucket, key=key, region=region):
+                h.update(chunk)
+                f.write(chunk)
+                size += len(chunk)
+        content_digest = f'sha256:{h.hexdigest()}'
+        logger.info(f's3://{bucket}/{key}: {size} bytes, {content_digest}')
+
+        full_synthetic = ss3.synthetic_oci_ref(registry_base, bucket, key, content_digest)
+        repo_ref = om.OciImageReference(full_synthetic).ref_without_tag
+
+        spdx_path = os.path.join(tmp, 'sbom.spdx.json')
+        cdx_path  = os.path.join(tmp, 'sbom.cdx.json')
+        cbom_path = os.path.join(tmp, 'cbom.cdx.json')
+
+        subprocess.run(  # nosec B607
+            [
+                'syft', 'scan', blob_path,
+                '-o', f'spdx-json={spdx_path}',
+                '-o', f'cyclonedx-json@1.6={cdx_path}',
+            ],
+            check=True,
+            env=env,
+        )
+
+        with open(spdx_path, 'rb') as f:
+            spdx_bytes = f.read()
+        with open(cdx_path, 'rb') as f:
+            cdx_bytes = f.read()
+
+        try:
+            _run_cbomkit_theia(
+                image_ref=blob_path,  # cbomkit-theia accepts local paths too
+                cdx_bom_path=cdx_path,
+                out_path=cbom_path,
+                tmpdir=tmp,
+            )
+            with open(cbom_path, 'rb') as f:
+                cbom_bytes = f.read()
+        except Exception as e:
+            logger.warning('cbomkit-theia failed for %r: %s', blob_path, e)
+            cbom_bytes = None
+
+    resolved_tool_ver = tool_ver or _syft_version_from_spdx(spdx_bytes)
+    cbom_tool_ver = _cbomkit_theia_version() if cbom_bytes is not None else None
+
+    spdx_digest, cdx_digest = soci.push_sbom_standalone(
+        spdx_bytes=spdx_bytes,
+        cdx_bytes=cdx_bytes,
+        repo_ref=repo_ref,
+        content_digest=content_digest,
+        oci_client=oci_client,
+        tool_version=resolved_tool_ver,
+    )
+    cbom_digest = _push_cbom_standalone(
+        cbom_bytes=cbom_bytes,
+        repo_ref=repo_ref,
+        oci_client=oci_client,
+        tool_version=cbom_tool_ver,
+    ) if cbom_bytes is not None else None
+
+    return (
+        spdx_bytes, cdx_bytes, cbom_bytes,
+        resolved_tool_ver, cbom_tool_ver,
+        spdx_digest, cdx_digest, cbom_digest,
+        repo_ref, content_digest,
+    )
+
+
+def lookup_s3_sboms(
+    access: 'ocm.S3Access | ocm.LegacyS3Access',
+    oci_client: oc.Client,
+    registry_base: str,
+    tmpdir: str,
+) -> tuple[bytes, bytes, str, str, str, str] | None:
+    '''
+    Check whether SBOM standalone manifests already exist for an S3 resource.
+
+    Always returns None for now: manifest digests are not pre-computable without first running
+    the syft scan, so a true cache-hit path cannot be implemented without storing a separate
+    digest index.  Scan + push operations are idempotent, so redundant runs are safe.
+
+    A future optimisation could store manifest digests in a local cache file keyed by the
+    S3 content digest (sha256 of the downloaded object).
+    '''
+    return None
+
+
+def build_s3_sbom_ocm_resources(
+    resource_name: str,
+    version: str,
+    s3_url: str,
+    content_digest: str,
+    repo_ref: str,
+    spdx_manifest_digest: str,
+    cdx_manifest_digest: str,
+    cbom_manifest_digest: str,
+    tool_ver: str | None = None,
+    cbom_tool_ver: str | None = None,
+    source_extra_identity: dict | None = None,
+) -> tuple[ocm.Resource, ocm.Resource, ocm.Resource]:
+    '''
+    Build (spdx_resource, cdx_resource, cbom_resource) OCM Resource objects for an S3 resource.
+
+    All three use OciAccess pointing at standalone manifests pushed to the synthetic OCI repo.
+    `source_extra_identity` is merged into each resource's extraIdentity.
+    '''
+    def _make_sbom(media_type, sbom_format, manifest_digest):
+        label_value = {
+            'data-source': {
+                'kind': 'local-scan',
+                'tool': 'syft',
+                'tool-version': tool_ver,
+            },
+            'format': sbom_format,
+        } if tool_ver else None
+        labels = [
+            ocm.Label(name='gardener.cloud/sbom/source-image',        value=s3_url),
+            ocm.Label(name='gardener.cloud/sbom/source-image-digest', value=content_digest),
+        ]
+        if label_value:
+            labels.append(ocm.Label(name='gardener.cloud/sbom', value=label_value))
+        extra_id = {
+            **(source_extra_identity or {}),
+            'version': version,
+            'sbom-format': sbom_format,
+        }
+        return ocm.Resource(
+            name=resource_name,
+            version=version,
+            type=media_type,
+            relation=ocm.ResourceRelation.EXTERNAL,
+            extraIdentity=extra_id,
+            access=ocm.OciAccess(imageReference=f'{repo_ref}@{manifest_digest}'),
+            labels=labels,
+        )
+
+    label_value = {
+        'data-source': {
+            'kind': 'local-scan',
+            'tool': 'cbomkit-theia',
+            'tool-version': cbom_tool_ver,
+        },
+        'format': 'cyclonedx-1.6',
+    } if cbom_tool_ver else None
+    cbom_labels = [
+        ocm.Label(name='gardener.cloud/cbom/source-image',        value=s3_url),
+        ocm.Label(name='gardener.cloud/cbom/source-image-digest', value=content_digest),
+    ]
+    if label_value:
+        cbom_labels.append(ocm.Label(name='gardener.cloud/cbom', value=label_value))
+    cbom_extra_id = {
+        **(source_extra_identity or {}),
+        'version': version,
+        'cbom-format': 'cyclonedx-1.6',
+    }
+    cbom_resource = ocm.Resource(
+        name=resource_name,
+        version=version,
+        type=scbom.CBOM_LAYER_MEDIA_TYPE,
+        relation=ocm.ResourceRelation.EXTERNAL,
+        extraIdentity=cbom_extra_id,
+        access=ocm.OciAccess(imageReference=f'{repo_ref}@{cbom_manifest_digest}'),
+        labels=cbom_labels,
+    )
+
+    return (
+        _make_sbom(soci.SPDX_JSON_MEDIA_TYPE,     'spdx-2.3',      spdx_manifest_digest),
+        _make_sbom(soci.CYCLONEDX_JSON_MEDIA_TYPE, 'cyclonedx-1.6', cdx_manifest_digest),
         cbom_resource,
     )

--- a/sbom/iter.py
+++ b/sbom/iter.py
@@ -84,10 +84,10 @@ def iter_sboms_for_resource(
     '''
     # --- phase 1: OCM resources from the component descriptor (in-memory, no I/O) ---
     resource_name = resource.name
-    # SBOM resources share name (and non-sbom extraIdentity keys) with their source resource
+    # SBOM/CBOM resources share name (and non-sbom/cbom extraIdentity keys) with their source
     source_extra = {
         k: v for k, v in (resource.extraIdentity or {}).items()
-        if k not in ('sbom-format', 'version')
+        if k not in ('sbom-format', 'cbom-format', 'version')
     }
     for candidate in component.resources:
         if not _is_sbom_resource(candidate):

--- a/sbom/oci.py
+++ b/sbom/oci.py
@@ -294,6 +294,116 @@ def build_sbom_ocm_resources(
     )
 
 
+def push_sbom_standalone(
+    spdx_bytes: bytes,
+    cdx_bytes: bytes,
+    repo_ref: str,
+    content_digest: str,
+    oci_client: oc.Client,
+    tool_version: str | None = None,
+) -> tuple[str, str]:
+    '''
+    Push SPDX and CycloneDX SBOM documents as standalone OCI manifests (no `subject` field).
+
+    Used for S3-backed resources that have no OCI image to hang referrers off.  Each document
+    is pushed as a single-layer manifest; the tag used is derived from `content_digest` so the
+    result is content-addressable and cache lookups are cheap (HEAD request).
+
+    Returns (spdx_manifest_digest, cdx_manifest_digest).
+    '''
+    annotations = {'gardener.cloud/sbom/tool-version': tool_version} if tool_version else None
+    digests = []
+    for doc_bytes, doc_media_type, artifact_type in (
+        (spdx_bytes, SPDX_JSON_MEDIA_TYPE,      SPDX_JSON_MEDIA_TYPE),
+        (cdx_bytes,  CYCLONEDX_JSON_MEDIA_TYPE,  CYCLONEDX_JSON_MEDIA_TYPE),
+    ):
+        doc_digest = f'sha256:{hashlib.sha256(doc_bytes).hexdigest()}'
+        logger.info(f'pushing standalone doc blob {doc_digest} to {repo_ref}')
+        oci_client.put_blob(
+            image_reference=repo_ref,
+            digest=doc_digest,
+            octets_count=len(doc_bytes),
+            data=doc_bytes,
+            mimetype=doc_media_type,
+        )
+        oci_client.put_blob(
+            image_reference=repo_ref,
+            digest=_EMPTY_CONFIG_DIGEST,
+            octets_count=len(_EMPTY_CONFIG),
+            data=_EMPTY_CONFIG,
+            mimetype=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+        )
+        manifest = om.OciImageManifest(
+            config=om.OciBlobRef(
+                digest=_EMPTY_CONFIG_DIGEST,
+                mediaType=OCI_EMPTY_CONFIG_MEDIA_TYPE,
+                size=len(_EMPTY_CONFIG),
+            ),
+            layers=[
+                om.OciBlobRef(
+                    digest=doc_digest,
+                    mediaType=doc_media_type,
+                    size=len(doc_bytes),
+                ),
+            ],
+            artifactType=artifact_type,
+            annotations={
+                'org.opencontainers.image.created': _utcnow_iso(),
+                **(annotations or {}),
+            },
+        )
+        manifest_bytes = json.dumps(manifest.as_dict()).encode()
+        manifest_digest = f'sha256:{hashlib.sha256(manifest_bytes).hexdigest()}'
+        logger.info(f'pushing standalone SBOM manifest to {repo_ref}@{manifest_digest}')
+        oci_client.put_manifest(
+            image_reference=f'{repo_ref}@{manifest_digest}',
+            manifest=manifest_bytes,
+        )
+        digests.append(manifest_digest)
+    return digests[0], digests[1]
+
+
+def lookup_sbom_standalone(
+    repo_ref: str,
+    spdx_manifest_digest: str,
+    cdx_manifest_digest: str,
+    oci_client: oc.Client,
+) -> tuple[bytes, bytes] | None:
+    '''
+    Check whether standalone SBOM manifests already exist in the registry.
+
+    Returns (spdx_bytes, cdx_bytes) if both are present, otherwise None.
+    The digests come from the synthetic OCI ref built from the S3 content hash.
+    '''
+    try:
+        spdx_manifest_bytes = oci_client.manifest_raw(
+            f'{repo_ref}@{spdx_manifest_digest}',
+            absent_ok=True,
+        )
+        cdx_manifest_bytes = oci_client.manifest_raw(
+            f'{repo_ref}@{cdx_manifest_digest}',
+            absent_ok=True,
+        )
+    except Exception:  # nosec B110
+        return None
+
+    if spdx_manifest_bytes is None or cdx_manifest_bytes is None:
+        return None
+
+    def _get_layer_blob(manifest_bytes_resp, repo) -> bytes:
+        m = json.loads(manifest_bytes_resp.content)
+        blob_digest = m['layers'][0]['digest']
+        return oci_client.blob(image_reference=repo, digest=blob_digest).content
+
+    try:
+        spdx_bytes = _get_layer_blob(spdx_manifest_bytes, repo_ref)
+        cdx_bytes = _get_layer_blob(cdx_manifest_bytes, repo_ref)
+        return spdx_bytes, cdx_bytes
+    except Exception as e:
+        logger.warning(f'failed to fetch existing standalone SBOM blobs from {repo_ref}: {e}')
+        return None
+
+
 def _utcnow_iso() -> str:
     import datetime
     return datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/sbom/s3.py
+++ b/sbom/s3.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Minimal S3 download helper for public buckets (no auth required).
+
+Only uses stdlib — no boto3/botocore dependency.  Virtual-hosted-style URLs are used when a
+region is known; path-style (us-east-1 endpoint) is used as fallback and lets AWS redirect.
+'''
+import urllib.error
+import urllib.request
+
+
+def s3_url(bucket: str, key: str, region: str | None = None) -> str:
+    '''Return the HTTPS URL for a public S3 object.'''
+    if region:
+        return f'https://{bucket}.s3.{region}.amazonaws.com/{key}'
+    return f'https://{bucket}.s3.amazonaws.com/{key}'
+
+
+def iter_s3_object(
+    bucket: str,
+    key: str,
+    region: str | None = None,
+    chunk_size: int = 65536,
+):
+    '''
+    Stream a public S3 object, yielding chunks of bytes.
+
+    Follows redirects (e.g. region-correction from us-east-1 endpoint).
+    Raises urllib.error.HTTPError on non-200 responses.
+    '''
+    url = s3_url(bucket, key, region)
+    with urllib.request.urlopen(url) as resp:  # nosec B310
+        while True:
+            chunk = resp.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+
+def mangle_s3_path(s: str) -> str:
+    '''
+    Mangle an S3 bucket name or object key into a string safe for use in an OCI repository path.
+
+    Replaces characters not in [a-z0-9._-] with underscores; collapses consecutive underscores.
+    '''
+    import re
+    return re.sub(r'_+', '_', re.sub(r'[^a-z0-9._-]', '_', s.lower())).strip('_')
+
+
+def synthetic_oci_ref(
+    registry_base: str,
+    bucket: str,
+    key: str,
+    content_digest: str,
+) -> str:
+    '''
+    Build a stable synthetic OCI reference for an S3 object.
+
+    Convention:
+      <registry_base>/sbom-s3/<mangled-bucket>/<mangled-key>@<content_digest>
+
+    The digest component makes the reference content-addressable, enabling cache lookups via
+    sbom.inject.lookup_sbom_referrers without re-downloading.
+    '''
+    mangled_bucket = mangle_s3_path(bucket)
+    # key may have directory components — replace slashes separately to keep structure
+    mangled_key = '/'.join(mangle_s3_path(p) for p in key.split('/') if p)
+    registry_base = registry_base.rstrip('/')
+    return f'{registry_base}/sbom-s3/{mangled_bucket}/{mangled_key}@{content_digest}'

--- a/test/sbom/s3_test.py
+++ b/test/sbom/s3_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''Unit tests for sbom.s3 and related helpers.'''
+import pytest
+
+import sbom.s3 as ss3
+
+
+def test_s3_url_with_region():
+    assert ss3.s3_url('my-bucket', 'path/to/key', 'eu-west-1') == (
+        'https://my-bucket.s3.eu-west-1.amazonaws.com/path/to/key'
+    )
+
+
+def test_s3_url_without_region():
+    assert ss3.s3_url('my-bucket', 'some/key') == (
+        'https://my-bucket.s3.amazonaws.com/some/key'
+    )
+
+
+def test_iter_s3_object(monkeypatch):
+    payload = b'hello world' * 1000
+    import unittest.mock as mock
+
+    fake_resp = mock.MagicMock()
+    fake_resp.__enter__ = lambda s: s
+    fake_resp.__exit__ = mock.MagicMock(return_value=False)
+    fake_resp.read = mock.MagicMock(side_effect=[
+        payload[:4096], payload[4096:], b'',
+    ])
+
+    with mock.patch('urllib.request.urlopen', return_value=fake_resp):
+        chunks = list(ss3.iter_s3_object('bucket', 'key'))
+    assert b''.join(chunks) == payload[:4096] + payload[4096:]
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('my-bucket',      'my-bucket'),
+    ('MY_BUCKET',      'my_bucket'),
+    ('a/b/c',          'a_b_c'),
+    ('foo--bar',       'foo--bar'),
+    ('foo__bar',       'foo_bar'),       # consecutive underscores collapsed
+    ('foo/BAR/baz',    'foo_bar_baz'),
+    ('hello.world',    'hello.world'),
+    ('.leading',       '.leading'),      # dots are valid OCI path chars; kept as-is
+    ('trailing.',      'trailing.'),
+])
+def test_mangle_s3_path(s, expected):
+    assert ss3.mangle_s3_path(s) == expected
+
+
+def test_synthetic_oci_ref_structure():
+    ref = ss3.synthetic_oci_ref(
+        registry_base='europe-docker.pkg.dev/gardener-project/snapshots',
+        bucket='gardenlinux-github-releases',
+        key='releases/1337.0/amd64-gcp.tar.gz',
+        content_digest='sha256:abcdef1234',
+    )
+    assert ref.startswith('europe-docker.pkg.dev/gardener-project/snapshots/sbom-s3/')
+    assert 'gardenlinux-github-releases' in ref
+    assert '@sha256:abcdef1234' in ref
+
+
+def test_synthetic_oci_ref_no_double_slash():
+    ref = ss3.synthetic_oci_ref(
+        registry_base='europe-docker.pkg.dev/foo/',   # trailing slash
+        bucket='b',
+        key='k',
+        content_digest='sha256:ff',
+    )
+    assert '//' not in ref
+
+
+def test_synthetic_oci_ref_repo_split():
+    ref = ss3.synthetic_oci_ref(
+        registry_base='registry.example.com/base',
+        bucket='bucket',
+        key='some/object/key.tar.gz',
+        content_digest='sha256:0011',
+    )
+    repo_ref, digest = ref.split('@')
+    assert digest == 'sha256:0011'
+    assert repo_ref.startswith('registry.example.com/base/sbom-s3/')
+    # no '@' in the repo part
+    assert '@' not in repo_ref

--- a/test/sbom/upload_fmt_test.py
+++ b/test/sbom/upload_fmt_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''Unit tests for upload.py _fmt_id / _filename for CBOM resources.'''
+import importlib.util
+import os
+
+import ocm
+import sbom.iter as si
+import sbom.oci as soci
+
+
+def _make_sbom_resource(extra_identity: dict) -> ocm.Resource:
+    return ocm.Resource(
+        name='some-image',
+        version='v1.0.0',
+        type=soci.CYCLONEDX_JSON_MEDIA_TYPE,
+        relation=ocm.ResourceRelation.EXTERNAL,
+        extraIdentity=extra_identity,
+        access=ocm.OciAccess(imageReference='registry.example.com/repo@sha256:ff'),
+    )
+
+
+def _make_mapping(resource: ocm.Resource) -> si.SbomMapping:
+    component = ocm.Component(
+        name='github.com/foo/bar',
+        version='v1',
+        repositoryContexts=[],
+        provider='test',
+        sources=[],
+        componentReferences=[],
+        resources=[],
+    )
+    return si.SbomMapping(
+        source=si.SbomSource.OCM,
+        component=component,
+        resource=resource,
+        sbom=resource,
+    )
+
+
+# import the functions under test from the action script
+_upload_py = os.path.join(
+    os.path.dirname(__file__),
+    '../../.github/actions/sbom-upload/upload.py',
+)
+_spec = importlib.util.spec_from_file_location('upload', _upload_py)
+_upload = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_upload)
+_fmt_id = _upload._fmt_id
+_filename = _upload._filename
+
+
+def test_fmt_id_sbom():
+    r = _make_sbom_resource({'sbom-format': 'spdx-2.3', 'version': 'v1.0.0'})
+    m = _make_mapping(r)
+    assert _fmt_id(m) == 'spdx-2.3'
+
+
+def test_fmt_id_cyclonedx():
+    r = _make_sbom_resource({'sbom-format': 'cyclonedx-1.6', 'version': 'v1.0.0'})
+    m = _make_mapping(r)
+    assert _fmt_id(m) == 'cyclonedx-1.6'
+
+
+def test_fmt_id_cbom():
+    r = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6', 'version': 'v1.0.0'})
+    m = _make_mapping(r)
+    assert _fmt_id(m) == 'cbom-cyclonedx-1.6'
+
+
+def test_fmt_id_neither_returns_none():
+    r = _make_sbom_resource({'version': 'v1.0.0'})
+    m = _make_mapping(r)
+    assert _fmt_id(m) is None
+
+
+def test_filename_excludes_cbom_format_key():
+    component = ocm.Component(
+        name='github.com/foo/bar',
+        version='v1',
+        repositoryContexts=[],
+        provider='test',
+        sources=[],
+        componentReferences=[],
+        resources=[],
+    )
+    resource = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6', 'version': 'v1.0.0'})
+    name = _filename(component, resource, 'cbom-cyclonedx-1.6')
+    # should not contain 'cyclonedx-1.6' twice (the format value should not appear in name)
+    assert name.count('cyclonedx-1.6') == 1
+    assert name.endswith('.sbom.cbom-cyclonedx-1.6')
+
+
+def test_filename_excludes_sbom_format_key():
+    component = ocm.Component(
+        name='github.com/foo/bar',
+        version='v1',
+        repositoryContexts=[],
+        provider='test',
+        sources=[],
+        componentReferences=[],
+        resources=[],
+    )
+    resource = _make_sbom_resource({'sbom-format': 'spdx-2.3', 'version': 'v1.0.0'})
+    name = _filename(component, resource, 'spdx-2.3')
+    assert name.endswith('.sbom.spdx-2.3')
+    assert name.count('spdx-2.3') == 1


### PR DESCRIPTION
## Summary

- `sbom/s3.py`: public S3 download helper (no boto3)
- `sbom/oci.py`: standalone OCI manifest push for non-referrer SBOM storage
- `sbom/inject.py`: `scan_s3_resource`, `build_s3_sbom_ocm_resources`
- `ctt`: `inject_s3_sboms` flag + S3 injection loop in `process_replication_plan_step`
- `upload.py`: `_fmt_id`/`_filename` handle `cbom-format` extraIdentity key
- `sbom/iter.py`: exclude `cbom-format` from `source_extra` filter
- task specs in `sbom-tasks.d/`, unit tests in `test/sbom/`