### PR TITLE
pin: update stale internal refs when dep gets a new pinned SHA

### DIFF
--- a/.github/actions/pin-actions-and-workflows/pin.py
+++ b/.github/actions/pin-actions-and-workflows/pin.py
@@ -189,7 +189,7 @@ def _extract_internal_deps(
         if '@' not in after_repo:
             continue
         dep_prefix, ref = after_repo.rsplit('@', 1)
-        if not _is_pinned(ref, repo) and dep_prefix in known_prefixes:
+        if dep_prefix in known_prefixes:
             yield dep_prefix
 
 
@@ -296,11 +296,17 @@ def _rewrite_parsed(
             continue
         dep_prefix, ref = after_repo.rsplit('@', 1)
         if _is_pinned(ref, repo):
-            continue
-        digest = prefix_to_digest.get(dep_prefix)
-        if digest is None:
-            logger.warning('No pinned digest found for %s — leaving unchanged', dep_prefix)
-            continue
+            # For internal deps: update if a newer digest is available; otherwise skip.
+            # For external deps: prefix_to_digest has no entry, so we skip correctly.
+            new_digest = prefix_to_digest.get(dep_prefix)
+            if new_digest is None or new_digest == ref:
+                continue
+            digest = new_digest
+        else:
+            digest = prefix_to_digest.get(dep_prefix)
+            if digest is None:
+                logger.warning('No pinned digest found for %s — leaving unchanged', dep_prefix)
+                continue
         step[key] = f'{own_prefix}{dep_prefix}@{digest}'
         changed = True
 

--- a/test/actions/pin-actions-and-workflows/test_pin.py
+++ b/test/actions/pin-actions-and-workflows/test_pin.py
@@ -20,6 +20,7 @@ import pin
 
 
 _SHA = 'a' * 40
+_SHA2 = 'b' * 40
 _ORG = 'myorg'
 _REPO = 'myrepo'
 _OWN_PREFIX = f'{_ORG}/{_REPO}/'
@@ -52,7 +53,8 @@ def test_rewrite_unpinned_ref():
     assert uses == f'{_OWN_PREFIX}{dep_prefix}@{_SHA}'
 
 
-def test_already_pinned_ref_unchanged():
+def test_already_pinned_ref_at_current_sha_unchanged():
+    '''A pinned internal ref already at the current digest must not be touched.'''
     dep_prefix = '.github/actions/foo'
     original_uses = f'{_OWN_PREFIX}{dep_prefix}@{_SHA}'
     parsed = _make_parsed(original_uses)
@@ -62,16 +64,61 @@ def test_already_pinned_ref_unchanged():
             parsed,
             own_org=_ORG,
             own_repo=_REPO,
-            prefix_to_digest={dep_prefix: 'b' * 40},
+            prefix_to_digest={dep_prefix: _SHA},  # same SHA — already current
             repo=None,
         )
 
     assert not changed
-    uses = parsed['runs']['steps'][0]['uses']
-    assert uses == original_uses
+    assert parsed['runs']['steps'][0]['uses'] == original_uses
 
 
-def test_extract_internal_deps_finds_dep():
+def test_stale_pinned_internal_ref_is_updated():
+    '''
+    Regression: if a caller already has a pinned SHA for an internal dep, but that
+    dep has since been updated (new SHA in prefix_to_digest), the caller must be
+    rewritten to the new SHA.  Previously _rewrite_parsed skipped all pinned refs
+    unconditionally, leaving callers pointing at stale SHAs.
+    '''
+    dep_prefix = '.github/actions/foo'
+    old_sha = _SHA
+    new_sha = _SHA2
+    parsed = _make_parsed(f'{_OWN_PREFIX}{dep_prefix}@{old_sha}')
+
+    # old_sha is a valid/existing commit (pinned), new_sha is the updated digest
+    def _is_pinned_side_effect(ref, repo):
+        return ref == old_sha
+
+    with unittest.mock.patch('pin._is_pinned', side_effect=_is_pinned_side_effect):
+        changed = pin._rewrite_parsed(
+            parsed,
+            own_org=_ORG,
+            own_repo=_REPO,
+            prefix_to_digest={dep_prefix: new_sha},
+            repo=None,
+        )
+
+    assert changed, 'stale pinned internal ref should have been updated'
+    assert parsed['runs']['steps'][0]['uses'] == f'{_OWN_PREFIX}{dep_prefix}@{new_sha}'
+
+
+def test_stale_pinned_external_ref_not_touched():
+    '''External (non-own-repo) pinned refs must never be rewritten.'''
+    parsed = _make_parsed(f'actions/checkout@{_SHA}')
+
+    with unittest.mock.patch('pin._is_pinned', return_value=True):
+        changed = pin._rewrite_parsed(
+            parsed,
+            own_org=_ORG,
+            own_repo=_REPO,
+            prefix_to_digest={},
+            repo=None,
+        )
+
+    assert not changed
+    assert parsed['runs']['steps'][0]['uses'] == f'actions/checkout@{_SHA}'
+
+
+def test_extract_internal_deps_finds_unpinned_dep():
     dep_prefix = '.github/actions/bar'
     parsed = _make_parsed(f'{_OWN_PREFIX}{dep_prefix}@master')
 
@@ -85,3 +132,26 @@ def test_extract_internal_deps_finds_dep():
         ))
 
     assert deps == [dep_prefix]
+
+
+def test_extract_internal_deps_finds_pinned_dep():
+    '''
+    Regression: internal deps referenced via an already-pinned SHA must still be
+    included in the dependency graph so topological ordering is correct and
+    _rewrite_parsed gets a chance to update them.
+    '''
+    dep_prefix = '.github/actions/bar'
+    parsed = _make_parsed(f'{_OWN_PREFIX}{dep_prefix}@{_SHA}')
+
+    with unittest.mock.patch('pin._is_pinned', return_value=True):
+        deps = list(pin._extract_internal_deps(
+            parsed,
+            own_org=_ORG,
+            own_repo=_REPO,
+            known_prefixes={dep_prefix},
+            repo=None,
+        ))
+
+    assert deps == [dep_prefix], (
+        'pinned internal dep must be included in graph so callers are updated when dep changes'
+    )


### PR DESCRIPTION
## Problem

When an internal action/workflow changes on master and gets a new pinned SHA
on v1, any callers that already hold a pinned SHA for that dep are silently
left pointing at the old (stale) SHA.

Root cause: `_rewrite_parsed` skipped **all** already-pinned refs
unconditionally (`if _is_pinned(ref): continue`), and `_extract_internal_deps`
excluded them from the dependency graph entirely.  So the topological walk
never revisited a caller once its dep ref appeared to be "already pinned".

This is latent whenever the source passed to the pinner (`refs/capture-commit`
for releases) contains workflow files that were bootstrapped from a prior v1 —
which is exactly the normal case.  It manifested when `merge-ocm-fragments`
had its cbomkit-theia install fixed mid-release-cycle: the action itself got a
new pin commit on v1, but `release.yaml` / `post-build.yaml` etc. were left
pointing at the pre-fix SHA.

## Fix

Two targeted changes in `pin.py`:

- **`_extract_internal_deps`**: always yield internal deps regardless of
  whether the current ref is already pinned, so the topological sort is
  correct even when callers carry pinned SHAs.
- **`_rewrite_parsed`**: when a ref is already pinned, check whether
  `prefix_to_digest` holds a *different* (newer) digest for that dep and
  update if so; external deps (not in `prefix_to_digest`) are left untouched.

## Tests

Two regression tests added:
- `test_stale_pinned_internal_ref_is_updated` — verifies the rewrite happens
- `test_extract_internal_deps_finds_pinned_dep` — verifies graph inclusion

Plus a corrected existing test (`test_already_pinned_ref_unchanged` →
`test_already_pinned_ref_at_current_sha_unchanged`) that now correctly asserts
no change only when the SHA is already current, not when it differs.