### PR TITLE
fix: replace all pinned internal refs with @master; enforce via test

### DIFF
--- a/.github/actions/base-component-descriptor/action.yaml
+++ b/.github/actions/base-component-descriptor/action.yaml
@@ -87,7 +87,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: base-component-descriptor
       id: base-component-descriptor
       shell: python
@@ -238,7 +238,7 @@ runs:
             ```
             </details>
           '''))
-    - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
         name: base-component-descriptor
         path: component-descriptor.tar.gz

--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -149,7 +149,7 @@ runs:
 
         gzip ${objects_out}
       shell: bash
-    - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       if: ${{ inputs.to-artefact != '' }}
       with:
         name: ${{ inputs.to-artefact }}

--- a/.github/actions/component-diff/action.yaml
+++ b/.github/actions/component-diff/action.yaml
@@ -40,13 +40,13 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
-    - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+    - uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.ocm-repositories }} # only the first entry will be used
     - name: download-component-descriptor-artifact
       if: ${{ inputs.component-descriptor-artifact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artifact }}
         path: /tmp/cd-artifact

--- a/.github/actions/draft-release/action.yaml
+++ b/.github/actions/draft-release/action.yaml
@@ -17,10 +17,10 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
 
     - name: fetch-release-notes
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: release-notes
         path: /tmp

--- a/.github/actions/export-ocm-fragments/action.yaml
+++ b/.github/actions/export-ocm-fragments/action.yaml
@@ -94,7 +94,7 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: preprocess
       shell: bash
       run: |
@@ -232,7 +232,7 @@ runs:
           f.write(f'artefact-tarfile={ocm_tar_outfname}\n')
 
     - name: upload-ocm-fragments-artefact
-      uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
         name: ${{ steps.merge.outputs.artefact-name }}
         path: ${{ steps.merge.outputs.artefact-tarfile }}

--- a/.github/actions/helmchart/action.yaml
+++ b/.github/actions/helmchart/action.yaml
@@ -98,11 +98,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - uses: azure/setup-helm@v4
     - name: download-component-descriptor-artifact
       if: ${{ inputs.component-descriptor-artifact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artifact }}
         path: /tmp/cd-artifact
@@ -128,7 +128,7 @@ runs:
         EOF
     - name: authenticate
       if: ${{ inputs.push == 'true' }}
-      uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.oci-registry }}
         gh-token: ${{ inputs.gh-token }}
@@ -290,7 +290,7 @@ runs:
           )
 
     - name: export-ocm-fragments
-      uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+      uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
       with:
         ocm-resources-file: ocm-resources.yaml
         blobs-directory: blobs.d

--- a/.github/actions/import-commit/action.yaml
+++ b/.github/actions/import-commit/action.yaml
@@ -77,7 +77,7 @@ runs:
         echo "${{ inputs.commit-objects }}" | base64 -d | tar x -C "${GITHUB_WORKSPACE}"
     - name: import-commit-objects-from-artefact
       if: ${{ inputs.commit-objects-artefact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.commit-objects-artefact }}
     - name: extract-commit-objects-from-artefact

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -122,7 +122,7 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: preprocess
       id: preprocess
       shell: bash
@@ -144,7 +144,7 @@ runs:
         EOF
     - name: import-component-descriptor-artefact
       if: ${{ inputs.component-descriptor-artefact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artefact }}
     - name: extract-component-descriptor-artefact
@@ -176,7 +176,7 @@ runs:
            --out "${component_descriptor}"
         fi
     - name: import-ocm-fragments
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         pattern: ${{ steps.preprocess.outputs.artefact-name }}
         path: ${{ inputs.outdir }}
@@ -220,7 +220,7 @@ runs:
           f.write(f'component-version={name}:{version}\n')
 
     - name: checkout-for-postprocessing
-      uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       if: ${{ inputs.post-process == 'component-cli' }}
       with:
         path: repo.d # avoid conflicts w/ component-descriptor
@@ -333,7 +333,7 @@ runs:
 
     - name: authenticate-for-spdx
       if: ${{ inputs.oci-registry != '' }}
-      uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.oci-registry }}
         gh-token: ${{ github.token }}
@@ -365,7 +365,7 @@ runs:
         set -eu
         tar czf /tmp/component-descriptor.tar.gz \
           -C "${{ inputs.outdir }}" component-descriptor.yaml
-    - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
         name: merged-component-descriptor
         path: /tmp/component-descriptor.tar.gz

--- a/.github/actions/oci-auth/action.yaml
+++ b/.github/actions/oci-auth/action.yaml
@@ -56,7 +56,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: OCI Auth
       id: oci-auth
       shell: python

--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -107,14 +107,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - uses: actions/checkout@v6
       with:
         token: ${{ inputs.github-token }}
-    - uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+    - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
     - name: download-component-descriptor-artifact
       if: ${{ inputs.component-descriptor-artifact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artifact }}
         path: /tmp/cd-artifact
@@ -153,7 +153,7 @@ runs:
       if: ${{ inputs.prepare-action-path != '' }}
       uses: ./../prepare-action
     - name: authenticate-against-oci-registry
-      uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.ocm-repositories }} # only the first entry will be used
         gh-token: ${{ github.server_url == 'https://github.com' && inputs.github-token || '' }} # only try to authenticate for gh-com

--- a/.github/actions/ocm-validate/action.yaml
+++ b/.github/actions/ocm-validate/action.yaml
@@ -59,7 +59,7 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: validate-component-descriptor
       id: val
       shell: python

--- a/.github/actions/params/action.yaml
+++ b/.github/actions/params/action.yaml
@@ -107,7 +107,7 @@ runs:
   using: composite
   steps:
     - id: repo-metadata
-      uses: gardener/cc-utils/.github/actions/repo-metadata@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/repo-metadata@master
       with:
         gh-token: ${{ inputs.gh-token }}
     - name: params

--- a/.github/actions/pin-actions-and-workflows/action.yaml
+++ b/.github/actions/pin-actions-and-workflows/action.yaml
@@ -73,12 +73,12 @@ runs:
 
     - name: import-release-commit
       if: ${{ inputs.release-commit-objects-artefact != '' }}
-      uses: gardener/cc-utils/.github/actions/import-commit@1e9411318ed25b64b49a68b609f8822b495f27b0
+      uses: gardener/cc-utils/.github/actions/import-commit@master
       with:
         commit-objects-artefact: ${{ inputs.release-commit-objects-artefact }}
         after-import: noop
 
-    - uses: gardener/cc-utils/.github/actions/bundle-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/bundle-gardener-gha-libs@master
       id: bundle
 
     - name: pin

--- a/.github/actions/pullrequest-trust-helper/action.yaml
+++ b/.github/actions/pullrequest-trust-helper/action.yaml
@@ -31,7 +31,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: check-event
       id: check
       shell: python

--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -71,21 +71,21 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: checkout
       uses: actions/checkout@v6
       with:
         fetch-depth: 0 # release-notes code needs full commit-history and tags
         fetch-tags: 0
-    - uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+    - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
     - name: authenticate-against-oci-registry
-      uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ inputs.ocm-repositories }} # only the first entry will be used
 
     - name: download-component-descriptor-artifact
       if: ${{ inputs.component-descriptor-artifact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artifact }}
         path: /tmp/cd-artifact
@@ -167,7 +167,7 @@ runs:
         echo '## Release-Notes (local)' >> ${GITHUB_STEP_SUMMARY}
         cat local-release-notes.md >> ${GITHUB_STEP_SUMMARY}
 
-    - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
         name: release-notes
         path: release-notes.tar

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -194,13 +194,13 @@ runs:
   using: composite
   steps:
     - name: install-gardener-gha-libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - uses: actions/checkout@v6
       with:
         token: ${{ inputs.git-push-token || inputs.github-token }}
     - name: download-component-descriptor-artifact
       if: ${{ inputs.component-descriptor-artifact != '' }}
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.component-descriptor-artifact }}
         path: /tmp/cd-artifact
@@ -212,13 +212,13 @@ runs:
         tar xf /tmp/cd-artifact/component-descriptor.tar.gz \
           -C /tmp component-descriptor.yaml
     - name: import-release-commit
-      uses: gardener/cc-utils/.github/actions/import-commit@1e9411318ed25b64b49a68b609f8822b495f27b0
+      uses: gardener/cc-utils/.github/actions/import-commit@master
       with:
         commit-objects-artefact: ${{ inputs.release-commit-objects-artefact }}
         commit-objects: ${{ inputs.release-commit-objects }}
         commit-digest: ${{ inputs.release-commit-digest }}
         after-import: rebase
-    - uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+    - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
     - name: write-component-descriptor-from-input
       if: ${{ inputs.component-descriptor-artifact == '' }}
       shell: bash
@@ -247,7 +247,7 @@ runs:
         EOF
 
     - name: fetch-prepare-values
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: prepare-workflow-values
 
@@ -261,13 +261,13 @@ runs:
         echo "ocm-repositories=${ocm_repositories}" >> ${GITHUB_OUTPUT}
 
     - name: authenticate-against-oci-registry
-      uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      uses: gardener/cc-utils/.github/actions/oci-auth@master
       with:
         oci-image-reference: ${{ steps.read-ocm-repositories.outputs.ocm-repositories }}
         gh-token: ${{ inputs.github-token }}
 
     - name: fetch-release-notes
-      uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: release-notes
         path: /tmp
@@ -358,7 +358,7 @@ runs:
             stream=f,
           )
     - name: validate OCM Component-Descriptor
-      uses: gardener/cc-utils/.github/actions/ocm-validate@bd5413249d8bd1ba47a790ac6b639b1ae5af870d
+      uses: gardener/cc-utils/.github/actions/ocm-validate@master
       with:
         component-descriptor-path: /tmp/component-descriptor.yaml
         on-validation-errors: ${{ inputs.on-validation-errors }}
@@ -378,7 +378,7 @@ runs:
         tar czf /tmp/component-descriptor.tar.gz -C/tmp component-descriptor.yaml
 
     - name: upload OCM Component-Descriptor as artifact
-      uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
         path: /tmp/component-descriptor.tar.gz
         name: component-descriptor
@@ -573,7 +573,7 @@ runs:
 
     - name: create-bump-commit
       id: bump
-      uses: gardener/cc-utils/.github/actions/version@c0de0b1905aed54005f1f6c56fb42e3342736c8c
+      uses: gardener/cc-utils/.github/actions/version@master
       # must be kept in sync with version action called in release workflow (except "version-operation")
       with:
         versionfile: ${{ inputs.version-versionfile }}

--- a/.github/actions/sbom-upload/action.yaml
+++ b/.github/actions/sbom-upload/action.yaml
@@ -146,7 +146,7 @@ runs:
 
     - name: Install gardener-gha-libs
       if: steps.check-status.outputs.already-released != 'true'
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
 
     - name: Upload SBOMs
       if: steps.check-status.outputs.already-released != 'true'

--- a/.github/actions/setup-testrunner/action.yaml
+++ b/.github/actions/setup-testrunner/action.yaml
@@ -17,7 +17,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: install-testrunner
       id: install
       shell: bash

--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -158,7 +158,7 @@ runs:
         fi
 
     - name: create-token-via-federated-github-access-token-server
-      uses: gardener/cc-utils/.github/actions/github-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/github-auth@master
       if: ${{ inputs.token-server != '' }}
       id: fed-token
       with:
@@ -330,7 +330,7 @@ runs:
           check=True,
         )
     - if: ${{ steps.calc.outputs.remove-label }}
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: remove-trusted-label
       if: ${{ steps.calc.outputs.remove-label != '' && inputs.remove-trusted-label == 'true' }}
       shell: python
@@ -359,6 +359,6 @@ runs:
           # is an expected, and of course, acceptable case
           exit(0)
     - if: ${{ inputs.init-git-identity == 'true' }}
-      uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+      uses: gardener/cc-utils/.github/actions/setup-git-identity@master
       with:
         scope: ${{ inputs.path || '.' }}/.git/config

--- a/.github/actions/update-extension-provider-images/action.yaml
+++ b/.github/actions/update-extension-provider-images/action.yaml
@@ -33,7 +33,7 @@ runs:
         fi
 
     - name: Install Gardener GHA Libs
-      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
 
     - name: Run image update script
       id: run_script_step

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -171,8 +171,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
-    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+    - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
+    - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
     - name: calculate-version
       id: calc-version
       shell: bash
@@ -256,7 +256,7 @@ runs:
 
     - name: capture-commit
       id: capture-commit
-      uses: gardener/cc-utils/.github/actions/capture-commit@386a57fa61c7c341a2d6ff507ab863462d702bbc
+      uses: gardener/cc-utils/.github/actions/capture-commit@master
       with:
         timestamp-reference: /tmp/timestamp-ref
         to-artefact: ${{ inputs.commit-objects-artefact }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -163,11 +163,11 @@ jobs:
           find "${pkg_dir}"
           tar czf distribution-packages.tar.gz dist
       - name: export-ocm-fragments
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           ocm-resources-file: dist/ocm_resources.yaml
           blobs-directory: dist/blobs.d
-      - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/upload-artifact@master
         with:
           name: distribution-packages
           path: distribution-packages.tar.gz
@@ -182,7 +182,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Retrieve Distribution Packages
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: distribution-packages
       - name: lint
@@ -246,7 +246,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Retrieve Distribution Packages
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: distribution-packages
       - name: run-tests
@@ -299,7 +299,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
       - name: run
@@ -310,7 +310,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
       - name: install-act
@@ -337,7 +337,7 @@ jobs:
           mkdir documentation-out.d
           GH_PAGES_PATH=$PWD/documentation-out.d .ci/generate_documentation
           ls documentation-out.d
-      - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/upload-artifact@master
         with:
           name: documentation
           path: documentation-out.d
@@ -358,11 +358,11 @@ jobs:
         with:
           ref: refs/heads/gh-pages
       - name: Retrieve Documentation
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: documentation
           path: /tmp/documentation-out.d
-      - uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+      - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
       - name: Publish Documentation
         run: |
           tar c -C /tmp/documentation-out.d . | tar x -C.
@@ -385,10 +385,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
-      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: install-syft
         shell: bash
         run: |
@@ -399,7 +399,7 @@ jobs:
           echo "${install_dir}" >> "${GITHUB_PATH}"
       - name: install-cbomkit-theia
         uses: ./.github/actions/install-cbomkit-theia
-      - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
         with:
           oci-image-reference: ${{ needs.prepare.outputs.oci-registry }}
           gh-token: ${{ github.token }}
@@ -422,10 +422,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
-      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: install-syft
         shell: bash
         run: |
@@ -436,7 +436,7 @@ jobs:
           echo "${install_dir}" >> "${GITHUB_PATH}"
       - name: install-cbomkit-theia
         uses: ./.github/actions/install-cbomkit-theia
-      - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
         with:
           oci-image-reference: ${{ needs.prepare.outputs.oci-registry }}
           gh-token: ${{ github.token }}

--- a/.github/workflows/component-diff.yaml
+++ b/.github/workflows/component-diff.yaml
@@ -41,12 +41,12 @@ jobs:
       - uses: actions/checkout@v6
       - name: collect-component-descriptor
         id: component-descriptor
-        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@95afc05821b176da01a01147082eed3c969522a7
+        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@master
         with:
           component-descriptor-artefact: base-component-descriptor
       - name: fetch-prepare-values
         if: ${{ inputs.ocm-repositories == '' }}
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: prepare-prepare-workflow-values
@@ -60,7 +60,7 @@ jobs:
             ocm_repositories="${{ inputs.ocm-repositories }}"
           fi
           echo "ocm-repositories=${ocm_repositories}" >> ${GITHUB_OUTPUT}
-      - uses: gardener/cc-utils/.github/actions/component-diff@0293f4db0aed454dfc32c8efd040045b9e8db59b
+      - uses: gardener/cc-utils/.github/actions/component-diff@master
         id: component-diff
         with:
           component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}

--- a/.github/workflows/helmchart-ocm.yaml
+++ b/.github/workflows/helmchart-ocm.yaml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: retrieve-params
         if: ${{ inputs.push == 'if-possible' }}
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: check-params
@@ -146,16 +146,16 @@ jobs:
 
       - name: fetch-ocm-fragments
         id: fetch-ocm
-        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@95afc05821b176da01a01147082eed3c969522a7
+        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@master
         with:
           component-descriptor: ${{ inputs.component-descriptor }}
           component-descriptor-artefact: base-component-descriptor
           ctx: ${{ inputs.ocm-ctx }}
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
       - name: build-helmchart
-        uses: gardener/cc-utils/.github/actions/helmchart@6d50f2102d34c3a7ffd316a43b57388782b59318
+        uses: gardener/cc-utils/.github/actions/helmchart@master
         with:
           name: ${{ inputs.name }}
           dir: ${{ inputs.dir }}

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -264,7 +264,7 @@ jobs:
     steps:
       - name: retrieve-params
         if: ${{ inputs.push == 'if-possible' }}
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: check-params
@@ -439,24 +439,24 @@ jobs:
             cat /tmp/config.json >> "${GITHUB_OUTPUT}"
           fi
           echo EOF >> "${GITHUB_OUTPUT}"
-      - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
         continue-on-error: true # successful auth might not be required
         with:
           oci-image-reference: ${{ matrix.args.image-reference }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
       - name: import-release-commit
         if: ${{ inputs.commit-objects-artefact != '' }}
-        uses: gardener/cc-utils/.github/actions/import-commit@1e9411318ed25b64b49a68b609f8822b495f27b0
+        uses: gardener/cc-utils/.github/actions/import-commit@master
         with:
           commit-objects-artefact: ${{ inputs.commit-objects-artefact }}
           after-import: rebase
       - name: retrieve build-ctx-artefact
         if: ${{ matrix.args.build-artefact != '' }}
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: ${{ matrix.args.build-artefact }}
           merge-multiple: true
@@ -494,7 +494,7 @@ jobs:
         with:
           image-reference: ${{ matrix.args.image-reference }}
 
-      - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
         if: ${{ needs.preprocess.outputs.push == 'true' }}
         with:
           oci-image-reference: ${{ matrix.args.image-reference }}
@@ -521,7 +521,7 @@ jobs:
 
       - name: 'install cbomkit-theia / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
-        uses: gardener/cc-utils/.github/actions/install-cbomkit-theia@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/install-cbomkit-theia@master
 
       - name: 'generate SBOM / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
@@ -546,7 +546,7 @@ jobs:
           version="$(cbomkit-theia version 2>/dev/null | awk '{print $NF}' || true)"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
-      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
 
       - name: 'push SBOM referrers / ${{ matrix.args.platform-name }}'
@@ -692,7 +692,7 @@ jobs:
 
       - name: 'export SBOM OCM fragments / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           ocm-resources-file: sbom-ocm-resources.yaml
           blobs-directory: blobs.d
@@ -790,7 +790,7 @@ jobs:
 
       - name: 'export CBOM OCM fragments / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           ocm-resources-file: cbom-ocm-resources.yaml
           blobs-directory: blobs.d
@@ -810,7 +810,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: inject-authtoken
         id: extra-auth
         shell: bash
@@ -823,7 +823,7 @@ jobs:
           hostname=$(echo ${{ needs.preprocess.outputs.target-image-ref }} | cut -d/ -f1 )
           echo "extra-auths={\"$hostname\": {\"auth\": \"${{ secrets.auth-token }}\" }}" \
             >> $GITHUB_OUTPUT
-      - uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
         if: ${{ needs.preprocess.outputs.push == 'true' }}
         with:
           oci-image-reference: ${{ needs.preprocess.outputs.target-image-ref }}
@@ -935,7 +935,7 @@ jobs:
             '''))
       - name: export-ocm-fragments
         if: ${{ !inputs.omit-ocm-fragment }}
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           ocm-resources: ${{ steps.collect-images.outputs.ocm-resource }}
           ctx: ${{ inputs.ctx }}

--- a/.github/workflows/pin-actions-and-workflows.yaml
+++ b/.github/workflows/pin-actions-and-workflows.yaml
@@ -50,7 +50,7 @@ jobs:
       contents: write  # required to push the target branch and preservation refs
       id-token: write  # required for OIDC federated token exchange
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           fetch-depth: 0  # full history required for git worktree operations
           token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}
@@ -60,7 +60,7 @@ jobs:
             workflows: write
 
       - name: pin-actions-and-workflows
-        uses: gardener/cc-utils/.github/actions/pin-actions-and-workflows@42030b84bc357dceec6a2ef04fe759b7867f020c
+        uses: gardener/cc-utils/.github/actions/pin-actions-and-workflows@master
         with:
           own-ref: ${{ inputs.own-ref }}
           target-branch: ${{ inputs.target-branch }}

--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -153,14 +153,14 @@ jobs:
     steps:
       - name: collect-component-descriptor
         id: collect
-        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@95afc05821b176da01a01147082eed3c969522a7
+        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@master
         with:
           component-descriptor-artefact: base-component-descriptor
           outdir: /tmp/ocm
           post-process: ${{ inputs.ocm-post-process }}
 
       - name: fetch-prepare-values
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: prepare-prepare-workflow-values
@@ -187,12 +187,12 @@ jobs:
             >> $GITHUB_OUTPUT
       - name: authenticate-against-oci-registry
         if: ${{ steps.prep.outputs.can-push == 'true' }}
-        uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+        uses: gardener/cc-utils/.github/actions/oci-auth@master
         with:
           oci-image-reference: ${{ steps.prep.outputs.ocm-repositories }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           extra-auths: ${{ steps.extra-auth.outputs.extra-auths }}
-      - uses: gardener/cc-utils/.github/actions/ocm-validate@bd5413249d8bd1ba47a790ac6b639b1ae5af870d
+      - uses: gardener/cc-utils/.github/actions/ocm-validate@master
         with:
           component-descriptor-path: /tmp/ocm/component-descriptor.yaml
           on-validation-errors: ${{ inputs.on-validation-errors }}
@@ -209,7 +209,7 @@ jobs:
             --on-exist ${{ inputs.on-existing-component-descriptor }}
           tar czf component-descriptor.tar.gz -C /tmp/ocm component-descriptor.yaml
       - name: upload-component-descriptor-as-artefact
-        uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/upload-artifact@master
         with:
           path: component-descriptor.tar.gz
           name: component-descriptor
@@ -222,7 +222,7 @@ jobs:
       fork: ${{ steps.repo-metadata.outputs.fork }}
     steps:
       - id: repo-metadata
-        uses: gardener/cc-utils/.github/actions/repo-metadata@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/repo-metadata@master
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -294,7 +294,7 @@ jobs:
           fi
       - name: fetch-prepare-values
         if: ${{ steps.preprocess.outputs.create-draft-release == 'true' && inputs.ocm-repositories == '' }}
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: prepare-prepare-workflow-values
@@ -309,7 +309,7 @@ jobs:
             ocm_repos="${{ inputs.ocm-repositories }}"
           fi
           echo "ocm-repositories=${ocm_repos}" >> ${GITHUB_OUTPUT}
-      - uses: gardener/cc-utils/.github/actions/github-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
         with:
@@ -320,7 +320,7 @@ jobs:
             pull-requests: read
       - name: draft-release-notes
         if: ${{ steps.preprocess.outputs.create-draft-release == 'true' }}
-        uses: gardener/cc-utils/.github/actions/release-notes@32dbc9654b7b789102e04ccb021d8de16918bc8d
+        uses: gardener/cc-utils/.github/actions/release-notes@master
         with:
           component-descriptor-artifact: component-descriptor
           ocm-repositories: ${{ steps.prep.outputs.ocm-repositories }}
@@ -345,7 +345,7 @@ jobs:
               include_resources: true
       - name: update-draft-release
         if: ${{ steps.preprocess.outputs.create-draft-release == 'true' }}
-        uses: gardener/cc-utils/.github/actions/draft-release@96106806a7448b46ac2b53eef2cb348c8c511baa
+        uses: gardener/cc-utils/.github/actions/draft-release@master
         with:
           version: ${{ needs.component-descriptor.outputs.version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -217,7 +217,7 @@ jobs:
     steps:
       - name: params
         id: params
-        uses: gardener/cc-utils/.github/actions/params@0b6242d5ece7580a7fb3109e2f6b0aa9005f1400
+        uses: gardener/cc-utils/.github/actions/params@master
         with:
           mode: ${{ inputs.mode }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -225,7 +225,7 @@ jobs:
           snapshots-suffix: ${{ inputs.snapshots-suffix }}
           releases-suffix: ${{ inputs.releases-suffix }}
           ocm-repositories: ${{ inputs.ocm-repositories }}
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -249,7 +249,7 @@ jobs:
           fi
           echo "prerelease=${prerelease}" >> ${GITHUB_OUTPUT}
           echo "commit-message=${commit_msg}" >> ${GITHUB_OUTPUT}
-      - uses: gardener/cc-utils/.github/actions/version@c0de0b1905aed54005f1f6c56fb42e3342736c8c
+      - uses: gardener/cc-utils/.github/actions/version@master
         id: version
         name: create-release-commit
         with:
@@ -272,7 +272,7 @@ jobs:
           versionfile: ${{ inputs.versionfile }}
           version-operation: ${{ inputs.version-operation }}
           commit-kind: ${{ inputs.mode == 'release' && 'release' || 'build' }}
-      - uses: gardener/cc-utils/.github/actions/base-component-descriptor@3477807502047b06732ea8e386b7d1363221bc22
+      - uses: gardener/cc-utils/.github/actions/base-component-descriptor@master
         id: component-descriptor
         with:
           base-component: ${{ inputs.base-component-file }}
@@ -304,7 +304,7 @@ jobs:
           tar cf "${{ inputs.output-artefact-filename }}" $p
           tar tf "${{ inputs.output-artefact-filename }}" # debug
 
-      - uses: gardener/cc-utils/.github/actions/upload-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/upload-artifact@master
         with:
           name: ${{ inputs.output-artefact }}
           path: ${{ inputs.output-artefact-filename }}

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -57,7 +57,7 @@ jobs:
       id-token: write
     environment: ${{ inputs.github-environment }}
     steps:
-      - uses: gardener/cc-utils/.github/actions/github-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
         with:
@@ -67,7 +67,7 @@ jobs:
           permissions: |
             pull-requests: write
             members: read
-      - uses: gardener/cc-utils/.github/actions/pullrequest-trust-helper@f6afd99a25b2ee0ebd5bdf26f515fad905055769
+      - uses: gardener/cc-utils/.github/actions/pullrequest-trust-helper@master
         with:
           trusted-label: ${{ inputs.trusted-label || vars.DEFAULT_LABEL_OK_TO_TEST || 'ok-to-test' }}
           trusted-teams: ${{ inputs.trusted-teams }}

--- a/.github/workflows/release-cc-utils.yaml
+++ b/.github/workflows/release-cc-utils.yaml
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve Distribution Packages
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: distribution-packages
           path: /tmp/dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -297,7 +297,7 @@ jobs:
 
     steps:
       - name: fetch-prepare-values
-        uses: gardener/cc-utils/.github/actions/download-artifact@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/download-artifact@master
         with:
           name: prepare-workflow-values
       - name: prepare-prepare-workflow-values
@@ -313,7 +313,7 @@ jobs:
           echo "oci-registry=${oci_registry}" >> ${GITHUB_OUTPUT}
       - name: collect-component-descriptor
         id: component-descriptor
-        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@95afc05821b176da01a01147082eed3c969522a7
+        uses: gardener/cc-utils/.github/actions/merge-ocm-fragments@master
         with:
           component-descriptor-artefact: base-component-descriptor
           component-descriptor: ${{ inputs.component-descriptor }}
@@ -383,7 +383,7 @@ jobs:
           print(f'INFO: "automatic" version operation has been resolved to {next_version=}')
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f'next-version={next_version}\n')
-      - uses: gardener/cc-utils/.github/actions/github-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
         with:
@@ -391,7 +391,7 @@ jobs:
           repositories: |
             ${{ github.event.repository.name }}
           permissions: ${{ inputs.github-auth-token-permissions }}
-      - uses: gardener/cc-utils/.github/actions/release-notes@32dbc9654b7b789102e04ccb021d8de16918bc8d
+      - uses: gardener/cc-utils/.github/actions/release-notes@master
         id: release-notes
         with:
           component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
@@ -415,7 +415,7 @@ jobs:
               categories: ''
               recursion_depth: 0
               include_resources: true
-      - uses: gardener/cc-utils/.github/actions/release@98411fb31b82f1b1e5d411838c3a0dab7bec2954
+      - uses: gardener/cc-utils/.github/actions/release@master
         id: release
         with:
           component-descriptor-artifact: ${{ steps.component-descriptor.outputs.component-descriptor-artifact }}
@@ -490,7 +490,7 @@ jobs:
 
       - name: create-release-branch-bump-commit
         if: ${{ inputs.create-release-branch && steps.prep-next-version.outputs.next-version != 'bump-patch' }}
-        uses: gardener/cc-utils/.github/actions/version@c0de0b1905aed54005f1f6c56fb42e3342736c8c
+        uses: gardener/cc-utils/.github/actions/version@master
         # must be kept in sync with version action called in release action (except "version-operation")
         with:
           versionfile: ${{ inputs.version-versionfile }}
@@ -541,7 +541,7 @@ jobs:
 
       - name: cleanup-stale-release-branches
         if: ${{ inputs.cleanup-release-branches }}
-        uses: gardener/cc-utils/.github/actions/cleanup-release-branches@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/cleanup-release-branches@master
         with:
           version: ${{ steps.component-descriptor.outputs.version }}
           github-token: ${{ steps.fed-token.outputs.token }}

--- a/.github/workflows/run-testmachinery-tests.yaml
+++ b/.github/workflows/run-testmachinery-tests.yaml
@@ -93,11 +93,11 @@ jobs:
 
     steps:
       - uses: azure/setup-kubectl@v4
-      - uses: gardener/cc-utils/.github/actions/setup-testrunner@3218671eab64437904202a6e9f774a0abc7adb6c
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/setup-testrunner@master
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
-      - uses: gardener/cc-utils/.github/actions/kubernetes-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/kubernetes-auth@master
         with:
           server: ${{ inputs.k8s-api-endpoint }}
           server-ca: ${{ inputs.k8s-api-ca }}

--- a/.github/workflows/sastlint-ocm.yaml
+++ b/.github/workflows/sastlint-ocm.yaml
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
       - uses: actions/setup-go@v5
@@ -76,7 +76,7 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
       - name: setup-git-identity
         if: ${{ inputs.setup-git-identity }}
-        uses: 'gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0'
+        uses: 'gardener/cc-utils/.github/actions/setup-git-identity@master'
       - name: run-linter
         shell: bash
         run: |
@@ -96,7 +96,7 @@ jobs:
           tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
 
       - name: add-sast-report-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@c595b15575052a91301f78cadbb1fe7db2fbeb42
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |

--- a/.github/workflows/sbom-upload.yaml
+++ b/.github/workflows/sbom-upload.yaml
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Exchange tokens
-        uses: gardener/cc-utils/.github/actions/oidc-gcp-token-exchange@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/oidc-gcp-token-exchange@master
         with:
           api-url: ${{ inputs.token-exchange-api-url }}
           oidc-audience: ${{ inputs.token-exchange-audience }}
@@ -129,13 +129,13 @@ jobs:
           echo "gcs-token=${!token_var}" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to OCI registry
-        uses: gardener/cc-utils/.github/actions/oci-auth@ca6389dc24b62b33f669ca0b2a5e98286d85a746
+        uses: gardener/cc-utils/.github/actions/oci-auth@master
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           oci-image-reference: ${{ inputs.oci-registry }}
 
       - name: Fetch and upload SBOMs
-        uses: gardener/cc-utils/.github/actions/sbom-upload@a25452367ad33b453f439ec59a1b1b14791108fc
+        uses: gardener/cc-utils/.github/actions/sbom-upload@master
         with:
           ocm-component: ${{ inputs.ocm-component }}
           ocm-repositories: ${{ inputs.ocm-repositories }}

--- a/.github/workflows/update-extension-provider-images.yaml
+++ b/.github/workflows/update-extension-provider-images.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run image update action
         id: image_update
-        uses: gardener/cc-utils/.github/actions/update-extension-provider-images@6b5c7a76f9943a54d75890f65a9a147c363d364c
+        uses: gardener/cc-utils/.github/actions/update-extension-provider-images@master
         with:
           images-yaml-path: ${{ inputs.images-yaml-path }}
           release-notes-path: ${{ inputs.release-notes-path }}
@@ -75,7 +75,7 @@ jobs:
             echo "notes_content=" >> $GITHUB_OUTPUT
           fi
 
-      - uses: gardener/cc-utils/.github/actions/github-auth@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+      - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
         with:
@@ -86,7 +86,7 @@ jobs:
             pull-requests: write
 
       - name: Setup Git Identity
-        uses: gardener/cc-utils/.github/actions/setup-git-identity@bf59953785bcbb3999f6ef0b5ab535b4cde503e0
+        uses: gardener/cc-utils/.github/actions/setup-git-identity@master
 
       - name: Check for Changes
         id: check_changes

--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -139,7 +139,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@a5b1491ea86de48f04973d998e56433655d78bad
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         id: checkout
         with:
           submodules: ${{ inputs.checkout-submodules }}
@@ -147,7 +147,7 @@ jobs:
           github-auth-token-permissions: |
             contents: write
             pull-requests: write
-      - uses: gardener/cc-utils/.github/actions/ocm-upgrade@bc0f212cf1bbbee249425e21881fa31007ab9653
+      - uses: gardener/cc-utils/.github/actions/ocm-upgrade@master
         with:
           component-descriptor: ${{ inputs.component-descriptor }}
           component-descriptor-artifact: ${{ inputs.component-descriptor == '' && needs.prepare.outputs.component-descriptor || '' }}

--- a/.github/workflows/validate-release-notes.yaml
+++ b/.github/workflows/validate-release-notes.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: ${{ inputs.github-environment }}
     steps:
       - name: install-gardener-gha-libs
-        uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@d95236f2aeaa7c861ca52aec76e7b42ad9e528ad
+        uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
 
       - name: raise-on-malformed-release-notes
         shell: python

--- a/test/actions/pin-actions-and-workflows/test_no_pinned_internal_refs.py
+++ b/test/actions/pin-actions-and-workflows/test_no_pinned_internal_refs.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+Check that no workflow or action file in .github/ contains a pinned SHA reference
+to an internal (own-repo) action or workflow.
+
+On master, all internal uses: references must use @master (or another mutable
+branch ref), not a hardcoded commit SHA.  Pinned SHAs belong exclusively on the
+v1 branch, where the pin-actions-and-workflows tool writes them.
+
+If a specific reference must legitimately be pinned on master, append
+a `# pin-allow` comment to that line.
+
+This test is only meaningful on master; it is skipped on other refs.
+'''
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', '.github', 'actions',
+                     'pin-actions-and-workflows')
+    ),
+)
+
+import pin
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', '..')
+)
+_OWN_ORG = 'gardener'
+_OWN_REPO = 'cc-utils'
+
+
+def _current_ref() -> str:
+    '''
+    Return the current branch name.  Prefers the GITHUB_REF_NAME env var (set
+    by GitHub Actions even for detached-HEAD checkouts) over git symbolic-ref.
+    '''
+    import subprocess
+    # GitHub Actions sets this for both push and pull_request events
+    if ref := os.environ.get('GITHUB_REF_NAME'):
+        return ref
+    result = subprocess.run(
+        ['git', 'symbolic-ref', '--short', 'HEAD'],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return subprocess.check_output(
+        ['git', 'rev-parse', '--short', 'HEAD'],
+        text=True,
+        cwd=_REPO_ROOT,
+    ).strip()
+
+
+def _scan_violations() -> list[tuple[str, str]]:
+    '''
+    Return list of (file_path, uses_value) for every internal uses: reference
+    that is pinned to a SHA rather than a mutable branch ref.
+    '''
+    import glob
+    import ruamel.yaml as _yaml
+
+    _y = _yaml.YAML()
+    _y.preserve_quotes = True
+
+    own_prefix = f'{_OWN_ORG}/{_OWN_REPO}/'
+    import git as gitpython
+    repo = gitpython.Repo(_REPO_ROOT)
+
+    violations = []
+    patterns = [
+        os.path.join(_REPO_ROOT, '.github', 'actions', '**', 'action.yaml'),
+        os.path.join(_REPO_ROOT, '.github', 'actions', '**', 'action.yml'),
+        os.path.join(_REPO_ROOT, '.github', 'workflows', '*.yaml'),
+        os.path.join(_REPO_ROOT, '.github', 'workflows', '*.yml'),
+    ]
+    for pattern in patterns:
+        for fpath in glob.glob(pattern, recursive=True):
+            with open(fpath) as f:
+                raw = f.read()
+            parsed = _y.load(raw)
+            if not isinstance(parsed, dict):
+                continue
+            rel = os.path.relpath(fpath, _REPO_ROOT)
+            for step, key in pin._iter_step_uses(parsed):
+                uses_value = step[key]
+                if not isinstance(uses_value, str):
+                    continue
+                if not uses_value.startswith(own_prefix):
+                    continue
+                after_repo = uses_value[len(own_prefix):]
+                if '@' not in after_repo:
+                    continue
+                _, ref = after_repo.rsplit('@', 1)
+                if not pin._is_pinned(ref, repo):
+                    continue
+                # check for explicit exemption comment on this line
+                # ruamel.yaml stores end-of-line comments on the value's column object
+                comment = None
+                try:
+                    ca = step.ca  # CommentedMap attribute
+                    if ca and ca.items.get(key):
+                        comment_token = ca.items[key][2]  # end-of-value comment
+                        if comment_token:
+                            comment = comment_token.value
+                except Exception:
+                    pass
+                if comment and 'pin-allow' in comment:
+                    continue
+                violations.append((rel, uses_value))
+
+    return violations
+
+
+def test_no_pinned_internal_refs_on_master():
+    ref = _current_ref()
+    if ref != 'master':
+        pytest.skip(f'only enforced on master (current ref: {ref})')
+
+    violations = _scan_violations()
+    if violations:
+        lines = '\n'.join(f'  {path}: {uses}' for path, uses in violations)
+        pytest.fail(
+            f'Found {len(violations)} internal uses: reference(s) with pinned SHAs on master.\n'
+            f'Internal refs must use @master. Add "# pin-allow" to exempt intentional pins.\n'
+            f'\n{lines}'
+        )


### PR DESCRIPTION
## Summary

- Replaces all `gardener/cc-utils/...@<sha>` internal refs in `.github/` with `@master` (37 files). Pinned SHAs belong exclusively on the `v1` branch.
- Adds `test/actions/pin-actions-and-workflows/test_no_pinned_internal_refs.py`: scans all `.github/` action/workflow YAML files and fails if any internal ref is pinned to a SHA. Skips on non-master branches. Supports `# pin-allow` to exempt intentional pins.

## Test plan

- [ ] Test skips on non-master branches (verified locally)
- [ ] Test passes on master with zero violations (verified locally with `GITHUB_REF_NAME=master`)
- [ ] CI checks pass on this PR