### PR TITLE
sbom-set-status: add multi-key support + reusable workflow

### DIFF
--- a/.github/actions/sbom-set-status/action.yaml
+++ b/.github/actions/sbom-set-status/action.yaml
@@ -1,6 +1,6 @@
 name: 'Set Cumulus release status (sbom-set-status)'
 description: >
-  Writes a Cumulus release-status entry for a GCS run-key, with smart
+  Writes a Cumulus release-status entry for one or more GCS run-keys, with smart
   transition logic: targets that require a prior "promoted" write
   (deployed-to-production, released) will have it prepended automatically
   if not already present. For "released", also polls until sbom/ is locked
@@ -14,8 +14,13 @@ inputs:
     description: 'Bearer token for the GCS JSON API'
     required: true
   run-key:
-    description: 'GCS path prefix (run-key) to set status on, e.g. "1.2.3"'
-    required: true
+    description: 'Single GCS path prefix (run-key) to set status on, e.g. "1.2.3"'
+    required: false
+    default: ''
+  run-keys:
+    description: 'Newline-separated list of GCS run-keys to set status on'
+    required: false
+    default: ''
   release-status:
     description: >
       Target release status. One of:
@@ -31,6 +36,13 @@ inputs:
     description: >
       Action when the run-key is already in "released" state:
         skip – exit 0 (default)
+        fail – exit 1
+    required: false
+    default: 'skip'
+  on-absent:
+    description: >
+      Action when a run-key has no status entries in the bucket:
+        skip – silently ignore (default)
         fail – exit 1
     required: false
     default: 'skip'
@@ -54,17 +66,31 @@ runs:
         GCS_BUCKET: ${{ inputs.gcs-bucket }}
         GCS_TOKEN: ${{ inputs.gcs-token }}
         RUN_KEY: ${{ inputs.run-key }}
+        RUN_KEYS: ${{ inputs.run-keys }}
         RELEASE_STATUS: ${{ inputs.release-status }}
         ON_ALREADY_RELEASED: ${{ inputs.on-already-released }}
+        ON_ABSENT: ${{ inputs.on-absent }}
         POLL_INTERVAL: ${{ inputs.poll-interval }}
         POLL_TIMEOUT: ${{ inputs.poll-timeout }}
       run: |
         set -euo pipefail
-        python3 "$GITHUB_ACTION_PATH/set_status.py" \
-          --gcs-bucket           "$GCS_BUCKET" \
-          --gcs-token            "$GCS_TOKEN" \
-          --run-key              "$RUN_KEY" \
-          --release-status       "$RELEASE_STATUS" \
-          --on-already-released  "$ON_ALREADY_RELEASED" \
-          --poll-interval        "$POLL_INTERVAL" \
-          --poll-timeout         "$POLL_TIMEOUT"
+        if [ -n "${RUN_KEYS}" ]; then
+          python3 "$GITHUB_ACTION_PATH/set_status.py" \
+            --gcs-bucket           "$GCS_BUCKET" \
+            --gcs-token            "$GCS_TOKEN" \
+            --run-keys             "$RUN_KEYS" \
+            --release-status       "$RELEASE_STATUS" \
+            --on-already-released  "$ON_ALREADY_RELEASED" \
+            --on-absent            "$ON_ABSENT" \
+            --poll-interval        "$POLL_INTERVAL" \
+            --poll-timeout         "$POLL_TIMEOUT"
+        else
+          python3 "$GITHUB_ACTION_PATH/set_status.py" \
+            --gcs-bucket           "$GCS_BUCKET" \
+            --gcs-token            "$GCS_TOKEN" \
+            --run-key              "$RUN_KEY" \
+            --release-status       "$RELEASE_STATUS" \
+            --on-already-released  "$ON_ALREADY_RELEASED" \
+            --poll-interval        "$POLL_INTERVAL" \
+            --poll-timeout         "$POLL_TIMEOUT"
+        fi

--- a/.github/actions/sbom-set-status/set_status.py
+++ b/.github/actions/sbom-set-status/set_status.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 '''
-Set the Cumulus release status for a given GCS run-key.
+Set the Cumulus release status for one or more GCS run-keys.
 
 Smart transition logic:
   - release-candidate, promoted: single write.
@@ -129,7 +129,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--gcs-bucket', required=True, metavar='BUCKET')
     parser.add_argument('--gcs-token', required=True, metavar='TOKEN')
-    parser.add_argument('--run-key', required=True, metavar='KEY')
+
+    key_group = parser.add_mutually_exclusive_group(required=True)
+    key_group.add_argument('--run-key', metavar='KEY',
+        help='single GCS run-key to set status on')
+    key_group.add_argument('--run-keys', metavar='KEYS',
+        help='newline-separated list of GCS run-keys to set status on')
+
     parser.add_argument(
         '--release-status',
         required=True,
@@ -143,6 +149,13 @@ def main() -> None:
         default='skip',
         metavar='ACTION',
         help='"skip" exits 0, "fail" exits 1 when run-key is already released (default: skip)',
+    )
+    parser.add_argument(
+        '--on-absent',
+        choices=('skip', 'fail'),
+        default='skip',
+        metavar='ACTION',
+        help='"skip" ignores run-keys with no status entries, "fail" aborts (default: skip)',
     )
     parser.add_argument(
         '--poll-interval',
@@ -162,30 +175,42 @@ def main() -> None:
 
     bucket = args.gcs_bucket
     token = args.gcs_token
-    run_key = args.run_key
     target = args.release_status
 
-    current = _current_status(bucket, token, run_key)
-    print(f'run-key: {run_key!r}  current: {current!r}  target: {target!r}', file=sys.stderr)
+    if args.run_keys:
+        run_keys = [k.strip() for k in args.run_keys.splitlines() if k.strip()]
+    else:
+        run_keys = [args.run_key]
 
-    if current == 'released':
-        msg = f'run-key {run_key!r} is already in "released" state'
-        if args.on_already_released == 'fail':
-            print(f'error: {msg}', file=sys.stderr)
-            sys.exit(1)
-        print(f'{msg} — skipping', file=sys.stderr)
-        return
+    for run_key in run_keys:
+        current = _current_status(bucket, token, run_key)
+        print(f'run-key: {run_key!r}  current: {current!r}  target: {target!r}', file=sys.stderr)
 
-    # pre-write promoted if the target requires it and it hasn't been done yet
-    if target in _NEEDS_PROMOTED and current not in _PROMOTED_DONE:
-        print('pre-writing promoted (required before {})'.format(target), file=sys.stderr)
-        _write_status(bucket, token, run_key, 'promoted')
+        if current is None:
+            if args.on_absent == 'fail':
+                print(f'error: run-key {run_key!r} has no status entries', file=sys.stderr)
+                sys.exit(1)
+            print(f'run-key {run_key!r} absent — skipping', file=sys.stderr)
+            continue
 
-    # for released: wait until Cumulus has processed the promoted write (sbom/ locked)
-    if target == 'released':
-        _poll_sbom_locked(bucket, token, run_key, args.poll_interval, args.poll_timeout)
+        if current == 'released':
+            msg = f'run-key {run_key!r} is already in "released" state'
+            if args.on_already_released == 'fail':
+                print(f'error: {msg}', file=sys.stderr)
+                sys.exit(1)
+            print(f'{msg} — skipping', file=sys.stderr)
+            continue
 
-    _write_status(bucket, token, run_key, target)
+        # pre-write promoted if the target requires it and it hasn't been done yet
+        if target in _NEEDS_PROMOTED and current not in _PROMOTED_DONE:
+            print('pre-writing promoted (required before {})'.format(target), file=sys.stderr)
+            _write_status(bucket, token, run_key, 'promoted')
+
+        # for released: wait until Cumulus has processed the promoted write (sbom/ locked)
+        if target == 'released':
+            _poll_sbom_locked(bucket, token, run_key, args.poll_interval, args.poll_timeout)
+
+        _write_status(bucket, token, run_key, target)
 
 
 if __name__ == '__main__':

--- a/.github/workflows/sbom-set-status.yaml
+++ b/.github/workflows/sbom-set-status.yaml
@@ -1,0 +1,145 @@
+name: Set Cumulus SBOM release status
+
+# Reusable workflow: sets a Cumulus release status for one or more versions.
+#
+# When limit > 1, also processes the (limit-1) preceding versions by decrementing
+# the minor component (requires major.minor.patch scheme with incrementing minor).
+# Versions absent from the bucket are silently skipped.
+#
+# Caller example:
+#
+#   jobs:
+#     set-status:
+#       uses: gardener/cc-utils/.github/workflows/sbom-set-status.yaml@v1
+#       with:
+#         run-key: '1.2795.0'
+#         release-status: released
+#         gcs-bucket: my-pipeline-uuid
+#         token-exchange-api-url: 'https://api.example.com'
+#         token-exchange-audience: 'api://MyService'
+#         token-exchange-pipeline-id: 'my-pipeline'
+#         token-exchange-pipeline-group-id: 'my-org/my-project'
+#         token-exchange-scope: 'cumulus'
+#       permissions:
+#         id-token: write
+
+on:
+  workflow_call:
+    inputs:
+      run-key:
+        description: 'Version / GCS run-key (e.g. "1.2.3")'
+        required: true
+        type: string
+      limit:
+        description: >
+          Number of consecutive versions to process, counting down from run-key.
+          1 (default) = only run-key; N = run-key plus the N-1 preceding versions.
+        required: false
+        type: string
+        default: '1'
+      release-status:
+        description: >
+          Target Cumulus release status: release-candidate, promoted,
+          deployed-to-production, or released.
+        required: true
+        type: string
+      gcs-bucket:
+        description: 'GCS bucket name (Cumulus pipeline UUID)'
+        required: true
+        type: string
+      token-exchange-api-url:
+        description: 'Base URL of the token exchange API'
+        required: true
+        type: string
+      token-exchange-audience:
+        description: 'OIDC audience for the identity token'
+        required: true
+        type: string
+      token-exchange-pipeline-id:
+        description: 'Pipeline identifier passed to the token exchange API'
+        required: true
+        type: string
+      token-exchange-pipeline-group-id:
+        description: 'Pipeline group identifier passed to the token exchange API'
+        required: true
+        type: string
+      token-exchange-scope:
+        description: 'Scope to request from the token exchange API (e.g. "cumulus")'
+        required: true
+        type: string
+      runner:
+        description: 'Newline-separated list of runner labels (e.g. "self-hosted")'
+        required: false
+        type: string
+        default: 'self-hosted'
+      on-already-released:
+        description: '"skip" (default) or "fail" when a version is already released'
+        required: false
+        type: string
+        default: 'skip'
+      poll-interval:
+        description: 'Seconds between lock-poll attempts when transitioning to released'
+        required: false
+        type: string
+        default: '30'
+      poll-timeout:
+        description: 'Max seconds to wait for sbom/ lock before proceeding (default: 600)'
+        required: false
+        type: string
+        default: '600'
+
+jobs:
+  set-status:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Exchange tokens
+        uses: gardener/cc-utils/.github/actions/oidc-gcp-token-exchange@master
+        with:
+          api-url: ${{ inputs.token-exchange-api-url }}
+          oidc-audience: ${{ inputs.token-exchange-audience }}
+          pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
+          pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
+          scopes: ${{ inputs.token-exchange-scope }}
+          token-env-prefix: 'GCS_'
+
+      - name: Export GCS token
+        id: gcs-token
+        shell: bash
+        env:
+          SCOPE: ${{ inputs.token-exchange-scope }}
+        run: |
+          upper=$(echo "$SCOPE" | tr '[:lower:]' '[:upper:]')
+          token_var="GCS_${upper}_TOKEN"
+          echo "gcs-token=${!token_var}" >> "$GITHUB_OUTPUT"
+
+      - name: Build run-key list
+        id: keys
+        shell: bash
+        env:
+          RUN_KEY: ${{ inputs.run-key }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          set -euo pipefail
+          IFS=. read -r major minor patch <<< "$RUN_KEY"
+          {
+            printf 'run-keys<<EOF\n'
+            for i in $(seq 0 $((LIMIT - 1))); do
+              printf '%s.%s.%s\n' "$major" "$((minor - i))" "$patch"
+            done
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set release status
+        uses: gardener/cc-utils/.github/actions/sbom-set-status@master
+        with:
+          gcs-bucket: ${{ inputs.gcs-bucket }}
+          gcs-token: ${{ steps.gcs-token.outputs.gcs-token }}
+          run-keys: ${{ steps.keys.outputs.run-keys }}
+          release-status: ${{ inputs.release-status }}
+          on-already-released: ${{ inputs.on-already-released }}
+          on-absent: 'skip'
+          poll-interval: ${{ inputs.poll-interval }}
+          poll-timeout: ${{ inputs.poll-timeout }}

--- a/.github/workflows/sbom-upload.yaml
+++ b/.github/workflows/sbom-upload.yaml
@@ -71,10 +71,10 @@ on:
         required: true
         type: string
       runner:
-        description: 'Runner label(s) as a JSON array string, e.g. "[\"self-hosted\"]"'
+        description: 'Newline-separated list of runner labels (e.g. "self-hosted")'
         required: false
         type: string
-        default: '["self-hosted"]'
+        default: 'self-hosted'
       run-key:
         description: 'GCS path prefix (run key); defaults to OCM component version'
         required: false
@@ -102,7 +102,7 @@ on:
 
 jobs:
   sbom-upload:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ inputs.runner }}
     permissions:
       id-token: write
 


### PR DESCRIPTION
Extends the `sbom-set-status` action and adds a reusable `sbom-set-status.yaml` workflow.

**Action changes** (`.github/actions/sbom-set-status/`):
- `--run-keys`: newline-separated list of run-keys as alternative to `--run-key`
- `--on-absent skip|fail`: silently skip or abort for run-keys with no status entries (default: `skip`)
- `action.yaml` gains `run-keys` and `on-absent` inputs accordingly

**New reusable workflow** (`.github/workflows/sbom-set-status.yaml`):
- Wraps token exchange + action call
- `run-key` + `limit` inputs: processes `limit` consecutive versions by decrementing the minor component (e.g. `1.2795.0` with `limit=3` → `1.2795.0`, `1.2794.0`, `1.2793.0`)
- Absent versions are silently skipped