### PR TITLE
sbom: add S3 scanning, restore mandatory cbomkit-theia, rename cbom format

### DIFF
--- a/.github/actions/sbom-upload/upload.py
+++ b/.github/actions/sbom-upload/upload.py
@@ -32,10 +32,7 @@ def _mangle(s: str) -> str:
 def _fmt_id(mapping: si.SbomMapping) -> str | None:
     if mapping.source is si.SbomSource.OCM:
         ei = mapping.sbom.extraIdentity or {}
-        # SBOM resources use 'sbom-format'; CBOM resources use 'cbom-format'
-        return ei.get('sbom-format') or (
-            f'cbom-{ei["cbom-format"]}' if ei.get('cbom-format') else None
-        )
+        return ei.get('sbom-format') or ei.get('cbom-format') or None
     for fid, media_type in soci.SBOM_FORMATS:
         if mapping.sbom.artifact_type == media_type:
             return fid

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -883,6 +883,7 @@ def process_replication_plan_step(
     if sbom_candidates:
         if processing_mode is not ProcessingMode.DRY_RUN:
             sbom_inject.check_syft()
+            sbom_inject.check_cbomkit_theia()
 
         tmpdir = os.environ.get('TMPDIR') or os.environ.get('RUNNER_TEMP') or None
         syft_ver = sbom_inject._syft_version()

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -112,7 +112,7 @@ def test_build_sbom_ocm_resources_distinct_identity_for_same_name():
     assert spdx_arm64.extraIdentity.get('arch') == 'arm64'
     assert spdx_amd64.extraIdentity.get('sbom-format') == 'spdx-2.3'
     assert cdx_amd64.extraIdentity.get('sbom-format') == 'cyclonedx-1.6'
-    assert cbom_amd64.extraIdentity.get('cbom-format') == 'cyclonedx-1.6'
+    assert cbom_amd64.extraIdentity.get('cbom-format') == 'cyclonedx-1.6+cbom'
 
 
 def test_build_sbom_ocm_resources_no_source_extra_identity():
@@ -129,7 +129,7 @@ def test_build_sbom_ocm_resources_no_source_extra_identity():
     )
     assert spdx.extraIdentity == {'version': '2.0', 'sbom-format': 'spdx-2.3'}
     assert cdx.extraIdentity == {'version': '2.0', 'sbom-format': 'cyclonedx-1.6'}
-    assert cbom.extraIdentity == {'version': '2.0', 'cbom-format': 'cyclonedx-1.6'}
+    assert cbom.extraIdentity == {'version': '2.0', 'cbom-format': 'cyclonedx-1.6+cbom'}
     peers = [spdx, cdx, cbom]
     assert len({r.identity(peers=peers) for r in peers}) == 3
 

--- a/sbom/cbom.py
+++ b/sbom/cbom.py
@@ -72,14 +72,14 @@ def build_cbom_ocm_resources(
     extraIdentity.cbom-format distinguishes CBOM resources from SBOM resources that share
     the same resource name.
     '''
-    extra_identity = {'version': version, 'cbom-format': 'cyclonedx-1.6'}
+    extra_identity = {'version': version, 'cbom-format': 'cyclonedx-1.6+cbom'}
     label_value = {
         'data-source': {
             'kind': 'local-scan',
             'tool': 'cbomkit-theia',
             'tool-version': tool_ver,
         },
-        'format': 'cyclonedx-1.6',
+        'format': 'cyclonedx-1.6+cbom',
     } if tool_ver else None
     labels = [
         {'name': 'gardener.cloud/cbom/source-image',        'value': source_image_ref},

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -58,6 +58,22 @@ def check_syft():
         )
 
 
+def check_cbomkit_theia():
+    '''Verify cbomkit-theia is on PATH; raise RuntimeError with a friendly message if not.'''
+    try:
+        subprocess.run(  # nosec B607
+            ['cbomkit-theia', '--help'],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            'cbomkit-theia is not installed or not on PATH. '
+            'Please install cbomkit-theia (https://github.com/IBM/cbomkit-theia) before '
+            'running CTT with SBOM/CBOM injection enabled.'
+        )
+
+
 def _cbomkit_theia_version() -> str | None:
     try:
         result = subprocess.run(  # nosec B607
@@ -292,21 +308,17 @@ def scan_image(
         with open(cdx_path, 'rb') as f:
             cdx_bytes = f.read()
 
-        try:
-            _run_cbomkit_theia(
-                image_ref=str(image_ref),
-                cdx_bom_path=cdx_path,
-                out_path=cbom_path,
-                tmpdir=tmpdir,
-            )
-            with open(cbom_path, 'rb') as f:
-                cbom_bytes = f.read()
-        except Exception as e:
-            logger.warning('cbomkit-theia failed for %r: %s', str(image_ref), e)
-            cbom_bytes = None
+        _run_cbomkit_theia(
+            image_ref=str(image_ref),
+            cdx_bom_path=cdx_path,
+            out_path=cbom_path,
+            tmpdir=tmpdir,
+        )
+        with open(cbom_path, 'rb') as f:
+            cbom_bytes = f.read()
 
     resolved_tool_ver = tool_ver or _syft_version_from_spdx(spdx_bytes)
-    cbom_tool_ver = _cbomkit_theia_version() if cbom_bytes is not None else None
+    cbom_tool_ver = _cbomkit_theia_version()
 
     spdx_referrer_digest, cdx_referrer_digest = soci.push_sbom_referrers(
         spdx_bytes=spdx_bytes,
@@ -320,7 +332,7 @@ def scan_image(
         image_reference=image_ref,
         oci_client=oci_client,
         tool_version=cbom_tool_ver,
-    ) if cbom_bytes is not None else None
+    )
 
     return (
         spdx_bytes, cdx_bytes, cbom_bytes,
@@ -477,7 +489,7 @@ def build_sbom_ocm_resources(
             'tool': 'cbomkit-theia',
             'tool-version': cbom_tool_ver,
         },
-        'format': 'cyclonedx-1.6',
+        'format': 'cyclonedx-1.6+cbom',
     } if cbom_tool_ver else None
     cbom_labels = [
         ocm.Label(name='gardener.cloud/cbom/source-image',        value=source_image_ref),
@@ -488,7 +500,7 @@ def build_sbom_ocm_resources(
     cbom_extra_id = {
         **(source_extra_identity or {}),
         'version': version,
-        'cbom-format': 'cyclonedx-1.6',
+        'cbom-format': 'cyclonedx-1.6+cbom',
     }
     cbom_resource = ocm.Resource(
         name=resource_name,
@@ -739,7 +751,7 @@ def build_s3_sbom_ocm_resources(
             'tool': 'cbomkit-theia',
             'tool-version': cbom_tool_ver,
         },
-        'format': 'cyclonedx-1.6',
+        'format': 'cyclonedx-1.6+cbom',
     } if cbom_tool_ver else None
     cbom_labels = [
         ocm.Label(name='gardener.cloud/cbom/source-image',        value=s3_url),
@@ -750,7 +762,7 @@ def build_s3_sbom_ocm_resources(
     cbom_extra_id = {
         **(source_extra_identity or {}),
         'version': version,
-        'cbom-format': 'cyclonedx-1.6',
+        'cbom-format': 'cyclonedx-1.6+cbom',
     }
     cbom_resource = ocm.Resource(
         name=resource_name,

--- a/test/sbom/upload_fmt_test.py
+++ b/test/sbom/upload_fmt_test.py
@@ -65,9 +65,9 @@ def test_fmt_id_cyclonedx():
 
 
 def test_fmt_id_cbom():
-    r = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6', 'version': 'v1.0.0'})
+    r = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6+cbom', 'version': 'v1.0.0'})
     m = _make_mapping(r)
-    assert _fmt_id(m) == 'cbom-cyclonedx-1.6'
+    assert _fmt_id(m) == 'cyclonedx-1.6+cbom'
 
 
 def test_fmt_id_neither_returns_none():
@@ -86,11 +86,11 @@ def test_filename_excludes_cbom_format_key():
         componentReferences=[],
         resources=[],
     )
-    resource = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6', 'version': 'v1.0.0'})
-    name = _filename(component, resource, 'cbom-cyclonedx-1.6')
-    # should not contain 'cyclonedx-1.6' twice (the format value should not appear in name)
-    assert name.count('cyclonedx-1.6') == 1
-    assert name.endswith('.sbom.cbom-cyclonedx-1.6')
+    resource = _make_sbom_resource({'cbom-format': 'cyclonedx-1.6+cbom', 'version': 'v1.0.0'})
+    name = _filename(component, resource, 'cyclonedx-1.6+cbom')
+    # cbom-format value should not appear as an extra suffix in the filename
+    assert name.count('cyclonedx-1.6+cbom') == 1
+    assert name.endswith('.sbom.cyclonedx-1.6+cbom')
 
 
 def test_filename_excludes_sbom_format_key():


### PR DESCRIPTION
## Summary

- Add S3-backed resource SBOM/CBOM scanning via `sbom/inject.scan_s3_resource` +
  `build_s3_sbom_ocm_resources`; downloads S3 objects using stdlib only (no boto3)
- Restore `check_cbomkit_theia()` as a mandatory pre-flight check (reverts the
  try/except softening from the `sbom-s3-scanning` branch)
- Rename `cbom-format` extraIdentity value `cyclonedx-1.6` → `cyclonedx-1.6+cbom`
  (RFC 6838 structured-syntax suffix, aligns with `CBOM_ARTIFACT_TYPE` which uses
  `profile=cbom`)
- Simplify `upload.py _fmt_id`: CBOM format value is now self-descriptive, no prefix needed
- Wire `inject_s3_sboms` flag through `ctt/process_dependencies.py`

## Test plan

- [ ] `ctt/test/process_deps_test.py` — 11 tests pass (SBOM resource identity + format values)
- [ ] `test/sbom/upload_fmt_test.py` — format ID and filename tests pass with new cbom-format value
- [ ] CI (full suite)