### PR TITLE
sbom-upload: add scan-missing option

### DIFF
--- a/.github/actions/sbom-upload/action.yaml
+++ b/.github/actions/sbom-upload/action.yaml
@@ -65,6 +65,17 @@ inputs:
     description: 'Scope to re-request on token refresh (e.g. "sbom")'
     required: false
     default: ''
+  scan-missing:
+    description: >
+      If true, run syft + cbomkit-theia for any OCI image resource that has no existing
+      SBOM referrer manifests, and push the results to the OCI registry before uploading.
+      Requires syft and cbomkit-theia to be on PATH.
+      Pushed referrers are discovered on subsequent runs, avoiding redundant scans.
+      OCM component descriptors and OCI image manifests are not modified.
+      NOTE: pushing referrer manifests requires write access to the OCI/OCM repository;
+      callers must ensure the authenticated identity has push permissions.
+    required: false
+    default: 'false'
 
 outputs:
   run-key:
@@ -147,6 +158,43 @@ runs:
     - name: Install gardener-gha-libs
       if: steps.check-status.outputs.already-released != 'true'
       uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+
+    - name: Install syft
+      if: >
+        steps.check-status.outputs.already-released != 'true' &&
+        inputs.scan-missing == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        install_dir="${HOME}/.local/bin"
+        mkdir -p "${install_dir}"
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+          | sh -s -- -b "${install_dir}"
+        echo "${install_dir}" >> "${GITHUB_PATH}"
+
+    - name: Install cbomkit-theia
+      if: >
+        steps.check-status.outputs.already-released != 'true' &&
+        inputs.scan-missing == 'true'
+      uses: gardener/cc-utils/.github/actions/install-cbomkit-theia@master
+
+    - name: Scan missing SBOMs
+      if: >
+        steps.check-status.outputs.already-released != 'true' &&
+        inputs.scan-missing == 'true'
+      shell: bash
+      env:
+        OCM_REPOSITORIES: ${{ inputs.ocm-repositories }}
+      run: |
+        set -euo pipefail
+        repos_args=()
+        while IFS= read -r repo; do
+          [ -z "$repo" ] && continue
+          repos_args+=(--ocm-repository "$repo")
+        done <<< "$OCM_REPOSITORIES"
+        python3 "$GITHUB_ACTION_PATH/scan.py" \
+          --ocm-component '${{ inputs.ocm-component }}' \
+          "${repos_args[@]}"
 
     - name: Upload SBOMs
       if: steps.check-status.outputs.already-released != 'true'

--- a/.github/actions/sbom-upload/scan.py
+++ b/.github/actions/sbom-upload/scan.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Scan OCI image resources in an OCM component tree that are missing SBOM referrers,
+run syft + cbomkit-theia, and push the results as OCI referrer manifests.
+
+Intended to run before upload.py so that the uploaded SBOMs include freshly scanned
+documents. Referrers pushed here are discovered by iter_sboms_for_resource (phase 2)
+on the next run, avoiding redundant scans.
+
+OCM component descriptors and OCI image manifests are not modified.
+'''
+import argparse
+import sys
+import tempfile
+
+import cnudie.retrieve
+import oci.auth
+import oci.client
+import oci.model as om
+import ocm
+import ocm.iter as ocm_iter
+import sbom.inject as sinject
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Scan missing SBOMs for all OCI image resources in an OCM component tree.',
+    )
+    parser.add_argument(
+        '--ocm-component',
+        required=True,
+        metavar='NAME:VERSION',
+    )
+    parser.add_argument(
+        '--ocm-repository',
+        required=True,
+        action='append',
+        dest='ocm_repositories',
+        metavar='URL',
+    )
+    args = parser.parse_args()
+
+    if ':' not in args.ocm_component:
+        print(f'error: --ocm-component must be name:version, got: {args.ocm_component!r}',
+              file=sys.stderr)
+        sys.exit(1)
+
+    sinject.check_syft()
+    sinject.check_cbomkit_theia()
+
+    name, version = args.ocm_component.rsplit(':', 1)
+    ocm_repositories = [r for r in args.ocm_repositories if r.strip()]
+
+    oci_client = oci.client.Client(
+        credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
+    )
+
+    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
+    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+        lookups=(
+            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+            ),
+            cnudie.retrieve.oci_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+                oci_client=oci_client,
+            ),
+        ),
+        ocm_repository_lookup=ocm_repo_lookup,
+    )
+
+    root_component = lookup(
+        ocm.ComponentIdentity(name=name, version=version),
+    ).component
+
+    all_nodes = list(ocm_iter.iter_resources(component=root_component, lookup=lookup))
+    print(f'discovered {len(all_nodes)} resources', file=sys.stderr)
+
+    # collect OCI image resources that have no existing referrers
+    missing = []
+    for node in all_nodes:
+        resource = node.resource
+        access = resource.access
+        if not isinstance(access, ocm.OciAccess):
+            continue
+        image_ref = om.OciImageReference.to_image_ref(access.imageReference)
+        # resolve to digest so referrer lookup is unambiguous
+        try:
+            digest_ref = oci_client.to_digest_hash(image_ref)
+        except Exception as e:
+            print(f'warning: cannot resolve digest for {resource.name!r}: {e}', file=sys.stderr)
+            continue
+
+        existing = sinject.lookup_sbom_referrers(
+            image_ref=digest_ref,
+            oci_client=oci_client,
+        )
+        if existing is not None:
+            print(f'skip (referrers present): {resource.name}', file=sys.stderr)
+            continue
+        missing.append((resource.name, digest_ref))
+
+    if not missing:
+        print('all resources have existing SBOM referrers — nothing to scan', file=sys.stderr)
+        return
+
+    print(f'{len(missing)} resource(s) to scan', file=sys.stderr)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        results = sinject.run_injections_resource_aware(
+            items=missing,
+            oci_client=oci_client,
+            tmpdir=tmpdir,
+        )
+
+    scanned = sum(1 for r in results if r[-1] == 'scanned')
+    failed  = sum(1 for r in results if r[-1] == 'failed')
+    print(f'scanned: {scanned}, failed: {failed}', file=sys.stderr)
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/sbom-upload.yaml
+++ b/.github/workflows/sbom-upload.yaml
@@ -99,6 +99,17 @@ on:
         required: false
         type: string
         default: 'skip'
+      scan-missing:
+        description: >
+          If true, run syft + cbomkit-theia for any OCI image resource that has no existing
+          SBOM referrer manifests, and push the results to the OCI registry before uploading.
+          Requires self-hosted runners with sufficient disk/memory.
+          NOTE: pushing referrer manifests requires write access to the OCI/OCM repository;
+          callers must ensure the authenticated identity has push permissions.
+          Default: false.
+        required: false
+        type: string
+        default: 'false'
 
 jobs:
   sbom-upload:
@@ -149,3 +160,4 @@ jobs:
           token-exchange-pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
           token-exchange-pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
           token-exchange-scope: ${{ inputs.token-exchange-scope }}
+          scan-missing: ${{ inputs.scan-missing }}


### PR DESCRIPTION
## Summary

- Adds a `scan-missing` input (default: `false`) to the `sbom-upload` reusable workflow and the `sbom-upload` composite action
- When enabled, a new `scan.py` script runs syft + cbomkit-theia for any OCI image resource in the component tree that has no existing SBOM referrer manifests, and pushes the results to the OCI registry before the upload step
- Reuses `sbom.inject.scan_image` / `run_injections_resource_aware` directly — no scanning logic is duplicated from `oci-ocm.yaml`
- OCM component descriptors and OCI image manifests are not modified
- Pushed referrer manifests are discovered by `iter_sboms_for_resource` on subsequent runs, avoiding redundant scans; images with stable digests across versions benefit automatically

## Test plan

- [ ] Pipelines green on feature branch (both CI and Build OCM runs pass)
- [ ] Verify `scan-missing: false` (default) behaviour is unchanged for existing callers
- [ ] Manual test with `scan-missing: true` against a component tree with missing SBOMs