### PR TITLE
sbom-upload: re-exchange GCS token before set-release-status

### DIFF
--- a/.github/actions/sbom-upload/action.yaml
+++ b/.github/actions/sbom-upload/action.yaml
@@ -220,6 +220,20 @@ runs:
           --token-exchange-scope '${{ inputs.token-exchange-scope }}' \
           "${repos_args[@]}"
 
+    - name: Refresh GCS token before status write
+      if: >
+        steps.check-status.outputs.already-released != 'true' &&
+        inputs.release-status != '' &&
+        inputs.token-exchange-api-url != ''
+      uses: gardener/cc-utils/.github/actions/oidc-gcp-token-exchange@master
+      with:
+        api-url: ${{ inputs.token-exchange-api-url }}
+        oidc-audience: ${{ inputs.token-exchange-audience }}
+        pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
+        pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
+        scopes: ${{ inputs.token-exchange-scope }}
+        token-env-prefix: 'GCS_STATUS_'
+
     - name: Set release status
       if: >
         steps.check-status.outputs.already-released != 'true' &&
@@ -227,11 +241,15 @@ runs:
       shell: bash
       env:
         BUCKET: ${{ inputs.gcs-bucket }}
-        GCS_TOKEN: ${{ inputs.gcs-token }}
+        GCS_TOKEN_INITIAL: ${{ inputs.gcs-token }}
+        TOKEN_EXCHANGE_SCOPE: ${{ inputs.token-exchange-scope }}
         RUN_KEY: ${{ steps.resolve-run-key.outputs.run-key }}
         RELEASE_STATUS: ${{ inputs.release-status }}
       run: |
         set -euo pipefail
+        scope_upper=$(echo "${TOKEN_EXCHANGE_SCOPE}" | tr '[:lower:]' '[:upper:]')
+        fresh_var="GCS_STATUS_${scope_upper}_TOKEN"
+        GCS_TOKEN="${!fresh_var:-${GCS_TOKEN_INITIAL}}"
         ts=$(date -u +%s)
         blob="${RUN_KEY}/.status-log/release/release-status-${ts}.json"
         blob_enc="${blob//\//%2F}"


### PR DESCRIPTION
## Problem

The GCS bearer token obtained at job start expires mid-run on long-running
jobs. The `Set release status` step uses `${{ inputs.gcs-token }}` — the
token evaluated at job startup — and has no awareness of the mid-run refresh
that `upload.py` performs internally via System Trust. On jobs that run longer
than the token TTL (~25 min), the status write fails with HTTP 401
\"Invalid Credentials\".

Observed on `kubernetes-dev/landscape-dev-garden` whose `sbom-upload` job
takes ~1h47m (1549 uploads + scan-missing). Staging (~30 min) is unaffected.
Result: SBOMs upload successfully but neither `promoted` nor `released` status
is written to the Cumulus GCS bucket for that run-key.

## Fix

Add a `Refresh GCS token before status write` step immediately before
`Set release status`, reusing the existing `oidc-gcp-token-exchange` action
with a distinct `token-env-prefix` (`GCS_STATUS_`). The `Set release status`
step then prefers the freshly-issued token and falls back to the initial token
when token-exchange inputs are not provided (static-token callers).

The refresh step is guarded by `inputs.token-exchange-api-url != ''` so it is
a no-op for callers that do not supply exchange parameters.

## Test plan

- [x] CI (non-release) green on feature branch
- [x] Build OCM (Image w/ CLI) green on feature branch
- [ ] Verify on next ls-dev deploy-and-release run: `set-release-status: HTTP 200`

**Release note**:
```bugfix operator
sbom-upload: re-exchange GCS token immediately before set-release-status to
prevent HTTP 401 on long-running jobs where the initial token expires mid-run.
```