### PR TITLE
release: fix release-branch base by saving release-commit digest early

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -383,6 +383,15 @@ jobs:
           print(f'INFO: "automatic" version operation has been resolved to {next_version=}')
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f'next-version={next_version}\n')
+      - name: save-release-commit-digest
+        id: save-release-commit-digest
+        if: ${{ inputs.create-release-branch && steps.prep-next-version.outputs.next-version != 'bump-patch' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # save now: the release action will call version with commit-to-head for the bump-commit,
+          # which overwrites refs/capture-commit - so we must read it before that happens
+          echo "digest=$(git rev-parse refs/capture-commit)" >> $GITHUB_OUTPUT
       - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
@@ -482,11 +491,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
-          # note: only works if capture-commit action was only used to create the release-commit
-          commit_digest="$(git rev-parse refs/capture-commit)"
-
-          git reset --hard "$commit_digest"
+          git reset --hard "${{ steps.save-release-commit-digest.outputs.digest }}"
 
       - name: create-release-branch-bump-commit
         if: ${{ inputs.create-release-branch && steps.prep-next-version.outputs.next-version != 'bump-patch' }}


### PR DESCRIPTION
## Summary

When releasing with `create-release-branch: true` and `next-version: bump-minor`, the `release`
action calls the `version` action twice in the same job — once with `repository-operation:
capture-commit` (release commit) and once with `commit-to-head` (bump commit). The second call
unconditionally overwrites `refs/capture-commit` with the bump commit's SHA (e.g. `1.51.0-dev`).

The subsequent `reset-repository-to-release-commit` step then resets to that wrong base, so the
release-branch bump-patch commit lands on top of `1.51.0-dev` → `1.51.1-dev` instead of the
intended `1.50.0` → `1.50.1-dev`.

Fix: read `refs/capture-commit` into a step output before calling the `release` action, and use
that saved digest in the reset step instead of re-reading the (by then clobbered) ref.

## Test plan

- [ ] Trigger a `bump-minor` release with `create-release-branch: true` and verify the release
      branch is based on the release commit (e.g. `1.50.0` → `1.50.1-dev`), not the bump commit.