### PR TITLE
ocm-upgrade: keep-going on callback failure

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -234,8 +234,9 @@ runs:
           '${{ inputs.upstream-update-policy }}'.strip()
         )
 
-        created_upgrade_pullrequests = tuple(
-          ocm_upgrade.create_upgrade_pullrequests(
+        created_upgrade_pullrequests = []
+        upgrade_errors = []
+        for result in ocm_upgrade.create_upgrade_pullrequests(
             component=component,
             component_descriptor_lookup=component_descriptor_lookup,
             version_lookup=version_lookup,
@@ -252,8 +253,11 @@ runs:
             upstream_update_policy=upstream_update_policy,
             ignore_prerelease_versions=True,
             pr_naming_pattern='${{ inputs.pr-naming-pattern }}'
-          )
-        )
+          ):
+          if isinstance(result, ocm_upgrade.UpgradeError):
+            upgrade_errors.append(result)
+          else:
+            created_upgrade_pullrequests.append(result)
 
         upgrade_pullrequests.extend(created_upgrade_pullrequests)
 
@@ -272,5 +276,19 @@ runs:
         Created {len(created_upgrade_pullrequests)=}.
         '''
 
+        if upgrade_errors:
+          summary += '\n        ## Warnings: Failed Upgrade-Attempts\n\n'
+          for ue in upgrade_errors:
+            uv = ue.upgrade_vector
+            summary += (
+              f'        - **{uv.component_name}**: '
+              f'`{uv.whence.version}` → `{uv.whither.version}` '
+              f'— callback exited with {ue.error.returncode}\n'
+            )
+
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
           f.write(summary)
+
+        if upgrade_errors:
+          logger.error(f'{len(upgrade_errors)} upgrade(s) failed — see summary for details')
+          sys.exit(1)

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import traceback
 import typing
 
 try:
@@ -80,6 +81,13 @@ class MergePolicyConfig:
             if re.fullmatch(component, component_name):
                 return True
         return False
+
+
+@dataclasses.dataclass
+class UpgradeError:
+    upgrade_vector: 'ocm.gardener.UpgradeVector'
+    error: Exception
+    formatted_traceback: str
 
 
 def create_ocm_lookups(
@@ -497,20 +505,37 @@ def create_upgrade_pullrequests(
                 logger.info(f'upgrade-pullrequest for {uv=} already exists (skipping)')
                 continue
 
-            yield create_upgrade_pullrequest(
-                upgrade_vector=uv,
-                component_descriptor_lookup=component_descriptor_lookup,
-                version_lookup=version_lookup,
-                repo_dir=repo_dir,
-                repo_url=repo_url,
-                repository=repository,
-                merge_policy=current_merge_policy,
-                merge_method=current_merge_method,
-                branch=branch,
-                oci_client=oci_client,
-                component_reference_name=component_reference_name,
-                reference_component=component
-            )
+            try:
+                yield create_upgrade_pullrequest(
+                    upgrade_vector=uv,
+                    component_descriptor_lookup=component_descriptor_lookup,
+                    version_lookup=version_lookup,
+                    repo_dir=repo_dir,
+                    repo_url=repo_url,
+                    repository=repository,
+                    merge_policy=current_merge_policy,
+                    merge_method=current_merge_method,
+                    branch=branch,
+                    oci_client=oci_client,
+                    component_reference_name=component_reference_name,
+                    reference_component=component
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    f'callback failed for {uv=} with exit-code {e.returncode} - skipping'
+                )
+                yield UpgradeError(
+                    upgrade_vector=uv,
+                    error=e,
+                    formatted_traceback=traceback.format_exc(),
+                )
+            finally:
+                github.pullrequest.reset_worktree(
+                    gitutil.GitHelper(
+                        repo=repo_dir,
+                        git_cfg=gitutil.GitCfg(repo_url=repo_url),
+                    )
+                )
 
 
 def main():

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -412,6 +412,13 @@ def set_dependency_cmd_env(
     return cmd_env
 
 
+def reset_worktree(git_helper: gitutil.GitHelper):
+    git_helper.repo.git.reset('HEAD')  # also resets submodule gitlinks in index
+    git_helper.repo.git.submodule('update')  # checkout submodules to HEAD-recorded commit
+    git_helper.repo.git.checkout('.')
+    git_helper.repo.git.clean('-fd')
+
+
 @contextlib.contextmanager
 def commit_and_push_to_tmp_branch(
     repository: github3.repos.repo.Repository,
@@ -441,11 +448,6 @@ def commit_and_push_to_tmp_branch(
         logger.warning('an error occurred - removing now useless pr-branch')
         repository.ref(f'heads/{new_branch_name}').delete()
         raise
-
-    git_helper.repo.git.reset('HEAD')  # also resets submodule gitlinks in index
-    git_helper.repo.git.submodule('update')  # checkout submodules to HEAD-recorded commit
-    git_helper.repo.git.checkout('.')
-    git_helper.repo.git.clean('-fd')
 
     try:
         yield new_branch_name


### PR DESCRIPTION
## Summary

- Wrap each `create_upgrade_pullrequest` call in `create_upgrade_pullrequests` with `try/except subprocess.CalledProcessError`
- On callback failure: reset git worktree, yield an `UpgradeError` and continue to the next component
- Caller (action.yaml) collects errors separately, appends a warnings section to the job summary, and exits with code 1 if any failures occurred — so the job still fails but processes all components first

## Test plan

- [ ] Trigger the upgrade-dependencies workflow against a repo whose `.ci/set_dependency_version` callback fails for one component — confirm other upgrade-PRs are still created
- [ ] Confirm the job summary lists the failed component(s) under "Warnings"
- [ ] Confirm the job exits with a non-zero status when at least one callback failed