### PR TITLE
ocm-upgrade: keep-going on any error during PR creation

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -529,6 +529,15 @@ def create_upgrade_pullrequests(
                     error=e,
                     formatted_traceback=traceback.format_exc(),
                 )
+            except Exception as e:
+                logger.error(
+                    f'failed to create upgrade-pullrequest for {uv=} - skipping'
+                )
+                yield UpgradeError(
+                    upgrade_vector=uv,
+                    error=e,
+                    formatted_traceback=traceback.format_exc(),
+                )
             finally:
                 github.pullrequest.reset_worktree(
                     gitutil.GitHelper(


### PR DESCRIPTION
Extends the existing keep-going semantics (introduced for callback failures) to cover any exception raised during `create_upgrade_pullrequest` — in particular errors from BOM diff generation when a transitive component reference cannot be resolved in any configured OCM repository. Such upgrades are skipped (yielding an `UpgradeError`) rather than aborting the entire run, so one broken component does not block upgrade PRs for others.