### PR TITLE
ocm-upgrade: fix UpgradeError summary for non-callback errors

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -283,7 +283,7 @@ runs:
             summary += (
               f'        - **{uv.component_name}**: '
               f'`{uv.whence.version}` → `{uv.whither.version}` '
-              f'— callback exited with {ue.error.returncode}\n'
+              f'— {ue.error}\n'
               f'        <details><summary>Traceback</summary>\n\n'
               f'        ```\n{ue.formatted_traceback}```\n'
               f'        </details>\n'


### PR DESCRIPTION
The step-summary formatter for failed upgrades unconditionally accessed `ue.error.returncode`, which only exists on `subprocess.CalledProcessError`. Since the keep-going handler was broadened to catch any `Exception`, non-callback errors (e.g. `requests.HTTPError` from unresolvable component references) now also produce `UpgradeError` and hit this code path, causing an `AttributeError`. Fix: use `str(ue.error)` instead.