### PR TITLE
oci/client: log actual exception type on retry

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -591,7 +591,9 @@ class Client:
             if remaining_retries == 0:
                 raise
 
-            logger.warning(f'caught ConnectionError, going to retry... ({remaining_retries=}); {e}')
+            logger.warning(
+                f'caught {type(e).__name__}, going to retry... ({remaining_retries=}); {e}'
+            )
             if sleep_before_retry_seconds > 0:
                 time.sleep(sleep_before_retry_seconds)
 
@@ -676,7 +678,9 @@ class Client:
             if remaining_retries == 0:
                 raise
 
-            logger.warning(f'caught ConnectionError, going to retry... ({remaining_retries=}); {e}')
+            logger.warning(
+                f'caught {type(e).__name__}, going to retry... ({remaining_retries=}); {e}'
+            )
             if sleep_before_retry_seconds > 0:
                 time.sleep(sleep_before_retry_seconds)
 


### PR DESCRIPTION
`Timeout` is not a subclass of `ConnectionError` in `requests`; the
hardcoded `'caught ConnectionError'` log message was therefore misleading
for read/connect timeouts.  Use `type(e).__name__` instead.