### PR TITLE
ocm/gardener: emit symbolic@digest for mixed-tag refs in imagevector overwrites

### DIFF
--- a/ocm/gardener.py
+++ b/ocm/gardener.py
@@ -476,11 +476,17 @@ def image_dict_from_image_dict_and_resource(
     '''
     image_ref = oci.model.OciImageReference(resource.access.imageReference)
 
+    if image_ref.has_mixed_tag:
+        symbolic, digest = image_ref.parsed_mixed_tag
+        tag = f'{symbolic}@{digest}'
+    else:
+        tag = image_ref.tag
+
     image_dict = {
         'name': image['name'],
         'repository': image_ref.ref_without_tag,
         'sourceRepository': component_name,
-        'tag': image_ref.tag,
+        'tag': tag,
     }
 
     if (target_version := image.get('targetVersion')):
@@ -533,10 +539,16 @@ def oci_image_dict_from_resource(
     image_ref = oci.model.OciImageReference(resource.access.imageReference)
     repository = image_ref.ref_without_tag
 
+    if image_ref.has_mixed_tag:
+        symbolic, digest = image_ref.parsed_mixed_tag
+        tag = f'{symbolic}@{digest}'
+    else:
+        tag = image_ref.tag
+
     image_dict = {
         'name': name,
         'repository': repository,
-        'tag': image_ref.tag,
+        'tag': tag,
     }
 
     if (target_version_label := resource.find_label(


### PR DESCRIPTION
## Summary

- `image_ref.tag` on a mixed-tag ref (`repo:symbolic@sha256:digest`) returns only the digest half (`sha256:digest`)
- Consumers that join `repository` + `:` + `tag` then produce `repo:sha256:digest` — an invalid OCI reference
- Fix both `image_dict_from_image_dict_and_resource` and `oci_image_dict_from_resource` to emit `symbolic@digest` instead

## Context

Observed as a live breakage with VictoriaLogs in gardenlet's imagevector-overwrite ConfigMap:
the `tag` field was written as `sha256:f3ae…` instead of `v1.37.2@sha256:f3ae…`, causing Lakom
admission webhook to reject the reference with "could not parse reference".

A partial fix was applied in landscape-setup (PR #11434) to scripts that directly split image refs,
but the root cause is here — `ocm.gardener.image_vector_overwrite()` is the function that produces
the ConfigMap content.

## Test plan
- [ ] Unit test: call `oci_image_dict_from_resource` / `image_dict_from_image_dict_and_resource` with a mixed-tag `imageReference` and assert `tag == "symbolic@sha256:digest"`
- [ ] Integration: regenerate imagevector-overwrite for a gardener component containing mixed-tag resources; verify `tag` field format