### PR TITLE
ocm-validate: support transitive recursion, default to full closure

### DIFF
--- a/.github/actions/ocm-validate/action.yaml
+++ b/.github/actions/ocm-validate/action.yaml
@@ -28,6 +28,23 @@ inputs:
       schema: fail
       access: fail
       artefact-uniqueness: fail
+  ocm-repositories:
+    description: |
+      Comma-separated list of OCM repository base-URLs used to resolve transitive component
+      references. Only needed when `recursion-depth` is non-zero and the component descriptor
+      has componentReferences that need to be followed.
+    type: string
+    required: false
+    default: ''
+  recursion-depth:
+    description: |
+      How deep to recurse into componentReferences when iterating the component descriptor.
+      -1 = unlimited (full transitive closure, default).
+       0 = only the top-level component (no lookup needed).
+      Positive integers limit depth accordingly.
+      When non-zero, `ocm-repositories` must be provided.
+    type: number
+    default: -1
   on-validation-errors:
     description: |
       Controls how this action should convey (fatal) findings (see `validation-cfg` input). If
@@ -83,6 +100,8 @@ runs:
         total, warnings, errors = validate.validate(
           component_descriptor_path='${{ inputs.component-descriptor-path }}',
           validation_cfg=validation_cfg,
+          ocm_repositories='${{ inputs.ocm-repositories }}',
+          recursion_depth=${{ inputs.recursion-depth }},
         )
 
         print(f'{total=} validation-results, thereof {len(warnings)=}, {len(errors)=}')

--- a/.github/actions/ocm-validate/validate.py
+++ b/.github/actions/ocm-validate/validate.py
@@ -1,5 +1,6 @@
 import yaml
 
+import cnudie.retrieve
 import ocm
 import ocm.iter
 import ocm.validate
@@ -10,16 +11,31 @@ import oci.client
 def validate(
     component_descriptor_path: str,
     validation_cfg: ocm.validate.ValidationCfg,
+    ocm_repositories: str = '',
+    recursion_depth: int = -1,
 ) -> tuple[int, list[ocm.validate.ValidationError], list[ocm.validate.ValidationError]]:
     with open(component_descriptor_path) as f:
         component_descriptor = yaml.safe_load(f)
 
     component_descriptor = ocm.ComponentDescriptor.from_dict(component_descriptor)
 
+    if recursion_depth != 0:
+        if not ocm_repositories:
+            raise ValueError(
+                '`ocm-repositories` must be provided when `recursion-depth` is non-zero'
+            )
+        repos = [r.strip() for r in ocm_repositories.split(',') if r.strip()]
+        ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*repos)
+        lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+            ocm_repository_lookup=ocm_repo_lookup,
+        )
+    else:
+        lookup = None
+
     nodes = ocm.iter.iter(
         component=component_descriptor,
-        lookup=None,
-        recursion_depth=0,
+        lookup=lookup,
+        recursion_depth=recursion_depth,
     )
 
     total = 0

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -172,6 +172,12 @@ inputs:
     options:
       - fail
       - continue
+  ocm-validation-recursion-depth:
+    default: -1
+    type: number
+    description: |
+      Passed as `recursion-depth` to the `ocm-validate` action. -1 = full transitive closure
+      (default). 0 = top-level only. Requires `ocm-repositories` to be resolvable when non-zero.
   release-notes-path:
     required: false
     type: string
@@ -362,6 +368,8 @@ runs:
       with:
         component-descriptor-path: /tmp/component-descriptor.yaml
         on-validation-errors: ${{ inputs.on-validation-errors }}
+        ocm-repositories: ${{ steps.read-ocm-repositories.outputs.ocm-repositories }}
+        recursion-depth: ${{ inputs.ocm-validation-recursion-depth }}
         validation-cfg: |
           schema: fail
           access: fail

--- a/.github/workflows/post-build.yaml
+++ b/.github/workflows/post-build.yaml
@@ -196,6 +196,8 @@ jobs:
         with:
           component-descriptor-path: /tmp/ocm/component-descriptor.yaml
           on-validation-errors: ${{ inputs.on-validation-errors }}
+          ocm-repositories: ${{ steps.prep.outputs.ocm-repositories }}
+          recursion-depth: 0
           validation-cfg: |
             schema: fail
             access: ${{ steps.prep.outputs.can-push == 'true' && 'fail' || 'skip' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,13 @@ on:
 
           Validation can be customised using `ocm-validation-cfg` input (currently, only
           OCM-Component-Descriptor validation is implemented).
+      ocm-validation-recursion-depth:
+        default: -1
+        type: number
+        description: |
+          How deep to recurse into componentReferences during OCM validation.
+          -1 = full transitive closure (default). 0 = top-level only.
+          See `ocm-validate` action for details.
       release-commit-objects:
         required: false
         type: string
@@ -436,6 +443,7 @@ jobs:
           next-version-commit-message: "next version: ${version}"
           next-version-callback-action-path: ${{ inputs.next-version-callback-action-path }}
           on-validation-errors: ${{ inputs.on-validation-errors }}
+          ocm-validation-recursion-depth: ${{ inputs.ocm-validation-recursion-depth }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-push-token: ${{ steps.fed-token.outputs.token }}
           release-on-github: ${{ inputs.release-on-github }}

--- a/test/actions/ocm-validate/schema-violation/workflow.yaml
+++ b/test/actions/ocm-validate/schema-violation/workflow.yaml
@@ -13,6 +13,7 @@ jobs:
             schema: fail
             access: skip
             artefact-uniqueness: skip
+          recursion-depth: 0
           on-validation-errors: continue
       - name: assert
         shell: bash

--- a/test/actions/ocm-validate/valid/workflow.yaml
+++ b/test/actions/ocm-validate/valid/workflow.yaml
@@ -13,6 +13,7 @@ jobs:
             schema: fail
             access: skip
             artefact-uniqueness: fail
+          recursion-depth: 0
           on-validation-errors: fail
       - name: assert
         shell: bash


### PR DESCRIPTION
## Summary

- `ocm-validate` action and `validate.py` hardcoded `recursion_depth=0`/`lookup=None`, so
  validation only covered the top-level component descriptor's own resources — transitive
  `componentReference` chains were never checked
- adds `ocm-repositories` (comma-separated) and `recursion-depth` inputs to `ocm-validate`
  action; wires them through `release` action and `release.yaml` workflow
- default is `-1` (full transitive closure); set explicitly to `0` to restore old behaviour

## Test plan

- [ ] trigger a release pipeline for a component with transitive references containing a
  deliberately stale OCI image — confirm validation now fails
- [ ] verify existing pipelines that do not pass `ocm-repositories` get a clear error rather
  than a silent no-op (ValueError raised in `validate.py`)