### PR TITLE
trusted-checkout: improve submodules input docs

### DIFF
--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -30,7 +30,16 @@ inputs:
     type: string
     default: false
     description: |
-      passed to `actions/checkout` as `submodules` input.
+      Controls submodule checkout. Accepted values:
+
+      - `false` (default): no submodule checkout
+      - `recursive`: check out all submodules recursively, using federated tokens
+        (via `token-server`) or app credentials where available, so private submodules
+        across organisations are handled transparently
+      - any other value (e.g. `true`): ignored — no submodule checkout will occur
+
+      Note: unlike `actions/checkout`, this input is *not* passed through to the
+      underlying checkout action. Submodule handling is done by this action itself.
   auth-app-client-id:
     type: string
     default: ''

--- a/.github/actions/trusted-checkout/action.yaml
+++ b/.github/actions/trusted-checkout/action.yaml
@@ -3,6 +3,10 @@ description: |
   A wrapper around github.com/actions/checkout, with safety measures for pullrequests triggered
   from forks with `pull_request_target` event.
 
+  Also handles submodule checkout (set `submodules: recursive`), including private submodules
+  across organisations, by transparently obtaining federated tokens via the OIDC federation
+  service (when `token-server` is configured).
+
   It will by default behave identical to wrapped checkout-action. For pullrequests from forked
   repositories, which are triggered by the `pull_request_target` event (where wrapped checkout
   action will by default checkout receiving repository's contents), this action will instead
@@ -37,9 +41,6 @@ inputs:
         (via `token-server`) or app credentials where available, so private submodules
         across organisations are handled transparently
       - any other value (e.g. `true`): ignored — no submodule checkout will occur
-
-      Note: unlike `actions/checkout`, this input is *not* passed through to the
-      underlying checkout action. Submodule handling is done by this action itself.
   auth-app-client-id:
     type: string
     default: ''


### PR DESCRIPTION
Clarify that the `submodules` input is **not** passed to `actions/checkout`.
Submodule handling is implemented by this action itself; only `recursive` triggers it.
Values like `true` are silently ignored.