### PR TITLE
feat(oci): cross-repository blob mounting for same-registry replication

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -445,6 +445,9 @@ def replicate_blobs(
     Note that the uploaded artifact must be finalised after the upload by a "manifest-put".
     '''
     blob_overwrites = {k.digest:v for k,v in blob_overwrites.items()}
+    src_ref = om.OciImageReference(src_ref)
+    tgt_ref = om.OciImageReference(tgt_ref)
+    same_registry = src_ref.netloc == tgt_ref.netloc
 
     def replicate_blob(blob: om.OciBlobRef) -> om.OciBlobRef:
         if blob_overwrite_bytes := blob_overwrites.get(blob.digest):
@@ -475,6 +478,24 @@ def replicate_blobs(
             )
         else:
             digest = blob.digest
+
+            if oci_client.head_blob(image_reference=tgt_ref, digest=digest).ok:
+                return om.OciBlobRef(
+                    digest=digest,
+                    mediaType=blob.mediaType,
+                    size=blob.size,
+                )
+
+            if same_registry and oci_client.mount_blob(
+                image_reference=tgt_ref,
+                digest=digest,
+                from_reference=src_ref,
+            ):
+                return om.OciBlobRef(
+                    digest=digest,
+                    mediaType=blob.mediaType,
+                    size=blob.size,
+                )
 
             src_blob: requests.models.Response = oci_client.blob(
                 image_reference=src_ref,

--- a/oci/client.py
+++ b/oci/client.py
@@ -182,6 +182,19 @@ class OciRoutes:
             'uploads',
         ) + '/'
 
+    def mount_url(
+        self,
+        image_reference: str,
+        digest: str,
+        from_repo: str,
+    ) -> str:
+        '''
+        URL for cross-repository blob mount per OCI distribution spec:
+        POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<other-repo>
+        '''
+        query = urllib.parse.urlencode({'mount': digest, 'from': from_repo})
+        return self.uploads_url(image_reference=image_reference) + '?' + query
+
     def single_post_blob_url(self, image_reference: str, digest: str) -> str:
         '''
         used for "single-post" monolithic upload (not supported e.g. by registry-1.docker.io)
@@ -1270,6 +1283,56 @@ class Client:
         res.raise_for_status()
 
         return res
+
+    @initialise_repository_if_required
+    def mount_blob(
+        self,
+        image_reference: str | om.OciImageReference,
+        digest: str,
+        from_reference: str | om.OciImageReference,
+    ) -> bool:
+        '''
+        Attempts a cross-repository blob mount per OCI distribution spec
+        (POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo>).
+
+        Returns True if the registry mounted the blob (HTTP 201), False if it
+        fell back to a normal upload session (HTTP 202 — caller must still upload
+        the blob via put_blob).
+
+        Using this before put_blob avoids a client-side download+re-upload when
+        source and target live on the same registry.
+        '''
+        image_reference = om.OciImageReference(image_reference)
+        from_reference = om.OciImageReference(from_reference)
+        scope = _scope(image_reference=image_reference, action='push,pull')
+
+        res = self._request(
+            url=self.routes.mount_url(
+                image_reference=str(image_reference),
+                digest=digest,
+                from_repo=from_reference.name,
+            ),
+            image_reference=image_reference,
+            scope=scope,
+            method='POST',
+            headers={'content-length': '0'},
+            raise_for_status=False,
+        )
+
+        if res.status_code == 201:
+            logger.debug(f'cross-repo mount succeeded {digest=} {from_reference=}')
+            return True
+
+        if res.status_code != 202:
+            # spec says 202 = mount unavailable, fall back to regular upload;
+            # non-compliant registries (e.g. keppel, nexus) may return errors instead —
+            # treat any non-201 as "mount not available" to stay robust
+            logger.warning(
+                f'unexpected response to mount attempt '
+                f'({res.status_code=}); falling back to regular upload'
+            )
+
+        return False
 
     def put_blob(
         self,


### PR DESCRIPTION
## Summary

- Adds `Client.mount_blob()` implementing the OCI distribution spec cross-repo mount (`POST .../blobs/uploads/?mount=<digest>&from=<repo>`)
- `replicate_blobs()` now attempts a mount before falling back to download + re-upload, avoiding a full client-side round-trip for same-registry copies
- Non-compliant registries (keppel, nexus, …) returning unexpected status codes fall back gracefully to regular upload with a warning logged

Addresses the one outstanding item from https://github.com/gardener/cc-utils/issues/560.

**Release note**:
```feature developer
oci: cross-repository blob mounting is now attempted during same-registry replication, avoiding redundant client-side download + re-upload when the registry supports it; non-compliant registries fall back to regular upload transparently.
```