### PR TITLE
sbom: add token refresh to set-status; drop inline bash

### DIFF
--- a/.github/actions/sbom-set-status/action.yaml
+++ b/.github/actions/sbom-set-status/action.yaml
@@ -56,6 +56,28 @@ inputs:
       A warning is printed if the timeout is reached; the released write still proceeds.
     required: false
     default: '600'
+  # token refresh — optional; when all four are supplied, set_status.py re-requests a
+  # fresh GCS token on HTTP 401, so a long-running poll cannot expire mid-flight.
+  token-exchange-api-url:
+    description: 'Base URL of the token exchange API (enables mid-run token refresh)'
+    required: false
+    default: ''
+  token-exchange-audience:
+    description: 'OIDC audience for token refresh'
+    required: false
+    default: ''
+  token-exchange-pipeline-id:
+    description: 'Pipeline identifier for token refresh'
+    required: false
+    default: ''
+  token-exchange-pipeline-group-id:
+    description: 'Pipeline group identifier for token refresh'
+    required: false
+    default: ''
+  token-exchange-scope:
+    description: 'Scope to re-request on token refresh (e.g. "cumulus")'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -72,8 +94,23 @@ runs:
         ON_ABSENT: ${{ inputs.on-absent }}
         POLL_INTERVAL: ${{ inputs.poll-interval }}
         POLL_TIMEOUT: ${{ inputs.poll-timeout }}
+        TOKEN_EXCHANGE_API_URL: ${{ inputs.token-exchange-api-url }}
+        TOKEN_EXCHANGE_AUDIENCE: ${{ inputs.token-exchange-audience }}
+        TOKEN_EXCHANGE_PIPELINE_ID: ${{ inputs.token-exchange-pipeline-id }}
+        TOKEN_EXCHANGE_PIPELINE_GROUP_ID: ${{ inputs.token-exchange-pipeline-group-id }}
+        TOKEN_EXCHANGE_SCOPE: ${{ inputs.token-exchange-scope }}
       run: |
         set -euo pipefail
+        extra_args=()
+        if [ -n "${TOKEN_EXCHANGE_API_URL}" ]; then
+          extra_args+=(
+            --token-exchange-api-url           "$TOKEN_EXCHANGE_API_URL"
+            --token-exchange-audience          "$TOKEN_EXCHANGE_AUDIENCE"
+            --token-exchange-pipeline-id       "$TOKEN_EXCHANGE_PIPELINE_ID"
+            --token-exchange-pipeline-group-id "$TOKEN_EXCHANGE_PIPELINE_GROUP_ID"
+            --token-exchange-scope             "$TOKEN_EXCHANGE_SCOPE"
+          )
+        fi
         if [ -n "${RUN_KEYS}" ]; then
           python3 "$GITHUB_ACTION_PATH/set_status.py" \
             --gcs-bucket           "$GCS_BUCKET" \
@@ -83,7 +120,8 @@ runs:
             --on-already-released  "$ON_ALREADY_RELEASED" \
             --on-absent            "$ON_ABSENT" \
             --poll-interval        "$POLL_INTERVAL" \
-            --poll-timeout         "$POLL_TIMEOUT"
+            --poll-timeout         "$POLL_TIMEOUT" \
+            "${extra_args[@]}"
         else
           python3 "$GITHUB_ACTION_PATH/set_status.py" \
             --gcs-bucket           "$GCS_BUCKET" \
@@ -92,5 +130,6 @@ runs:
             --release-status       "$RELEASE_STATUS" \
             --on-already-released  "$ON_ALREADY_RELEASED" \
             --poll-interval        "$POLL_INTERVAL" \
-            --poll-timeout         "$POLL_TIMEOUT"
+            --poll-timeout         "$POLL_TIMEOUT" \
+            "${extra_args[@]}"
         fi

--- a/.github/actions/sbom-set-status/set_status.py
+++ b/.github/actions/sbom-set-status/set_status.py
@@ -15,6 +15,7 @@ Smart transition logic:
 '''
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.parse
@@ -23,6 +24,65 @@ import urllib.request
 
 _GCS_BASE = 'https://storage.googleapis.com/storage/v1/b'
 _GCS_UPLOAD = 'https://storage.googleapis.com/upload/storage/v1/b'
+_MAX_RESPONSE = 65536  # cap on raw response reads (tokens, write-ACKs)
+
+
+def _read_capped(r, label: str = 'response') -> bytes:
+    data = r.read(_MAX_RESPONSE + 1)
+    if len(data) > _MAX_RESPONSE:
+        raise RuntimeError(f'{label} exceeds {_MAX_RESPONSE} bytes — aborting')
+    return data
+
+
+def _fetch_token(
+    api_url: str,
+    oidc_audience: str,
+    pipeline_id: str,
+    pipeline_group_id: str,
+    scope: str,
+) -> str:
+    '''Dual-token exchange against System Trust; return scoped GCS token.'''
+    request_token = os.environ.get('ACTIONS_ID_TOKEN_REQUEST_TOKEN', '')
+    request_url = os.environ.get('ACTIONS_ID_TOKEN_REQUEST_URL', '')
+    if not request_token or not request_url:
+        raise RuntimeError('ACTIONS_ID_TOKEN_REQUEST_TOKEN/_URL not set; cannot refresh token')
+
+    req = urllib.request.Request(
+        f'{request_url}&audience={urllib.parse.quote(oidc_audience)}',
+        headers={'Authorization': f'Bearer {request_token}'},
+    )
+    with urllib.request.urlopen(req) as r:  # nosec B310
+        actions_token = json.load(r)['value']
+
+    req = urllib.request.Request(
+        'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity'
+        f'?audience={urllib.parse.quote(oidc_audience)}&format=full',
+        headers={'Metadata-Flavor': 'Google'},
+    )
+    with urllib.request.urlopen(req) as r:  # nosec B310
+        gcp_token = _read_capped(r, 'GCP identity token').decode()
+
+    req = urllib.request.Request(
+        f'{api_url}/auth'
+        f'?group_id={urllib.parse.quote(pipeline_group_id, safe="")}'
+        f'&pipeline_id={urllib.parse.quote(pipeline_id, safe="")}',
+        headers={
+            'X-Trust-Authorization-Orchestrator': actions_token,
+            'X-Trust-Authorization-Runtime': gcp_token,
+        },
+    )
+    with urllib.request.urlopen(req) as r:  # nosec B310
+        session_token = json.load(r)['token']
+
+    req = urllib.request.Request(
+        f'{api_url}/tokens?systems={urllib.parse.quote(scope, safe="")}',
+        headers={'Authorization': f'Bearer {session_token}'},
+    )
+    with urllib.request.urlopen(req) as r:  # nosec B310
+        return json.load(r)[scope]
+
+
+# NOTE: _fetch_token is duplicated verbatim in sbom-upload/upload.py — keep in sync.
 
 # statuses that count as "promoted already done" for ordering purposes
 _PROMOTED_DONE = {'promoted', 'deployed-to-production', 'released'}
@@ -37,21 +97,29 @@ VALID_STATUSES = {
 }
 
 
-def _current_status(bucket: str, token: str, run_key: str) -> str | None:
+def _current_status(bucket: str, token: str, run_key: str, refresh=None) -> str | None:
     '''Return the most recent releaseStatus for run_key, or None if absent.'''
     prefix = f'{run_key}/.status-log/release/'
     url = (
         f'{_GCS_BASE}/{urllib.parse.quote(bucket, safe="")}/o'
         f'?prefix={urllib.parse.quote(prefix, safe="")}'
     )
-    req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}'})
-    try:
-        with urllib.request.urlopen(req) as r:  # nosec B310
-            body = json.load(r)
-    except urllib.error.HTTPError as e:
-        if e.code == 404:
-            return None
-        raise
+    refreshed = False
+    while True:
+        req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}'})
+        try:
+            with urllib.request.urlopen(req) as r:  # nosec B310
+                body = json.load(r)
+            break
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and not refreshed and refresh is not None:
+                print('GCS token expired — refreshing ...', file=sys.stderr)
+                token = refresh()
+                refreshed = True
+                continue
+            if e.code == 404:
+                return None
+            raise
     items = body.get('items', [])
     if not items:
         return None
@@ -64,7 +132,8 @@ def _current_status(bucket: str, token: str, run_key: str) -> str | None:
         return json.load(r).get('releaseStatus')
 
 
-def _write_status(bucket: str, token: str, run_key: str, status: str) -> None:
+def _write_status(bucket: str, token: str, run_key: str, status: str, refresh=None) -> str:
+    '''Write status entry; refreshes token on 401; returns the token (possibly refreshed).'''
     ts = int(time.time())
     blob = f'{run_key}/.status-log/release/release-status-{ts}.json'
     url = (
@@ -72,13 +141,24 @@ def _write_status(bucket: str, token: str, run_key: str, status: str) -> None:
         f'?uploadType=media&name={urllib.parse.quote(blob, safe="")}'
     )
     data = json.dumps({'releaseStatus': status}).encode()
-    req = urllib.request.Request(url, data=data, headers={
-        'Authorization': f'Bearer {token}',
-        'Content-Type': 'application/json',
-    })
-    with urllib.request.urlopen(req) as r:  # nosec B310
-        r.read()
-    print(f'wrote status: {status}', file=sys.stderr)
+    refreshed = False
+    while True:
+        req = urllib.request.Request(url, data=data, headers={
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/json',
+        })
+        try:
+            with urllib.request.urlopen(req) as r:  # nosec B310
+                _read_capped(r, 'GCS write response')
+            print(f'wrote status: {status}', file=sys.stderr)
+            return token
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and not refreshed and refresh is not None:
+                print('GCS token expired — refreshing ...', file=sys.stderr)
+                token = refresh()
+                refreshed = True
+                continue
+            raise
 
 
 def _first_sbom_object(bucket: str, token: str, run_key: str) -> str | None:
@@ -106,23 +186,26 @@ def _poll_sbom_locked(
     run_key: str,
     interval: int,
     timeout: int,
-) -> None:
+    refresh=None,
+) -> str:
     '''Poll an overwrite of an existing sbom/ object until Cumulus applies the hold (HTTP 403).
 
     Cumulus locks by setting per-object holds on existing objects, not path-level IAM.
     A new-object write always succeeds (200); only overwriting a held object returns 403.
     If no sbom/ objects exist, the lock can never fire — skip immediately.
+    Returns the (possibly refreshed) token.
     '''
     probe = _first_sbom_object(bucket, token, run_key)
     if probe is None:
         print('no sbom/ objects found — skipping lock poll', file=sys.stderr)
-        return
+        return token
     url = (
         f'{_GCS_UPLOAD}/{urllib.parse.quote(bucket, safe="")}/o'
         f'?uploadType=media&name={urllib.parse.quote(probe, safe="")}'
     )
     deadline = time.monotonic() + timeout
     attempt = 0
+    refreshed = False
     while True:
         attempt += 1
         req = urllib.request.Request(
@@ -135,20 +218,25 @@ def _poll_sbom_locked(
         )
         try:
             with urllib.request.urlopen(req) as r:  # nosec B310
-                r.read()
+                _read_capped(r, 'GCS lock-probe response')
             code = 200
         except urllib.error.HTTPError as e:
+            if e.code == 401 and not refreshed and refresh is not None:
+                print('GCS token expired — refreshing ...', file=sys.stderr)
+                token = refresh()
+                refreshed = True
+                continue
             code = e.code
         print(f'poll sbom/ lock: attempt {attempt}, HTTP {code}', file=sys.stderr)
         if code == 403:
             print('sbom/ locked — promoted registered with Cumulus', file=sys.stderr)
-            return
+            return token
         if time.monotonic() >= deadline:
             print(
                 f'warning: sbom/ not locked after {timeout}s — proceeding anyway',
                 file=sys.stderr,
             )
-            return
+            return token
         time.sleep(interval)
 
 
@@ -198,11 +286,34 @@ def main() -> None:
         metavar='SECONDS',
         help='max seconds to wait for sbom/ lock before proceeding (default: 600)',
     )
+    # token refresh — optional; enables re-auth on 401 mid-run
+    parser.add_argument('--token-exchange-api-url', default='', metavar='URL')
+    parser.add_argument('--token-exchange-audience', default='', metavar='AUD')
+    parser.add_argument('--token-exchange-pipeline-id', default='', metavar='ID')
+    parser.add_argument('--token-exchange-pipeline-group-id', default='', metavar='GID')
+    parser.add_argument('--token-exchange-scope', default='', metavar='SCOPE')
     args = parser.parse_args()
 
     bucket = args.gcs_bucket
     token = args.gcs_token
     target = args.release_status
+
+    refresh_args = (
+        args.token_exchange_api_url,
+        args.token_exchange_audience,
+        args.token_exchange_pipeline_id,
+        args.token_exchange_pipeline_group_id,
+        args.token_exchange_scope,
+    )
+    if all(refresh_args):
+        def refresh():
+            nonlocal token
+            token = _fetch_token(*refresh_args)
+            return token
+        print('token auto-refresh: enabled', file=sys.stderr)
+    else:
+        refresh = None
+        print('token auto-refresh: disabled', file=sys.stderr)
 
     if args.run_keys:
         run_keys = [k.strip() for k in args.run_keys.splitlines() if k.strip()]
@@ -210,7 +321,7 @@ def main() -> None:
         run_keys = [args.run_key]
 
     for run_key in run_keys:
-        current = _current_status(bucket, token, run_key)
+        current = _current_status(bucket, token, run_key, refresh=refresh)
         print(f'run-key: {run_key!r}  current: {current!r}  target: {target!r}', file=sys.stderr)
 
         if current is None:
@@ -231,13 +342,15 @@ def main() -> None:
         # pre-write promoted if the target requires it and it hasn't been done yet
         if target in _NEEDS_PROMOTED and current not in _PROMOTED_DONE:
             print('pre-writing promoted (required before {})'.format(target), file=sys.stderr)
-            _write_status(bucket, token, run_key, 'promoted')
+            token = _write_status(bucket, token, run_key, 'promoted', refresh=refresh)
 
         # for released: wait until Cumulus has processed the promoted write (sbom/ locked)
         if target == 'released':
-            _poll_sbom_locked(bucket, token, run_key, args.poll_interval, args.poll_timeout)
+            token = _poll_sbom_locked(
+                bucket, token, run_key, args.poll_interval, args.poll_timeout, refresh=refresh,
+            )
 
-        _write_status(bucket, token, run_key, target)
+        _write_status(bucket, token, run_key, target, refresh=refresh)
 
 
 if __name__ == '__main__':

--- a/.github/actions/sbom-upload/action.yaml
+++ b/.github/actions/sbom-upload/action.yaml
@@ -220,49 +220,19 @@ runs:
           --token-exchange-scope '${{ inputs.token-exchange-scope }}' \
           "${repos_args[@]}"
 
-    - name: Refresh GCS token before status write
-      if: >
-        steps.check-status.outputs.already-released != 'true' &&
-        inputs.release-status != '' &&
-        inputs.token-exchange-api-url != ''
-      uses: gardener/cc-utils/.github/actions/oidc-gcp-token-exchange@master
-      with:
-        api-url: ${{ inputs.token-exchange-api-url }}
-        oidc-audience: ${{ inputs.token-exchange-audience }}
-        pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
-        pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
-        scopes: ${{ inputs.token-exchange-scope }}
-        token-env-prefix: 'GCS_STATUS_'
-
     - name: Set release status
       if: >
         steps.check-status.outputs.already-released != 'true' &&
         inputs.release-status != ''
-      shell: bash
-      env:
-        BUCKET: ${{ inputs.gcs-bucket }}
-        GCS_TOKEN_INITIAL: ${{ inputs.gcs-token }}
-        TOKEN_EXCHANGE_SCOPE: ${{ inputs.token-exchange-scope }}
-        RUN_KEY: ${{ steps.resolve-run-key.outputs.run-key }}
-        RELEASE_STATUS: ${{ inputs.release-status }}
-      run: |
-        set -euo pipefail
-        scope_upper=$(echo "${TOKEN_EXCHANGE_SCOPE}" | tr '[:lower:]' '[:upper:]')
-        fresh_var="GCS_STATUS_${scope_upper}_TOKEN"
-        GCS_TOKEN="${!fresh_var:-${GCS_TOKEN_INITIAL}}"
-        ts=$(date -u +%s)
-        blob="${RUN_KEY}/.status-log/release/release-status-${ts}.json"
-        blob_enc="${blob//\//%2F}"
-        status=$(printf '{"releaseStatus":"%s"}' "$RELEASE_STATUS" | \
-          curl -s -o /tmp/gcs-status-resp.json -w '%{http_code}' \
-            -X POST \
-            "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${blob_enc}" \
-            -H "Authorization: Bearer ${GCS_TOKEN}" \
-            -H 'Content-Type: application/json' \
-            --data-binary @- \
-        )
-        echo "set-release-status: HTTP ${status}"
-        if [ "$status" != "200" ]; then
-          cat /tmp/gcs-status-resp.json || true
-          echo "Warning: failed to set release status (HTTP ${status})" >&2
-        fi
+      uses: gardener/cc-utils/.github/actions/sbom-set-status@master
+      with:
+        gcs-bucket: ${{ inputs.gcs-bucket }}
+        gcs-token: ${{ inputs.gcs-token }}
+        run-key: ${{ steps.resolve-run-key.outputs.run-key }}
+        release-status: ${{ inputs.release-status }}
+        on-already-released: ${{ inputs.on-already-released }}
+        token-exchange-api-url: ${{ inputs.token-exchange-api-url }}
+        token-exchange-audience: ${{ inputs.token-exchange-audience }}
+        token-exchange-pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
+        token-exchange-pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
+        token-exchange-scope: ${{ inputs.token-exchange-scope }}

--- a/.github/actions/sbom-upload/upload.py
+++ b/.github/actions/sbom-upload/upload.py
@@ -64,6 +64,16 @@ def _fmt_bytes(n: int) -> str:
         v /= 1024
 
 
+_MAX_RESPONSE = 65536  # cap on raw response reads (tokens, write-ACKs)
+
+
+def _read_capped(r, label: str = 'response') -> bytes:
+    data = r.read(_MAX_RESPONSE + 1)
+    if len(data) > _MAX_RESPONSE:
+        raise RuntimeError(f'{label} exceeds {_MAX_RESPONSE} bytes — aborting')
+    return data
+
+
 @dataclasses.dataclass
 class _TokenRefreshConfig:
     api_url: str
@@ -74,7 +84,9 @@ class _TokenRefreshConfig:
 
 
 def _fetch_token(cfg: _TokenRefreshConfig) -> str:
-    '''Perform dual-token exchange against System Trust; return scoped GCS token.'''
+    '''Perform dual-token exchange against System Trust; return scoped GCS token.
+    NOTE: duplicated verbatim in sbom-set-status/set_status.py — keep in sync.
+    '''
     # Step 1: GitHub OIDC token
     actions_token_request_token = os.environ.get('ACTIONS_ID_TOKEN_REQUEST_TOKEN', '')
     actions_token_request_url = os.environ.get('ACTIONS_ID_TOKEN_REQUEST_URL', '')
@@ -99,7 +111,7 @@ def _fetch_token(cfg: _TokenRefreshConfig) -> str:
         headers={'Metadata-Flavor': 'Google'},
     )
     with urllib.request.urlopen(req) as r:  # nosec B310
-        gcp_token = r.read().decode()
+        gcp_token = _read_capped(r, 'GCP identity token').decode()
 
     # Step 3: System Trust /auth
     group_enc = urllib.parse.quote(cfg.pipeline_group_id, safe='')


### PR DESCRIPTION
## Summary

- `set_status.py` gains `_fetch_token` and optional `--token-exchange-*` args; on HTTP 401 it re-fetches the GCS token and retries, preventing expiry failures during long lock-polls
- `sbom-set-status/action.yaml` exposes the new token-exchange inputs (all optional)
- `sbom-upload/action.yaml` replaces the separate pre-step token refresh + warn-only inline bash with a single `sbom-set-status@master` call — write failures now propagate correctly

## Test plan

- [ ] Trigger `sbom-upload` workflow on a fresh version; verify `promoted` and `released` writes succeed as before
- [ ] Confirm a re-run on an already-released version skips cleanly (`on-already-released=skip`)
- [ ] Verify `token auto-refresh: enabled` appears in logs when token-exchange args are supplied