### PR TITLE
sbom-set-status: add --mode, fix token refresh, improve logging

### DIFF
--- a/.github/actions/sbom-set-status/action.yaml
+++ b/.github/actions/sbom-set-status/action.yaml
@@ -111,6 +111,12 @@ runs:
         TOKEN_EXCHANGE_SCOPE: ${{ inputs.token-exchange-scope }}
       run: |
         set -euo pipefail
+        if [ -n "${RUN_KEY}" ]; then
+          echo "set-release-status: run-key='${RUN_KEY}' target=${RELEASE_STATUS} mode=${MODE}" >&2
+        else
+          n=$(echo "${RUN_KEYS}" | grep -c '[^[:space:]]' || true)
+          echo "set-release-status: ${n} run-key(s) target=${RELEASE_STATUS} mode=${MODE}" >&2
+        fi
         extra_args=()
         if [ -n "${TOKEN_EXCHANGE_API_URL}" ]; then
           extra_args+=(

--- a/.github/actions/sbom-set-status/action.yaml
+++ b/.github/actions/sbom-set-status/action.yaml
@@ -44,8 +44,17 @@ inputs:
       Action when a run-key has no status entries in the bucket:
         skip – silently ignore (default)
         fail – exit 1
+      Ignored unless mode is "update".
     required: false
     default: 'skip'
+  mode:
+    description: >
+      Write mode:
+        create           – fail if status entries already exist (exclusive first write).
+        update           – skip/fail if absent (on-absent applies); existence is fine.
+        create-or-update – write unconditionally; neither absence nor existence is an error.
+    required: false
+    default: 'create-or-update'
   poll-interval:
     description: 'Seconds between lock-poll attempts when transitioning to released (default: 30)'
     required: false
@@ -92,6 +101,7 @@ runs:
         RELEASE_STATUS: ${{ inputs.release-status }}
         ON_ALREADY_RELEASED: ${{ inputs.on-already-released }}
         ON_ABSENT: ${{ inputs.on-absent }}
+        MODE: ${{ inputs.mode }}
         POLL_INTERVAL: ${{ inputs.poll-interval }}
         POLL_TIMEOUT: ${{ inputs.poll-timeout }}
         TOKEN_EXCHANGE_API_URL: ${{ inputs.token-exchange-api-url }}
@@ -119,6 +129,7 @@ runs:
             --release-status       "$RELEASE_STATUS" \
             --on-already-released  "$ON_ALREADY_RELEASED" \
             --on-absent            "$ON_ABSENT" \
+            --mode                 "$MODE" \
             --poll-interval        "$POLL_INTERVAL" \
             --poll-timeout         "$POLL_TIMEOUT" \
             "${extra_args[@]}"
@@ -129,6 +140,8 @@ runs:
             --run-key              "$RUN_KEY" \
             --release-status       "$RELEASE_STATUS" \
             --on-already-released  "$ON_ALREADY_RELEASED" \
+            --on-absent            "$ON_ABSENT" \
+            --mode                 "$MODE" \
             --poll-interval        "$POLL_INTERVAL" \
             --poll-timeout         "$POLL_TIMEOUT" \
             "${extra_args[@]}"

--- a/.github/actions/sbom-set-status/set_status.py
+++ b/.github/actions/sbom-set-status/set_status.py
@@ -273,6 +273,17 @@ def main() -> None:
         help='"skip" ignores run-keys with no status entries, "fail" aborts (default: skip)',
     )
     parser.add_argument(
+        '--mode',
+        choices=('create', 'update', 'create-or-update'),
+        default='create-or-update',
+        metavar='MODE',
+        help=(
+            '"create": fail if status entries already exist; '
+            '"update": skip/fail if absent (on-absent applies); '
+            '"create-or-update": write unconditionally (default: create-or-update)'
+        ),
+    )
+    parser.add_argument(
         '--poll-interval',
         type=int,
         default=30,
@@ -325,11 +336,19 @@ def main() -> None:
         print(f'run-key: {run_key!r}  current: {current!r}  target: {target!r}', file=sys.stderr)
 
         if current is None:
-            if args.on_absent == 'fail':
-                print(f'error: run-key {run_key!r} has no status entries', file=sys.stderr)
-                sys.exit(1)
-            print(f'run-key {run_key!r} absent — skipping', file=sys.stderr)
-            continue
+            if args.mode == 'update':
+                if args.on_absent == 'fail':
+                    print(f'error: run-key {run_key!r} has no status entries', file=sys.stderr)
+                    sys.exit(1)
+                print(f'run-key {run_key!r} absent — skipping', file=sys.stderr)
+                continue
+            # create / create-or-update: absence is fine — fall through to write
+        elif args.mode == 'create':
+            print(
+                f'error: run-key {run_key!r} already has status {current!r}',
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         if current == 'released':
             msg = f'run-key {run_key!r} is already in "released" state'

--- a/.github/actions/sbom-set-status/set_status.py
+++ b/.github/actions/sbom-set-status/set_status.py
@@ -333,7 +333,11 @@ def main() -> None:
 
     for run_key in run_keys:
         current = _current_status(bucket, token, run_key, refresh=refresh)
-        print(f'run-key: {run_key!r}  current: {current!r}  target: {target!r}', file=sys.stderr)
+        current_s = current if current is not None else '(none)'
+        print(
+            f'setting status for run-key={run_key!r} to {target!r} (was: {current_s})',
+            file=sys.stderr,
+        )
 
         if current is None:
             if args.mode == 'update':

--- a/.github/actions/sbom-upload/action.yaml
+++ b/.github/actions/sbom-upload/action.yaml
@@ -231,6 +231,7 @@ runs:
         run-key: ${{ steps.resolve-run-key.outputs.run-key }}
         release-status: ${{ inputs.release-status }}
         on-already-released: ${{ inputs.on-already-released }}
+        mode: create-or-update
         token-exchange-api-url: ${{ inputs.token-exchange-api-url }}
         token-exchange-audience: ${{ inputs.token-exchange-audience }}
         token-exchange-pipeline-id: ${{ inputs.token-exchange-pipeline-id }}

--- a/.github/workflows/sbom-set-status.yaml
+++ b/.github/workflows/sbom-set-status.yaml
@@ -143,3 +143,8 @@ jobs:
           on-absent: 'skip'
           poll-interval: ${{ inputs.poll-interval }}
           poll-timeout: ${{ inputs.poll-timeout }}
+          token-exchange-api-url: ${{ inputs.token-exchange-api-url }}
+          token-exchange-audience: ${{ inputs.token-exchange-audience }}
+          token-exchange-pipeline-id: ${{ inputs.token-exchange-pipeline-id }}
+          token-exchange-pipeline-group-id: ${{ inputs.token-exchange-pipeline-group-id }}
+          token-exchange-scope: ${{ inputs.token-exchange-scope }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Fixes a bug where `set-status` silently skipped run-keys with no prior
status entries (`on-absent=skip` default), causing the status write to be
dropped immediately after a successful SBOM upload.

**Changes**:
- `sbom-set-status` action/script: add `--mode {create,update,create-or-update}`
  - `create`: exclusive first write — error if status already exists
  - `update`: requires prior status; `on-absent` (skip/fail) applies
  - `create-or-update`: unconditional write (new default)
- `sbom-upload` action: hardcode `mode: create-or-update` for robustness on re-runs
- `sbom-set-status` reusable workflow: wire `token-exchange-*` inputs through to
  the action (previously missing, disabling mid-run token refresh during lock-poll)
- Improve per-run-key log line: `setting status for run-key=... to ... (was: ...)`
- Add action-level log header in the bash wrapper

**Release note**:
```bugfix operator
sbom-set-status: fix status write being silently skipped on first run (absent run-key);
add --mode {create,update,create-or-update}; fix token refresh in reusable workflow
```