### PR TITLE
merge-ocm-fragments: deduplicate resources across run-attempts

### DIFF
--- a/.github/actions/export-ocm-fragments/action.yaml
+++ b/.github/actions/export-ocm-fragments/action.yaml
@@ -212,6 +212,14 @@ runs:
         buf = io.BytesIO(ocm_artefacts_yaml_bytes)
         ocm_tar.addfile(ocm_artefacts_info, buf)
 
+        # Sidecar with run-attempt so merge-ocm-fragments can prefer the highest
+        # attempt when the same resource identity appears across multiple attempts.
+        # Written as a separate file — NOT part of the .ocm-artefacts content.
+        meta_bytes = f'run-attempt: ${{ github.run_attempt }}\n'.encode()
+        meta_info = tarfile.TarInfo(name=f'{ocm_artefacts_fname}.meta')
+        meta_info.size = len(meta_bytes)
+        ocm_tar.addfile(meta_info, io.BytesIO(meta_bytes))
+
         ocm_tar.close()
         with open(ocm_tar.name, 'rb') as ocm_tar_fh:
           tarhash = hashlib.sha1()

--- a/.github/actions/merge-ocm-fragments/merge_ocm.py
+++ b/.github/actions/merge-ocm-fragments/merge_ocm.py
@@ -7,6 +7,29 @@ import os
 import yaml
 
 
+def _artefact_identity(artefact: dict) -> tuple:
+    '''Return a hashable identity key for an OCM artefact (resource or source).'''
+    extra = artefact.get('extraIdentity') or {}
+    return (
+        artefact.get('name'),
+        artefact.get('version'),
+        tuple(sorted(extra.items())),
+    )
+
+
+def _read_attempt(fpath: str) -> int:
+    '''
+    Read the run-attempt from a {fpath}.meta sidecar file.
+    Returns 0 if the sidecar is absent (fragments pre-dating the convention).
+    '''
+    meta_path = f'{fpath}.meta'
+    if not os.path.isfile(meta_path):
+        return 0
+    with open(meta_path) as f:
+        meta = yaml.safe_load(f)
+    return int(meta.get('run-attempt', 0))
+
+
 def merge_fragments(
     component_descriptor: dict,
     fragments_dir: str,
@@ -18,7 +41,15 @@ def merge_fragments(
     After merging, versions are patched in for artefacts with `relation: local` that do not
     already carry a version, using the component-level version.
 
-    Consumed fragment files are removed from fragments_dir.
+    When the same artefact identity (name, version, extraIdentity) appears in fragments from
+    multiple run-attempts, the entry from the highest attempt number wins.  This handles the
+    case where only a subset of jobs is re-run: successful jobs from earlier attempts and
+    re-run jobs from later attempts coexist in the artefact store, and the latest attempt's
+    output should take precedence.  The attempt number is read from a `{fragment}.meta`
+    sidecar file written by export-ocm-fragments; fragments without a sidecar are treated
+    as attempt 0.
+
+    Consumed fragment and sidecar files are removed from fragments_dir.
 
     Returns the modified component_descriptor.
     '''
@@ -28,6 +59,13 @@ def merge_fragments(
     if 'resources' not in component:
         component['resources'] = []
 
+    resource_attempt: dict[tuple, int] = {
+        _artefact_identity(r): 0 for r in component['resources']
+    }
+    source_attempt: dict[tuple, int] = {
+        _artefact_identity(s): 0 for s in component['sources']
+    }
+
     for fname in os.listdir(fragments_dir):
         if not fname.endswith('.ocm-artefacts'):
             continue
@@ -35,16 +73,51 @@ def merge_fragments(
         if not os.path.isfile(fpath):
             continue
 
-        print(f'adding artefacts from {fpath}')
+        attempt = _read_attempt(fpath)
+        print(f'adding artefacts from {fpath} (attempt={attempt})')
         with open(fpath) as f:
             artefacts = yaml.safe_load(f)
 
-        if (resources := artefacts.get('resources')):
-            component['resources'].extend(resources)
-        if (sources := artefacts.get('sources')):
-            component['sources'].extend(sources)
+        for resource in (artefacts.get('resources') or []):
+            key = _artefact_identity(resource)
+            prev = resource_attempt.get(key, -1)
+            if attempt < prev:
+                print(f'  skipping resource {key}: attempt {attempt} < {prev}')
+                continue
+            if attempt == prev:
+                print(f'  skipping duplicate resource {key} (same attempt)')
+                continue
+            resource_attempt[key] = attempt
+            for i, r in enumerate(component['resources']):
+                if _artefact_identity(r) == key:
+                    print(f'  replacing resource {key}: attempt {prev} -> {attempt}')
+                    component['resources'][i] = resource
+                    break
+            else:
+                component['resources'].append(resource)
+
+        for source in (artefacts.get('sources') or []):
+            key = _artefact_identity(source)
+            prev = source_attempt.get(key, -1)
+            if attempt < prev:
+                print(f'  skipping source {key}: attempt {attempt} < {prev}')
+                continue
+            if attempt == prev:
+                print(f'  skipping duplicate source {key} (same attempt)')
+                continue
+            source_attempt[key] = attempt
+            for i, s in enumerate(component['sources']):
+                if _artefact_identity(s) == key:
+                    print(f'  replacing source {key}: attempt {prev} -> {attempt}')
+                    component['sources'][i] = source
+                    break
+            else:
+                component['sources'].append(source)
 
         os.unlink(fpath)
+        meta_path = f'{fpath}.meta'
+        if os.path.isfile(meta_path):
+            os.unlink(meta_path)
 
     cversion = component.get('version')
     for artefact in component['sources'] + component['resources']:

--- a/test/actions/merge-ocm-fragments/test_merge_ocm.py
+++ b/test/actions/merge-ocm-fragments/test_merge_ocm.py
@@ -111,3 +111,89 @@ def test_merge_fragments_ignores_non_fragment_files():
         assert os.path.exists(other)
 
     assert descriptor['component']['resources'] == []
+
+
+def _write_meta(fragments_dir, fragment_fname, run_attempt):
+    meta = {'run-attempt': run_attempt}
+    with open(os.path.join(fragments_dir, f'{fragment_fname}.meta'), 'w') as f:
+        yaml.safe_dump(meta, f)
+
+
+def test_merge_fragments_deduplicates_same_attempt():
+    '''Two fragments with identical identity and same attempt: first one wins, no duplicate.'''
+    descriptor = _base_descriptor()
+    resource = {'name': 'img', 'version': '1.0', 'data': 'first'}
+    with tempfile.TemporaryDirectory() as d:
+        _write_fragment(d, 'a.ocm-artefacts', resources=[resource])
+        _write_meta(d, 'a.ocm-artefacts', run_attempt=2)
+        _write_fragment(d, 'b.ocm-artefacts', resources=[{**resource, 'data': 'second'}])
+        _write_meta(d, 'b.ocm-artefacts', run_attempt=2)
+
+        merge_ocm.merge_fragments(descriptor, d)
+
+    assert len(descriptor['component']['resources']) == 1
+
+
+def test_merge_fragments_higher_attempt_wins():
+    '''Same identity from two attempts: higher attempt replaces lower.'''
+    descriptor = _base_descriptor()
+    identity = {'name': 'img', 'version': '1.0', 'extraIdentity': {'architecture': 'arm64'}}
+    with tempfile.TemporaryDirectory() as d:
+        _write_fragment(d, 'a.ocm-artefacts', resources=[{**identity, 'access': 'old'}])
+        _write_meta(d, 'a.ocm-artefacts', run_attempt=1)
+        _write_fragment(d, 'b.ocm-artefacts', resources=[{**identity, 'access': 'new'}])
+        _write_meta(d, 'b.ocm-artefacts', run_attempt=2)
+
+        merge_ocm.merge_fragments(descriptor, d)
+
+    resources = descriptor['component']['resources']
+    assert len(resources) == 1
+    assert resources[0]['access'] == 'new'
+
+
+def test_merge_fragments_lower_attempt_does_not_overwrite():
+    '''Fragments processed in arbitrary order: lower attempt must not overwrite higher.'''
+    descriptor = _base_descriptor()
+    identity = {'name': 'img', 'version': '1.0'}
+    with tempfile.TemporaryDirectory() as d:
+        # write higher attempt first so it gets processed first (alphabetically)
+        _write_fragment(d, 'a.ocm-artefacts', resources=[{**identity, 'access': 'new'}])
+        _write_meta(d, 'a.ocm-artefacts', run_attempt=3)
+        _write_fragment(d, 'b.ocm-artefacts', resources=[{**identity, 'access': 'old'}])
+        _write_meta(d, 'b.ocm-artefacts', run_attempt=1)
+
+        merge_ocm.merge_fragments(descriptor, d)
+
+    resources = descriptor['component']['resources']
+    assert len(resources) == 1
+    assert resources[0]['access'] == 'new'
+
+
+def test_merge_fragments_no_meta_treated_as_attempt_zero():
+    '''Fragment without sidecar (old format) gets attempt=0, overridden by any attempt>=1.'''
+    descriptor = _base_descriptor()
+    identity = {'name': 'img', 'version': '1.0'}
+    with tempfile.TemporaryDirectory() as d:
+        _write_fragment(d, 'a.ocm-artefacts', resources=[{**identity, 'access': 'old'}])
+        # no .meta sidecar → attempt 0
+        _write_fragment(d, 'b.ocm-artefacts', resources=[{**identity, 'access': 'new'}])
+        _write_meta(d, 'b.ocm-artefacts', run_attempt=1)
+
+        merge_ocm.merge_fragments(descriptor, d)
+
+    resources = descriptor['component']['resources']
+    assert len(resources) == 1
+    assert resources[0]['access'] == 'new'
+
+
+def test_merge_fragments_meta_sidecar_consumed():
+    '''The .meta sidecar is deleted alongside its fragment.'''
+    descriptor = _base_descriptor()
+    with tempfile.TemporaryDirectory() as d:
+        _write_fragment(d, 'a.ocm-artefacts', resources=[{'name': 'r', 'version': '1.0'}])
+        _write_meta(d, 'a.ocm-artefacts', run_attempt=1)
+
+        merge_ocm.merge_fragments(descriptor, d)
+
+        assert not os.path.exists(os.path.join(d, 'a.ocm-artefacts'))
+        assert not os.path.exists(os.path.join(d, 'a.ocm-artefacts.meta'))


### PR DESCRIPTION
## Problem

When a workflow run fails and only the failing jobs are re-run, GHA retains artefacts from all prior attempts. `merge-ocm-fragments` downloads all matching `*.ocm-artefacts` artefacts, so fragments from attempt N and attempt N+1 are both merged — resulting in duplicate OCM resource identities and a validation failure.

## Solution

- `export-ocm-fragments` writes a `{fragment}.meta` sidecar (YAML, `run-attempt: N`) into each tarball alongside the `.ocm-artefacts` file. The sidecar is purely transient — it does not affect OCM content.
- `merge_ocm.merge_fragments` reads the sidecar and applies attempt-aware deduplication: on identity collision, the entry from the **highest attempt wins**; same-attempt duplicates are dropped. Fragments without a sidecar (pre-dating this change) are treated as attempt 0.

This correctly handles partial re-runs: artefacts from successful jobs in earlier attempts coexist with re-run artefacts from later attempts, and the latest attempt's output takes precedence.

## Tests

Regression tests added to `test/actions/merge-ocm-fragments/test_merge_ocm.py` covering: same-attempt dedup, higher-attempt wins, order-independence, no-sidecar backward compat, and sidecar cleanup.