### PR TITLE
capture-commit/import-commit: use git bundle transport

### DIFF
--- a/.github/actions/capture-commit/action.yaml
+++ b/.github/actions/capture-commit/action.yaml
@@ -7,14 +7,12 @@ description: |
   persisting it, yet (as subsequent jobs might still fail).
 
   This action will only work if git-repository is cloned using `git` (i.e. git-repository must be
-  present). It will work well if repository was cloned as `shallow`. The action needs a reference
-  timestamp, which is passed via regular file. Said file *must* be created _prior_ to creating the
-  commit to serialise (/"capture"). It leverages git's internal organisation of objects, where new
-  objects will be created in separate files; such newly created object-files will be picked up, thus
-  containing both added/changed blobs, as well as tree-objects, and commit.
+  present). It will work well if repository was cloned as `shallow`. Under the hood a `git bundle`
+  is created, containing the captured commit (and any of its ancestors not yet on a remote-tracking
+  ref). The bundle is race-free w.r.t. concurrent gc/repack.
 
   As release-commits are commonly rather small (typically just changing some versions in a few
-  files), the resulting data is typically only a few kiBs in size, which allows it to be exported
+  files), the resulting bundle is typically only a few kiBs in size, which allows it to be exported
   as a (base64-encoded) output (thus making passing-around somewhat less cumbersome).
 
   Thus-exported commits can be imported, retaining the exact same commit-digest, provided the
@@ -27,14 +25,13 @@ description: |
   Caveat: if more than one commit is imported, importing steps relying on said ref will have to
   guard against overwrites which will otherwise happen.
 
-  Note: this action makes use of git-internals (mostly layout of object-db). It will only work if
-  those are not violated (e.g. no git-gc or repack must be done prior to calling this action).
-
 inputs:
   timestamp-reference:
     required: true
     description: |
-      a filepath pointing to a file that was created before the head-commit
+      historical: filepath pointing to a file created before the head-commit.
+      No longer used by the bundle-based implementation; kept as a required input
+      for backwards-compat with existing callers. May be dropped in a future release.
   commit:
     required: false
     description: |
@@ -42,9 +39,9 @@ inputs:
   to-artefact:
     required: false
     description: |
-      if specified, the captured commits will also be uploaded as an artefact of the specified
-      name. The artefact will contain a single TARchive w/ the same contents as the `commit-objects`
-      output. Its name will be `commit-objects.tar.gz`
+      if specified, the captured commit will also be uploaded as an artefact of the specified
+      name. The artefact will contain a single file named `commit-objects.bundle` (a git bundle
+      with the same contents as the `commit-objects` output).
   commit-summary:
     description: |
       controls the step-summary to be emitted by this action.
@@ -67,7 +64,7 @@ outputs:
     value: ${{ steps.capture.outputs.commit-digest }}
   commit-objects:
     description: |
-      a base64-encoded tarfile containing the objects required to restore the head-commit.
+      a base64-encoded git bundle containing the objects required to restore the head-commit.
     value: ${{ steps.capture.outputs.commit-objects }}
 
 runs:
@@ -76,37 +73,25 @@ runs:
     - name: capture-commit
       id: capture
       run: |
-        # darwin/macOS is not supported. differences that would need addressing:
-        # - `stat --format=%s` (GNU) -> `stat -f %z` (BSD)
-        # - `base64 -w0` (GNU) -> `base64 | tr -d '\n'` (BSD)
-        if [ "$(uname -s)" = 'Darwin' ]; then
-          echo 'error: darwin/macOS is not supported'
-          exit 1
-        fi
+        set -euo pipefail
 
-        ts_ref=${{ inputs.timestamp-reference }}
-        if [ ! -f ${ts_ref} ]; then
-          echo "no timestamp-reference-file at expected path: ${ts_ref}"
-          exit 1
-        fi
-        objects_out='commit-objects.tar'
+        objects_out='commit-objects.bundle'
         commit_out='commit-digest'
         GIT_DIR=$PWD/.git \
           ${GITHUB_ACTION_PATH}/capture-commit \
             ${objects_out} \
-            ${ts_ref} \
+            '${{ inputs.timestamp-reference }}' \
             ${commit_out} \
             ${{ inputs.commit }}
 
-        tar tf ${objects_out}
         objects_size=$(stat --format=%s ${objects_out})
         objects_max_size=65536 # 64 KiB
 
         echo "commit-digest=$(cat ${commit_out})" >> ${GITHUB_OUTPUT}
         if [ ${objects_size} -lt ${objects_max_size} ]; then
-          echo "commit-objects=$(cat ${objects_out} | base64 -w0)" >> ${GITHUB_OUTPUT}
+          echo "commit-objects=$(base64 -w0 < ${objects_out})" >> ${GITHUB_OUTPUT}
         else
-          echo "Warning: captured objects were too large (${objects_size} octets)"
+          echo "Warning: captured bundle too large (${objects_size} octets)"
           echo "commit-objects output will not be set"
         fi
 
@@ -120,8 +105,8 @@ runs:
           </summary>
 
         commit-digest: \`$(cat ${commit_out})\`
-        objects-listing (tarfile):
-        $(tar tf ${objects_out})
+        bundle-refs:
+        $(git bundle list-heads ${objects_out})
         commit-message:
         $(git show)
         </details>
@@ -135,8 +120,8 @@ runs:
           </summary>
 
         commit-digest: \`$(cat ${commit_out})\`
-        objects-listing (tarfile):
-        $(tar tf ${objects_out})
+        bundle-refs:
+        $(git bundle list-heads ${objects_out})
         </details>
         EOF
 
@@ -146,19 +131,17 @@ runs:
           echo "Error: unexpected summary-kind: ${summary_kind}"
           exit 1
         fi
-
-        gzip ${objects_out}
       shell: bash
     - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       if: ${{ inputs.to-artefact != '' }}
       with:
         name: ${{ inputs.to-artefact }}
-        path: commit-objects.tar.gz
+        path: commit-objects.bundle
 
     - name: clean-up-capture-commit-archive
       shell: bash
       run: |
         set -euo pipefail
 
-        # archive was uploaded already, avoid local collisions in filesystem
-        unlink commit-objects.tar.gz
+        # bundle was uploaded already, avoid local collisions in filesystem
+        unlink commit-objects.bundle

--- a/.github/actions/capture-commit/capture-commit
+++ b/.github/actions/capture-commit/capture-commit
@@ -2,58 +2,55 @@
 
 set -euo pipefail
 
+# capture <commit> into a git-bundle file for consumption by import-commit.
+#
 # usage:
-# export GIT_DIR
-# $1: path to target-archive
-# $2: path to ref-file (must be older than commit)
-# $3: path to output-file for commit-digest (defaults to commit-digest)
-# $4: commit to capture (defaults to HEAD)
-
-# darwin/macOS is not supported. differences that would need addressing:
-# - `find -newermt` (GNU) -> `-newer` (BSD find; compares mtime, but no XY-syntax)
-if [ "$(uname -s)" = 'Darwin' ]; then
-  echo 'error: darwin/macOS is not supported'
-  exit 1
-fi
+# export GIT_DIR (usually $PWD/.git)
+# $1: path to output bundle
+# $2: (unused — kept for backwards-compat with the wrapper action; was the
+#      timestamp-reference file in the old find-based implementation)
+# $3: path to output-file for commit-digest (default 'commit-digest')
+# $4: commit to capture (default HEAD)
 
 if [ -z "${GIT_DIR:-}" ]; then
-  echo "must set GIT_DIR"
-  exit 1
+    echo 'must set GIT_DIR'
+    exit 1
 fi
 
 if [ -z "${1:-}" ]; then
-  echo "must pass target-file as ARGV[1]"
-  exit 1
-else
-  archive=${1}
+    echo 'must pass target-file as ARGV[1]'
+    exit 1
 fi
+archive=${1}
 
-if [ -z "${2:-}" ]; then
-  echo "must pass ref-file as ARGV[2]"
-  exit 1
-else
-  ref=$(readlink -f "${2}")
-fi
-
-if [ -z "${3:-}" ]; then
-  commit_digest_out='commit-digest'
-else
-  commit_digest_out=${3}
-fi
+commit_digest_out=${3:-commit-digest}
 
 if [ -z "${4:-}" ]; then
-  commit_digest="$(git rev-parse HEAD)"
+    commit_digest="$(git rev-parse HEAD)"
 else
-  commit_digest="$(git rev-parse ${4})"
+    commit_digest="$(git rev-parse "${4}")"
 fi
-echo "${commit_digest}" > "${GIT_DIR}/refs/capture-commit"
 
-object_paths=$(
-  cd "$(dirname "$GIT_DIR")"
-  find .git/objects -type f -newer "${ref}" | grep -v pack
-)
-object_paths+=('.git/refs/capture-commit')
+# contract: capture-commit is only ever intended for _local_, unpushed commits.
+# fail fast (with an expressive error) if the caller violates this — otherwise
+# `git bundle create --not --remotes` below would produce an empty bundle.
+if [ -n "$(git branch -r --contains "${commit_digest}" 2>/dev/null)" ]; then
+    echo "error: ${commit_digest} is already reachable from a remote-tracking ref"
+    echo "capture-commit is only intended for local, unpushed commits"
+    exit 1
+fi
 
-# objects are already gzipped - there is no point in compressing them again
-tar cf "${archive}" -b1 -C $(dirname "${GIT_DIR}") ${object_paths[*]}
-echo "${commit_digest}" > ${commit_digest_out}
+# a well-known ref so import-commit can look it up without needing to pass
+# commit-digest explicitly
+git update-ref refs/capture-commit "${commit_digest}"
+
+# prefer a thin bundle relative to any remote-tracking ref (receiver is assumed
+# to be at the same base). Fall back to a full-history bundle when there are
+# no remotes (typical for `git init`-based test fixtures).
+if git for-each-ref refs/remotes/ 2>/dev/null | grep -q .; then
+    git bundle create "${archive}" refs/capture-commit --not --remotes
+else
+    git bundle create "${archive}" refs/capture-commit
+fi
+
+echo "${commit_digest}" > "${commit_digest_out}"

--- a/.github/actions/import-commit/action.yaml
+++ b/.github/actions/import-commit/action.yaml
@@ -10,12 +10,16 @@ description: |
   present). It will work well if repository was cloned as `shallow`. The repository should have the
   same state as it had when `capture-commit` was executed.
 
+  Under the hood, the imported payload is a git bundle (produced by `capture-commit`). Importing
+  uses `git fetch <bundle-file> +refs/capture-commit:refs/capture-commit`, which is race-free
+  w.r.t. gc/repack and preserves commit-digests exactly.
+
 inputs:
   commit-objects:
     required: false
     description: |
-      a base64-encoded tarfile containing the objects to import into git-repository. The expected
-      format matches the one output from `capture-commit` action.
+      a base64-encoded git bundle containing the objects to import into git-repository. The
+      expected format matches the one output from `capture-commit` action.
 
       Either this input, or `commit-objects-artefact` must be passed.
   commit-objects-artefact:
@@ -52,8 +56,7 @@ inputs:
       *noop*
       import commit, and leave follow-up steps to caller. This is useful in cases where callers
       need more control. Note that if not explicitly doing something w/ imported objects, this will
-      have _no_ visible effect to either worktree nor commit-history (+ imported objects will remain
-      loose).
+      have _no_ visible effect to either worktree nor commit-history.
     options:
       - rebase
       - cherry-pick
@@ -73,24 +76,27 @@ runs:
       if: ${{ inputs.commit-objects != '' }}
       shell: bash
       run: |
-        set -eu
-        echo "${{ inputs.commit-objects }}" | base64 -d | tar x -C "${GITHUB_WORKSPACE}"
+        set -euo pipefail
+        bundle_file="$(mktemp --suffix=.bundle)"
+        trap 'rm -f "${bundle_file}"' EXIT
+        echo "${{ inputs.commit-objects }}" | base64 -d > "${bundle_file}"
+        git fetch "${bundle_file}" '+refs/capture-commit:refs/capture-commit'
     - name: import-commit-objects-from-artefact
       if: ${{ inputs.commit-objects-artefact != '' }}
       uses: gardener/cc-utils/.github/actions/download-artifact@master
       with:
         name: ${{ inputs.commit-objects-artefact }}
-    - name: extract-commit-objects-from-artefact
+    - name: unbundle-commit-objects-from-artefact
       if: ${{ inputs.commit-objects-artefact != '' }}
       shell: bash
       run: |
-        set -eu
-        tar xf commit-objects.tar.gz -C "${GITHUB_WORKSPACE}"
-        unlink commit-objects.tar.gz
+        set -euo pipefail
+        git fetch "$PWD/commit-objects.bundle" '+refs/capture-commit:refs/capture-commit'
+        unlink commit-objects.bundle
     - name: import-commit
       shell: bash
       run: |
-        echo 'importing objects into .git-dir'
+        set -euo pipefail
         if [ -n "${{ inputs.commit-digest }}" ]; then
           commit_digest="${{ inputs.commit-digest }}"
         else

--- a/test/actions/capture-commit/cherry-pick/fixture/hello.txt
+++ b/test/actions/capture-commit/cherry-pick/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/cherry-pick/workflow.yaml
+++ b/test/actions/capture-commit/cherry-pick/workflow.yaml
@@ -1,0 +1,75 @@
+name: test-capture-import-cherry-pick
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: make-commit
+        shell: bash
+        run: |
+          echo 'extra content' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit-to-cherry-pick'
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+      - name: assert-capture
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: reset-and-diverge
+        shell: bash
+        run: |
+          # go back to fixture, then create a divergent commit so that
+          # cherry-pick is the only sensible way to apply the captured commit
+          git reset --hard HEAD~1
+          echo 'divergent' > other.txt
+          git add other.txt
+          git commit -m 'divergent commit'
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: cherry-pick
+      - name: assert-cherry-pick
+        shell: bash
+        run: |
+          expected='${{ steps.capture.outputs.commit-digest }}'
+          head="$(git rev-parse HEAD)"
+          if [ "${head}" = "${expected}" ]; then
+            echo "HEAD unexpectedly equals captured digest (cherry-pick should re-parent): ${head}"
+            exit 1
+          fi
+          # captured commit's payload must be present in HEAD's tree
+          if ! grep -q '^extra content$' hello.txt; then
+            echo "expected captured content in hello.txt, got:"
+            cat hello.txt
+            exit 1
+          fi
+          # divergent commit must still be present as HEAD's ancestor
+          if ! git log --format=%s | grep -qx 'divergent commit'; then
+            echo "divergent commit missing from log:"
+            git log --format=%s
+            exit 1
+          fi
+          # cherry-picked message must appear on HEAD
+          msg="$(git log -1 --format=%s)"
+          if [ "${msg}" != 'commit-to-cherry-pick' ]; then
+            echo "expected HEAD message 'commit-to-cherry-pick', got: ${msg}"
+            exit 1
+          fi
+          git fsck --no-dangling
+          echo "cherry-pick: HEAD=${head} OK"

--- a/test/actions/capture-commit/explicit-commit-input/fixture/hello.txt
+++ b/test/actions/capture-commit/explicit-commit-input/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/explicit-commit-input/workflow.yaml
+++ b/test/actions/capture-commit/explicit-commit-input/workflow.yaml
@@ -1,0 +1,74 @@
+name: test-capture-explicit-commit-input
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: make-two-commits
+        id: commits
+        shell: bash
+        run: |
+          echo 'A' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit A'
+          echo "sha_a=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+          echo 'B' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit B (HEAD)'
+          echo "sha_b=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+          commit: ${{ steps.commits.outputs.sha_a }}
+      - name: assert-capture-non-empty
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: assert-capture-digest
+        shell: bash
+        run: |
+          captured='${{ steps.capture.outputs.commit-digest }}'
+          expected='${{ steps.commits.outputs.sha_a }}'
+          if [ "${captured}" != "${expected}" ]; then
+            echo "Expected captured digest=${expected} (commit A), got: ${captured}"
+            exit 1
+          fi
+          # refs/capture-commit must also point at A, not HEAD
+          ref_digest="$(git rev-parse refs/capture-commit)"
+          if [ "${ref_digest}" != "${expected}" ]; then
+            echo "refs/capture-commit=${ref_digest}, expected A=${expected}"
+            exit 1
+          fi
+          echo "explicit-commit-input: captured=${captured} OK"
+      - name: reset-two
+        shell: bash
+        run: git reset --hard HEAD~2
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: rebase
+      - name: assert-import
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          expected='${{ steps.commits.outputs.sha_a }}'
+          if [ "${head}" != "${expected}" ]; then
+            echo "Expected HEAD=${expected} (commit A), got: ${head}"
+            exit 1
+          fi
+          git fsck --no-dangling
+          echo "explicit-commit-input import: HEAD=${head} OK"

--- a/test/actions/capture-commit/merge-commit/fixture/hello.txt
+++ b/test/actions/capture-commit/merge-commit/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/merge-commit/workflow.yaml
+++ b/test/actions/capture-commit/merge-commit/workflow.yaml
@@ -1,0 +1,89 @@
+name: test-capture-import-merge-commit
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: create-merge-commit
+        id: build
+        shell: bash
+        run: |
+          set -eu
+          base="$(git rev-parse HEAD)"
+          echo "base=${base}" >> ${GITHUB_OUTPUT}
+
+          # feat "side" — commit, remember sha, then reset back
+          echo 'feat' > feat.txt
+          git add feat.txt
+          git commit -m 'feat commit'
+          feat_sha="$(git rev-parse HEAD)"
+          git reset --hard "${base}"
+
+          # main "side"
+          echo 'main' > main.txt
+          git add main.txt
+          git commit -m 'main commit'
+
+          # merge feat side
+          git merge --no-ff -m 'merge feat' "${feat_sha}"
+
+          # sanity: HEAD must have 2 parents (3 tokens: sha + 2 parent shas)
+          parents="$(git rev-list --parents -n 1 HEAD | wc -w)"
+          if [ "${parents}" -ne 3 ]; then
+            echo "expected merge commit, got ${parents} tokens"
+            git log --oneline --graph
+            exit 1
+          fi
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+      - name: assert-capture
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: reset-to-base
+        shell: bash
+        run: git reset --hard '${{ steps.build.outputs.base }}'
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: noop
+      - name: assert-import
+        shell: bash
+        run: |
+          set -eu
+          expected='${{ steps.capture.outputs.commit-digest }}'
+          # move HEAD explicitly to the imported commit — `noop` leaves HEAD
+          # at base by design; this asserts the objects landed intact.
+          git reset --hard "${expected}"
+          head="$(git rev-parse HEAD)"
+          if [ "${head}" != "${expected}" ]; then
+            echo "Expected HEAD=${expected}, got: ${head}"
+            git log --oneline --graph
+            exit 1
+          fi
+          # merge structure preserved
+          parents="$(git rev-list --parents -n 1 HEAD | wc -w)"
+          if [ "${parents}" -ne 3 ]; then
+            echo "expected merge preserved (3 tokens), got ${parents}"
+            git log --oneline --graph
+            exit 1
+          fi
+          [ -f feat.txt ] || { echo "feat.txt missing after import"; exit 1; }
+          [ -f main.txt ] || { echo "main.txt missing after import"; exit 1; }
+          git fsck --no-dangling
+          echo "merge-commit import: HEAD=${head} OK"

--- a/test/actions/capture-commit/multi-commit/fixture/hello.txt
+++ b/test/actions/capture-commit/multi-commit/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/multi-commit/workflow.yaml
+++ b/test/actions/capture-commit/multi-commit/workflow.yaml
@@ -1,0 +1,63 @@
+name: test-capture-import-multi-commit
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: make-two-commits
+        id: commits
+        shell: bash
+        run: |
+          echo 'A' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit A'
+          echo "sha_a=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+          echo 'B' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit B'
+          echo "sha_b=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+      - name: assert-capture
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: reset-two
+        shell: bash
+        run: git reset --hard HEAD~2
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: rebase
+      - name: assert-import
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          expected_b='${{ steps.commits.outputs.sha_b }}'
+          expected_a='${{ steps.commits.outputs.sha_a }}'
+          if [ "${head}" != "${expected_b}" ]; then
+            echo "Expected HEAD=${expected_b}, got: ${head}"
+            exit 1
+          fi
+          parent="$(git rev-parse HEAD~1)"
+          if [ "${parent}" != "${expected_a}" ]; then
+            echo "Expected HEAD~1=${expected_a}, got: ${parent}"
+            exit 1
+          fi
+          git fsck --no-dangling
+          echo "multi-commit import: HEAD=${head} HEAD~1=${parent} OK"

--- a/test/actions/capture-commit/multi-file/fixture/hello.txt
+++ b/test/actions/capture-commit/multi-file/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/multi-file/workflow.yaml
+++ b/test/actions/capture-commit/multi-file/workflow.yaml
@@ -1,0 +1,58 @@
+name: test-capture-import-multi-file
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: make-multi-file-commit
+        shell: bash
+        run: |
+          echo 'first' > a.txt
+          echo 'second' > b.txt
+          mkdir sub
+          echo 'nested' > sub/c.txt
+          git add a.txt b.txt sub/c.txt
+          git commit -m 'multi-file commit'
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+      - name: assert-capture
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: reset-to-parent
+        shell: bash
+        run: git reset --hard HEAD~1
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: rebase
+      - name: assert-import
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          expected='${{ steps.capture.outputs.commit-digest }}'
+          if [ "${head}" != "${expected}" ]; then
+            echo "Expected HEAD=${expected}, got: ${head}"
+            exit 1
+          fi
+          # verify all files are present with correct content
+          [ "$(cat a.txt)" = 'first' ] || { echo "a.txt mismatch"; exit 1; }
+          [ "$(cat b.txt)" = 'second' ] || { echo "b.txt mismatch"; exit 1; }
+          [ "$(cat sub/c.txt)" = 'nested' ] || { echo "sub/c.txt mismatch"; exit 1; }
+          git fsck --no-dangling
+          echo "multi-file import: HEAD=${head} OK"

--- a/test/actions/capture-commit/noop/fixture/hello.txt
+++ b/test/actions/capture-commit/noop/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/noop/workflow.yaml
+++ b/test/actions/capture-commit/noop/workflow.yaml
@@ -1,0 +1,62 @@
+name: test-capture-import-noop
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: make-timestamp-reference
+        shell: bash
+        run: touch /tmp/ts-ref
+      - name: make-commit
+        shell: bash
+        run: |
+          echo 'extra content' >> hello.txt
+          git add hello.txt
+          git commit -m 'extra commit'
+      - id: capture
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref
+      - name: assert-capture
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects'
+            exit 1
+          fi
+      - name: reset-to-parent
+        shell: bash
+        run: git reset --hard HEAD~1
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture.outputs.commit-digest }}
+          after-import: noop
+      - name: assert-noop
+        shell: bash
+        run: |
+          expected='${{ steps.capture.outputs.commit-digest }}'
+          head="$(git rev-parse HEAD)"
+          if [ "${head}" = "${expected}" ]; then
+            echo "HEAD unexpectedly moved to imported commit under noop: ${head}"
+            exit 1
+          fi
+          # captured commit must be reachable via its digest (i.e. present in .git/objects)
+          if ! git cat-file -e "${expected}"; then
+            echo "expected imported commit ${expected} to be present as an object"
+            exit 1
+          fi
+          # refs/capture-commit must point at the captured commit
+          ref_digest="$(git rev-parse refs/capture-commit)"
+          if [ "${ref_digest}" != "${expected}" ]; then
+            echo "refs/capture-commit=${ref_digest}, expected ${expected}"
+            exit 1
+          fi
+          git fsck --no-dangling
+          echo "noop import: object=${expected} present; HEAD=${head} unchanged OK"

--- a/test/actions/capture-commit/two-captures/fixture/hello.txt
+++ b/test/actions/capture-commit/two-captures/fixture/hello.txt
@@ -1,0 +1,1 @@
+hello from fixture

--- a/test/actions/capture-commit/two-captures/workflow.yaml
+++ b/test/actions/capture-commit/two-captures/workflow.yaml
@@ -1,0 +1,109 @@
+name: test-capture-two-captures
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: setup-git
+        shell: bash
+        run: |
+          git config user.email 'test@example.com'
+          git config user.name 'test'
+      - name: ts-ref-1-and-commit-A
+        id: a
+        shell: bash
+        run: |
+          touch /tmp/ts-ref-1
+          echo 'A' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit A'
+          echo "sha=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+      - id: capture-a
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref-1
+      - name: assert-capture-a-non-empty
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture-a.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects for capture-a'
+            exit 1
+          fi
+      - name: ts-ref-2-and-commit-B
+        id: b
+        shell: bash
+        run: |
+          touch /tmp/ts-ref-2
+          echo 'B' >> hello.txt
+          git add hello.txt
+          git commit -m 'commit B'
+          echo "sha=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
+      - id: capture-b
+        uses: gardener/cc-utils/.github/actions/capture-commit@master
+        with:
+          timestamp-reference: /tmp/ts-ref-2
+      - name: assert-capture-b-non-empty
+        shell: bash
+        run: |
+          if [ -z '${{ steps.capture-b.outputs.commit-objects }}' ]; then
+            echo 'expected non-empty commit-objects for capture-b'
+            exit 1
+          fi
+      - name: assert-captures
+        shell: bash
+        run: |
+          da='${{ steps.capture-a.outputs.commit-digest }}'
+          db='${{ steps.capture-b.outputs.commit-digest }}'
+          expected_a='${{ steps.a.outputs.sha }}'
+          expected_b='${{ steps.b.outputs.sha }}'
+          if [ "${da}" != "${expected_a}" ]; then
+            echo "capture-a digest=${da}, expected ${expected_a}"; exit 1
+          fi
+          if [ "${db}" != "${expected_b}" ]; then
+            echo "capture-b digest=${db}, expected ${expected_b}"; exit 1
+          fi
+          if [ "${da}" = "${db}" ]; then
+            echo "capture-a and capture-b unexpectedly identical: ${da}"; exit 1
+          fi
+          # refs/capture-commit must point at the *second* capture (B)
+          ref_digest="$(git rev-parse refs/capture-commit)"
+          if [ "${ref_digest}" != "${db}" ]; then
+            echo "refs/capture-commit=${ref_digest}, expected ${db} (second capture)"; exit 1
+          fi
+          echo "two-captures: A=${da} B=${db} OK"
+      - name: reset-and-import-a
+        shell: bash
+        run: git reset --hard HEAD~2
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture-a.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture-a.outputs.commit-digest }}
+          after-import: rebase
+      - name: assert-import-a
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          expected='${{ steps.capture-a.outputs.commit-digest }}'
+          if [ "${head}" != "${expected}" ]; then
+            echo "after importing A: HEAD=${head}, expected ${expected}"; exit 1
+          fi
+          echo "import capture-a OK: HEAD=${head}"
+      - name: reset-and-import-b
+        shell: bash
+        run: git reset --hard HEAD~1
+      - uses: gardener/cc-utils/.github/actions/import-commit@master
+        with:
+          commit-objects: ${{ steps.capture-b.outputs.commit-objects }}
+          commit-digest: ${{ steps.capture-b.outputs.commit-digest }}
+          after-import: rebase
+      - name: assert-import-b
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          expected='${{ steps.capture-b.outputs.commit-digest }}'
+          if [ "${head}" != "${expected}" ]; then
+            echo "after importing B: HEAD=${head}, expected ${expected}"; exit 1
+          fi
+          git fsck --no-dangling
+          echo "import capture-b OK: HEAD=${head}"


### PR DESCRIPTION
## Summary

- Replaces the tar-of-loose-objects transport in `capture-commit`/`import-commit` with `git bundle`, eliminating a race with git's background auto-gc/auto-maintenance under `set -euo pipefail` (surfaced in release runs as `find: '.git/objects/xx': No such file or directory`).
- `capture-commit` now writes a bundle (thin against remote-tracking refs where possible, full otherwise); `import-commit` consumes it via `git fetch <bundle> +refs/capture-commit:refs/capture-commit`.
- Action-level API preserved: input/output names, base64-encoding of the `commit-objects` output, the well-known `refs/capture-commit` side-effect, and the 64 KiB size threshold. `timestamp-reference` input remains required for backwards-compat but is now silently ignored.
- Adds broader act-based test coverage for the pair (multi-commit, multi-file, merge-commit, explicit-commit-input, cherry-pick, noop, two-captures) in a separate commit that locks in the pre-existing behaviour.

## Test plan

- [x] `test/actions/run-act-tests.sh capture-commit` — 8/8 pass
- [x] Full `build-and-test / test-actions` job on CI — green
- [x] All other CI jobs on the branch — green

**Release note**:
```bugfix operator
capture-commit/import-commit: switch to git-bundle transport, fixing a race with git auto-gc that could cause release pipelines to fail with 'find: .git/objects/xx: No such file or directory'.
```