### PR TITLE
sbom-set-status: improve lock-poll log messages

### DIFF
--- a/.github/actions/sbom-set-status/set_status.py
+++ b/.github/actions/sbom-set-status/set_status.py
@@ -227,10 +227,10 @@ def _poll_sbom_locked(
                 refreshed = True
                 continue
             code = e.code
-        print(f'poll sbom/ lock: attempt {attempt}, HTTP {code}', file=sys.stderr)
         if code == 403:
-            print('sbom/ locked — promoted registered with Cumulus', file=sys.stderr)
+            print(f'immutability confirmed for {probe} (attempt {attempt})', file=sys.stderr)
             return token
+        print(f'waiting for Cumulus hold on {probe}: attempt {attempt} ({code})', file=sys.stderr)
         if time.monotonic() >= deadline:
             print(
                 f'warning: sbom/ not locked after {timeout}s — proceeding anyway',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

The lock-polling loop logged `attempt N, HTTP 403` which reads alarming.
403 is actually the success condition (Cumulus hold confirmed), so reframe
the messages to reflect that:
- on 403: `immutability confirmed for <path> (attempt N)`
- still waiting: `waiting for Cumulus hold on <path>: attempt N, not yet immutable (HTTP 200)`

**Release note**:
```other operator
NONE
```