### PR TITLE
merge-ocm-fragments: make component-descriptor artifact name unique per run

### DIFF
--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -104,7 +104,13 @@ outputs:
       name of the GHA artifact containing the merged component-descriptor.
       The artifact holds a single file `component-descriptor.tar.gz` which
       in turn contains `component-descriptor.yaml`.
-    value: merged-component-descriptor
+
+      The name is made unique per workflow-run, run-attempt, and matrix-leg so
+      that multiple concurrent invocations of this action within the same
+      workflow-run (e.g. a helmchart-build matrix) do not collide on the
+      artifact name. Consumers must therefore read this output rather than
+      hardcoding `merged-component-descriptor`.
+    value: ${{ steps.artifact-name.outputs.name }}
   name:
     description: |
       the component-name (for convenience)
@@ -359,6 +365,20 @@ runs:
             force_rescan='${{ inputs.spdx-force-rescan }}' == 'true',
         )
 
+    - name: artifact-name
+      id: artifact-name
+      shell: bash
+      run: |
+        set -eu
+        # Make the artifact-name unique per workflow-run, run-attempt, and
+        # matrix-leg. Multiple concurrent invocations of this action within the
+        # same workflow-run (e.g. a helmchart-build matrix) would otherwise all
+        # upload an artifact named `merged-component-descriptor` and collide with
+        # a `(409) Conflict: an artifact with this name already exists` error
+        # (actions/upload-artifact@v4+ requires run-unique names).
+        name="merged-component-descriptor-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
+        echo "name=${name}" >> "${GITHUB_OUTPUT}"
+        echo "using artifact-name: ${name}"
     - name: upload-component-descriptor-artifact
       shell: bash
       run: |
@@ -367,5 +387,5 @@ runs:
           -C "${{ inputs.outdir }}" component-descriptor.yaml
     - uses: gardener/cc-utils/.github/actions/upload-artifact@master
       with:
-        name: merged-component-descriptor
+        name: ${{ steps.artifact-name.outputs.name }}
         path: /tmp/component-descriptor.tar.gz


### PR DESCRIPTION
## Problem

Release/build workflows that invoke `merge-ocm-fragments` from **multiple concurrent jobs of the same workflow-run** fail. The final step of the action uploads the merged component-descriptor with a hardcoded artifact name:

```yaml
- uses: gardener/cc-utils/.github/actions/upload-artifact@master
  with:
    name: merged-component-descriptor
    path: /tmp/component-descriptor.tar.gz
```

When several jobs run the action in the same run (e.g. a **helmchart-build matrix** with more than one chart target), each tries to upload an artifact called `merged-component-descriptor`. Since `actions/upload-artifact@v4+` requires **run-unique** artifact names, all but the first job fail with:

```
##[error]Failed to CreateArtifact: Received non-retryable error:
Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

The first failure then cancels the remaining (fail-fast) matrix legs and the release job never runs.

Observed on `gardener/gardener-extension-shoot-traefik` (three helmchart targets: extension + admission-runtime + admission-application), release run failing on exactly this 409. This affects any extension whose helmchart matrix has more than one entry.

This regressed after the descriptor was moved from `GITHUB_OUTPUT` to an artifact (commit dd2f25d2), which is fine for a single job but collides across a matrix.

## Fix

Compute a name that is unique per **workflow-run + run-attempt + matrix-leg**, use it for the upload, and expose it through the existing `component-descriptor-artifact` output so downstream consumers keep resolving the correct artifact (they already read this output rather than the literal string).

```yaml
name="merged-component-descriptor-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
```

`strategy.job-index` is `0` for non-matrix callers, so single-job usage is unaffected. This avoids the `overwrite: true` alternative, which would only trade the 409 for a last-writer-wins race between the parallel jobs (and the `upload-artifact` wrapper doesn't even expose `overwrite`).

## Notes

- `merged-component-descriptor` is not referenced literally anywhere else in this repo — the only consumer path is via the action's `component-descriptor-artifact` output, which now carries the unique name.