### PR TITLE
merge-ocm-fragments: configurable artifact-name; skip upload if empty

### DIFF
--- a/.github/actions/helmchart/action.yaml
+++ b/.github/actions/helmchart/action.yaml
@@ -63,6 +63,13 @@ inputs:
     description: |
       Name of a GHA artifact containing the component-descriptor (preferred over inline input).
 
+  component-descriptor-path:
+    required: false
+    type: string
+    description: |
+      Path to a component-descriptor.yaml on the runner filesystem. Use when
+      merge-ocm-fragments is called in the same job with upload: false.
+
   mappings:
     required: true
     type: string
@@ -120,6 +127,10 @@ runs:
         cat <<'EOF' > /tmp/component-descriptor.yaml
         ${{ inputs.component-descriptor }}
         EOF
+    - name: copy-component-descriptor-from-path
+      if: ${{ inputs.component-descriptor-path != '' }}
+      shell: bash
+      run: cp '${{ inputs.component-descriptor-path }}' /tmp/component-descriptor.yaml
     - name: preprocess-inputs
       shell: bash
       run: |

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -98,13 +98,27 @@ inputs:
       When set to `true`, the SBOM cache is ignored and all external images are re-scanned.
       Useful when a newer syft version is desired. Defaults to `false`.
 
+  upload-artifact-name:
+    required: false
+    type: string
+    default: merged-component-descriptor
+    description: |
+      Name under which the merged component-descriptor is uploaded as a GHA artifact.
+      Set to an empty string to skip the upload (e.g. when the descriptor is only needed
+      within the same job, to avoid artifact-name collisions in matrix jobs).
+
 outputs:
   component-descriptor-artifact:
     description: |
       name of the GHA artifact containing the merged component-descriptor.
       The artifact holds a single file `component-descriptor.tar.gz` which
       in turn contains `component-descriptor.yaml`.
-    value: merged-component-descriptor
+      Empty if `upload-artifact-name` input is empty.
+    value: ${{ inputs.upload-artifact-name }}
+  component-descriptor-path:
+    description: |
+      Path to the merged component-descriptor.yaml on the runner filesystem.
+    value: ${{ inputs.outdir }}/component-descriptor.yaml
   name:
     description: |
       the component-name (for convenience)
@@ -360,12 +374,14 @@ runs:
         )
 
     - name: upload-component-descriptor-artifact
+      if: ${{ inputs.upload-artifact-name != '' }}
       shell: bash
       run: |
         set -eu
         tar czf /tmp/component-descriptor.tar.gz \
           -C "${{ inputs.outdir }}" component-descriptor.yaml
     - uses: gardener/cc-utils/.github/actions/upload-artifact@master
+      if: ${{ inputs.upload-artifact-name != '' }}
       with:
-        name: merged-component-descriptor
+        name: ${{ inputs.upload-artifact-name }}
         path: /tmp/component-descriptor.tar.gz

--- a/.github/workflows/helmchart-ocm.yaml
+++ b/.github/workflows/helmchart-ocm.yaml
@@ -151,6 +151,7 @@ jobs:
           component-descriptor: ${{ inputs.component-descriptor }}
           component-descriptor-artefact: base-component-descriptor
           ctx: ${{ inputs.ocm-ctx }}
+          upload-artifact-name: ''
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
         with:
           remove-trusted-label: false
@@ -163,6 +164,6 @@ jobs:
           oci-registry: ${{ inputs.oci-registry }}
           oci-repository: ${{ inputs.oci-repository }}
           push: ${{ steps.check.outputs.push == 'true' }}
-          component-descriptor-artifact: ${{ steps.fetch-ocm.outputs.component-descriptor-artifact }}
+          component-descriptor-path: ${{ steps.fetch-ocm.outputs.component-descriptor-path }}
           mappings: ${{ inputs.ocm-mappings }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Adds an `upload` boolean input (default: `true`) to `merge-ocm-fragments`.
When set to `false`, the artifact upload is skipped and the descriptor is
only available via the new `component-descriptor-path` output (local
filesystem path).

Fixes 409 conflicts when `helmchart-ocm` is used in a matrix: each
concurrent helmchart job calls `merge-ocm-fragments` to resolve OCM
resource references, but only needs the descriptor locally — not as a
shared run artifact. `helmchart-ocm` now passes `upload: false` and
uses the path output instead.

Also adds a `component-descriptor-path` input to the `helmchart` action
as a path-based alternative to `component-descriptor-artifact`.

**Release note**:
```bugfix operator
merge-ocm-fragments: add `upload` input (default: true) to skip artifact
upload when descriptor is only needed within the same job. Fixes 409
conflicts in matrix helmchart builds.
```