### PR TITLE
fix(kubernetes-auth): tolerate non-zero openssl exit code when retrieving server CA

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -76,10 +76,16 @@ runs:
             normalised_api_url="${normalised_api_url}:443"
           fi
 
-          server_ca=$(echo | openssl s_client -showcerts -connect "${normalised_api_url}" 2>/dev/null \
+          raw=$(echo | openssl s_client -showcerts -connect "${normalised_api_url}" 2>/dev/null || true)
+          server_ca=$(printf '%s' "${raw}" \
             | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
             | base64 -w 0 \
             | tr -d '\n')
+
+          if [ -z "${server_ca}" ]; then
+            echo "Error: failed to retrieve server CA from ${normalised_api_url}"
+            exit 1
+          fi
         fi
 
         echo "server_ca=$server_ca" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
openssl s_client returns exit code 1 when it cannot fully verify the certificate chain against the system trust store, which is expected for clusters using a private/internal CA (e.g. SAP-internal clusters). With set -o pipefail this caused the prepare-server-ca step to fail silently even though the certificate was retrieved successfully.

  Fix:
  - Added || true to tolerate the non-zero openssl exit code
  - Added an explicit empty-check on server_ca afterwards so real failures (e.g. connection refused, no cert returned) still surface with a clear error message instead of failing silently in a later step
  
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
