### PR TITLE
fix(ocm-validate): degrade gracefully when ocm-repositories absent

### DIFF
--- a/.github/actions/ocm-validate/action.yaml
+++ b/.github/actions/ocm-validate/action.yaml
@@ -31,8 +31,8 @@ inputs:
   ocm-repositories:
     description: |
       Comma-separated list of OCM repository base-URLs used to resolve transitive component
-      references. Only needed when `recursion-depth` is non-zero and the component descriptor
-      has componentReferences that need to be followed.
+      references. Used when `recursion-depth` is non-zero and the component descriptor has
+      componentReferences that need to be followed. If omitted, recursion is silently skipped.
     type: string
     required: false
     default: ''
@@ -42,7 +42,6 @@ inputs:
       -1 = unlimited (full transitive closure, default).
        0 = only the top-level component (no lookup needed).
       Positive integers limit depth accordingly.
-      When non-zero, `ocm-repositories` must be provided.
     type: number
     default: -1
   on-validation-errors:

--- a/.github/actions/ocm-validate/validate.py
+++ b/.github/actions/ocm-validate/validate.py
@@ -19,11 +19,7 @@ def validate(
 
     component_descriptor = ocm.ComponentDescriptor.from_dict(component_descriptor)
 
-    if recursion_depth != 0:
-        if not ocm_repositories:
-            raise ValueError(
-                '`ocm-repositories` must be provided when `recursion-depth` is non-zero'
-            )
+    if recursion_depth != 0 and ocm_repositories:
         repos = [r.strip() for r in ocm_repositories.split(',') if r.strip()]
         ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*repos)
         lookup = cnudie.retrieve.create_default_component_descriptor_lookup(


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

When `recursion-depth` is non-zero but `ocm-repositories` is not passed (e.g. callers using an older version of `post-build.yaml` via a GHA re-run), the action previously raised a hard `ValueError`. It now silently falls back to `lookup=None` (top-level only), keeping the validation useful rather than failing outright.

**Release note**:
\`\`\`bugfix operator
ocm-validate: no longer fails when ocm-repositories is absent; falls back to top-level-only validation
\`\`\`