### PR TITLE
fix(kubernetes-auth): handle trailing slash in server URL

### DIFF
--- a/.github/actions/kubernetes-auth/action.yaml
+++ b/.github/actions/kubernetes-auth/action.yaml
@@ -70,8 +70,9 @@ runs:
         if [ -n "${server_ca_discovery_url}" ]; then
           server_ca=$(curl "${server_ca_discovery_url}" | jq -r .certs | base64 -w 0 | tr -d '\n')
         else
-          # normalise api-url: remove `https://` prefix and add `:443` suffix if required
+          # normalise api-url: remove `https://` prefix, trailing slash, and add `:443` suffix if required
           normalised_api_url="${server#https://}"
+          normalised_api_url="${normalised_api_url%/}"
           if [[ "${normalised_api_url}" != *:443 ]]; then
             normalised_api_url="${normalised_api_url}:443"
           fi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
This PR is a follow up to https://github.com/gardener/cc-utils/pull/1675 fixing a training slash in the CA URL.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
