### PR TITLE
feat(release): add extra-oci-registries input for auth before OCM validation

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -178,6 +178,13 @@ inputs:
     description: |
       Passed as `recursion-depth` to the `ocm-validate` action. -1 = full transitive closure
       (default). 0 = top-level only. Requires `ocm-repositories` to be resolvable when non-zero.
+  extra-oci-registries:
+    required: false
+    type: string
+    description: |
+      Optional newline-separated list of additional OCI image references (or registry prefixes) to
+      authenticate against before running OCM validation. Useful when transitive component
+      references or artefacts are stored in registries not covered by `ocm-repositories`.
   release-notes-path:
     required: false
     type: string
@@ -264,6 +271,10 @@ runs:
         tar xf prepare-workflow-values.tar prepare-values.d/ocm-repositories
         ocm_repositories="$(cat prepare-values.d/ocm-repositories)"
         rm -rf prepare-values.d prepare-workflow-values.tar
+        extra_oci_registries='${{ inputs.extra-oci-registries }}'
+        if [ -n "${extra_oci_registries}" ]; then
+          ocm_repositories="${ocm_repositories},$(printf '%s' "${extra_oci_registries}" | tr '\n' ',')"
+        fi
         echo "ocm-repositories=${ocm_repositories}" >> ${GITHUB_OUTPUT}
 
     - name: authenticate-against-oci-registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,14 @@ on:
           How deep to recurse into componentReferences during OCM validation.
           -1 = full transitive closure (default). 0 = top-level only.
           See `ocm-validate` action for details.
+      extra-oci-registries:
+        required: false
+        type: string
+        description: |
+          Optional newline-separated list of additional OCI image references (or registry prefixes) to
+          authenticate against before running OCM validation. Passed through to the `release` action.
+          Useful when transitive component references or artefacts are stored in registries not
+          covered by `ocm-repositories`.
       release-commit-objects:
         required: false
         type: string
@@ -444,6 +452,7 @@ jobs:
           next-version-callback-action-path: ${{ inputs.next-version-callback-action-path }}
           on-validation-errors: ${{ inputs.on-validation-errors }}
           ocm-validation-recursion-depth: ${{ inputs.ocm-validation-recursion-depth }}
+          extra-oci-registries: ${{ inputs.extra-oci-registries }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-push-token: ${{ steps.fed-token.outputs.token }}
           release-on-github: ${{ inputs.release-on-github }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Add an `extra-oci-registries` input to both the `release` action and the `release` reusable workflow.

Without this, OCM validation fails with a 403 when the component descriptor recursively references
components stored in registries not covered by `ocm-repositories` (e.g.
`gcr.io/gdch-partner-project`), because no credentials are set up for those registries before
validation runs.

The input accepts a newline-separated list of OCI image references / registry prefixes. They are
normalised to comma-separated and appended to the `ocm-repositories` list when calling `oci-auth`.

**Release note**:
```feature operator
`release` action and workflow: new `extra-oci-registries` input (newline-separated) to authenticate
against additional OCI registries before OCM validation.
```