### PR TITLE
Increase retries for github-auth to allow self healing for up to 10 minutes

### DIFF
--- a/.github/actions/github-auth/action.yaml
+++ b/.github/actions/github-auth/action.yaml
@@ -57,7 +57,7 @@ inputs:
     default: github-oidc-federation
   retries:
     type: number
-    default: 3
+    default: 12
     description: |
       Number of retry attempts on transient errors (5xx, 408, 429, network failures).
   backoff-base:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
TCP connectivity between GitHub Actions runners and the OIDC Federation service is intermittently disrupted, causing read timeouts in the github-auth action. Investigation across ~50 failing runs shows the connection self-heals in as little as 20 seconds but can take over 10 minutes. Only one of 50 runs failed to recover within that window.

This PR increases the default retries from 3 to 12 as a workaround until the root cause is addressed. With the default backoff settings (backoff-base=3, backoff-cap=60), this allows up to ~580 seconds (~9.7 minutes) of cumulative wait time before giving up and thus reduces the amount of failed workflows.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
