### PR TITLE
Hotfix: Fix clock skew in github-auth action

### DIFF
--- a/.github/actions/github-auth/get-token.py
+++ b/.github/actions/github-auth/get-token.py
@@ -174,7 +174,6 @@ def exchange_token(
     backoff_base: float = 3.0,
     backoff_cap: float = 60.0,
 ) -> str:
-    time.sleep(1)  # ensure token's iat is not in the future
     payload = {
         'host': host,
         'organization': organization,
@@ -186,6 +185,7 @@ def exchange_token(
 
     for oidc_attempt in range(2):
         payload['token'] = get_oidc_token(request_url, request_token, audience, **retry_kwargs)
+        time.sleep(1)  # ensure token's iat is not in the future
         print(f'Payload: {json.dumps(payload)}', file=sys.stderr)
         resp = _request_with_retry(
             'POST',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
The time.sleep(1) was placed before get_oidc_token(), so the sleep completed before the token was minted. By the time the token reached the server, its iat claim could still be in the future from the server's perspective, causing a 401.

Moving the sleep to after get_oidc_token() ensures the token has aged at least 1 second before it is sent to the token exchange endpoint, which is the intended behaviour.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
