### PR TITLE
fix(ocm-upgrade): pass reference_component to live-check

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -512,6 +512,7 @@ def create_upgrade_pullrequests(
                 upgrade_pullrequests=github.pullrequest.iter_upgrade_pullrequests(
                     repository=repository,
                     state='open',
+                    reference_component=component,
                 ),
                 component_reference_name=component_reference_name,
             ):


### PR DESCRIPTION
the live-check introduced in 179a29e was missing reference_component, causing a crash when parsing existing [ci:name:...] style pr titles.

<!-- Please ensure that you do not include company internal information. -->



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
\`\`\`bugfix operator
Fix crash when existing upgrade-PRs use reference-name titles during live-check
\`\`\`