### PR TITLE
trusted-checkout: fix HTTPS submodules being silently skipped

### DIFF
--- a/.github/actions/trusted-checkout/checkout-submodules.sh
+++ b/.github/actions/trusted-checkout/checkout-submodules.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # a (slightly hacky) script to be used as a workaround for allowing to checkout submodules
-# referenced with an SSH-URL with GitHub-Action's checkout-Action (using https / token-auth).
+# referenced with an SSH-URL or HTTPS-URL with GitHub-Action's checkout-Action (using https / token-auth).
 #
 # Will only work for submodules on same GitHub-Instance. Only needed on GHE (checkout-action
 # does have special-handling for github.com in place - or so they claim).
 #
 # This script is intended to be run after actions/checkout (which should be run w/o telling it
-# to checkout submodules). This script assumes checkout's token is still present as
-# http.<github-api>.extraHeader, and furthermore assumes this token is valid to retrieve each
-# submodule (i.e.: no support for cross-github-submodules, and (obviously) no support for
-# submodules not hosted in github).
+# to checkout submodules). For each submodule, it fetches a scoped token (via a token-server or
+# GitHub App) and uses it directly. If neither is configured, it falls back to a plain
+# `git submodule update`, which may still authenticate via the extraHeader left by
+# actions/checkout. No support for submodules not hosted on the same GitHub instance.
 
 set -euo pipefail
 
@@ -126,7 +126,7 @@ git submodule status | while read -r s; do
   sm_url=$(git config submodule.$path.url)
   if [[ -z "${TOKEN_SERVER:-}" && ( -z "${APP_ID:-}" || -z "${APP_KEY:-}" ) ]]; then
     echo "Neither a fed-server (inputs.token-server) nor a GitHub App (inputs.auth-app-private-key"
-    echo "and inputs.auth-app-client-id) is specified, will try to fetch submodule anonymously"
+    echo "and inputs.auth-app-client-id) is specified, will try to fetch submodule without scoped token"
     git submodule update $path
     continue
   fi

--- a/.github/actions/trusted-checkout/checkout-submodules.sh
+++ b/.github/actions/trusted-checkout/checkout-submodules.sh
@@ -124,12 +124,6 @@ git submodule status | while read -r s; do
 
   echo "git-cmd to run: git config get submodule.$path.url"
   sm_url=$(git config submodule.$path.url)
-  if [[ $sm_url == http* ]]; then
-    echo "submodule at $path not configured to use SSH"
-    continue
-  fi
-  echo "submodule at $path configured to use SSH - will reconfigure to https"
-
   if [[ -z "${TOKEN_SERVER:-}" && ( -z "${APP_ID:-}" || -z "${APP_KEY:-}" ) ]]; then
     echo "Neither a fed-server (inputs.token-server) nor a GitHub App (inputs.auth-app-private-key"
     echo "and inputs.auth-app-client-id) is specified, will try to fetch submodule anonymously"
@@ -137,16 +131,23 @@ git submodule status | while read -r s; do
     continue
   fi
 
-  # XXX: assume submodules-URL is of SSH-Type. Also assume submodule resides on same GH-Instance
-  # strip prefixes (allow either of long/short form (ssh://git@ or just git@)
-  sm_repo=${sm_url#ssh://}
-  # strip git@-prefix
-  sm_repo=${sm_repo#git@}
-  # strip hostname (we do not know where we have long or short form, yet)
-  sm_repo=${sm_repo#$github_host}
-  # strip either / or : (depends on ssh-url-type)
-  sm_repo=${sm_repo#:}
-  sm_repo=${sm_repo#/}
+  if [[ $sm_url == http* ]]; then
+    echo "submodule at $path configured to use HTTPS - will fetch with scoped token"
+    # strip scheme and host to get org/repo path
+    sm_repo=${sm_url#*://}
+    sm_repo=${sm_repo#$github_host/}
+  else
+    echo "submodule at $path configured to use SSH - will reconfigure to https"
+    # strip prefixes (allow either of long/short form (ssh://git@ or just git@)
+    sm_repo=${sm_url#ssh://}
+    # strip git@-prefix
+    sm_repo=${sm_repo#git@}
+    # strip hostname (we do not know where we have long or short form, yet)
+    sm_repo=${sm_repo#$github_host}
+    # strip either / or : (depends on ssh-url-type)
+    sm_repo=${sm_repo#:}
+    sm_repo=${sm_repo#/}
+  fi
 
   # git does not seem to honour http.<url>.extraheaders, so we have to jump through some (more)
   # hoops


### PR DESCRIPTION
## Summary

- HTTPS submodules were silently skipped in `checkout-submodules.sh`: the `http*` branch hit `continue` without performing any checkout
- The anonymous fallback check is now moved before the URL-type branch, since it applies equally to both SSH and HTTPS submodules
- HTTPS submodules now extract `org/repo` by stripping scheme and host from the URL, then fall through to the same scoped-token fetch logic used for SSH submodules — ensuring a repository-scoped token is obtained rather than relying on the top-level checkout token

## Test plan

- [ ] Verify a repo with an HTTPS submodule checks out the submodule correctly when `submodules: recursive` is set
- [ ] Verify SSH submodule checkout behaviour is unchanged
- [ ] Verify anonymous fallback (no `token-server` or app credentials) still works for public submodules