### PR TITLE
Pass reference_component to PR iteration

### DIFF
--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -512,6 +512,7 @@ def create_upgrade_pullrequests(
                 upgrade_pullrequests=github.pullrequest.iter_upgrade_pullrequests(
                     repository=repository,
                     state='open',
+                    reference_component=component
                 ),
                 component_reference_name=component_reference_name,
             ):


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

PR https://github.com/gardener/cc-utils/pull/1680 introduced another iteration over all open upgrade PRs which needs a `reference_component` passed like in https://github.com/gardener/cc-utils/blob/92dd9050e841cc8a0b4ad84546905736077a11e0/.github/actions/ocm-upgrade/action.yaml#L227 already.

Otherwise, the iteration fails on upgrade PR that have a form like `[ci:name:gardenlinux:2150.7.0->2150.8.0]` with 
```
Traceback (most recent call last):
  File "/opt/actions-runner/_work/_temp/8b5da18a-bd8c-4261-928e-28e6ba82ddc6.py", line 81, in <module>
    for result in ocm_upgrade.create_upgrade_pullrequests(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/actions-runner/_work/_actions/gardener/cc-utils/06a846c92ab750ba41aef38193ea7d2009d7fd78/.github/actions/ocm-upgrade/ocm_upgrade.py", line 510, in create_upgrade_pullrequests
    if upgrade_pullrequest_exists(
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/actions-runner/_work/_actions/gardener/cc-utils/06a846c92ab750ba41aef38193ea7d2009d7fd78/.github/actions/ocm-upgrade/ocm_upgrade.py", line 373, in upgrade_pullrequest_exists
    for upgrade_pullrequest in upgrade_pullrequests:
                               ^^^^^^^^^^^^^^^^^^^^
  File "/opt/actions-runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/github/pullrequest.py", line 210, in iter_upgrade_pullrequests
    if not has_upgrade_pr_title(pull_request):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/actions-runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/github/pullrequest.py", line 198, in has_upgrade_pr_title
    return parse_pullrequest_title(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/actions-runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/github/pullrequest.py", line 126, in parse_pullrequest_title
    raise ValueError(
ValueError: reference_component must be given when parsing pullrequest title with kind=name
```

as seen in https://github.wdf.sap.corp/kubernetes-dev/landscape-dev-garden/actions/runs/8370707/job/42040794

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue which caused the `create_upgrade_pr` job to fail if there were already open PRs with a `component_name` instead of `component_reference`
```
