### PR TITLE
fix(setup-testrunner): skip non-OCI resources when looking up tm-run

### DIFF
--- a/.github/actions/setup-testrunner/install_testrunner.py
+++ b/.github/actions/setup-testrunner/install_testrunner.py
@@ -21,6 +21,7 @@ except ImportError:
     )
     import cnudie.retrieve
 
+import ocm
 import oci.auth
 import oci.client
 import oci.platform
@@ -65,7 +66,7 @@ def main():
     logger.info(f'found {greatest_version=}')
 
     for resource in component.resources:
-        if resource.name == parsed.ocm_resource:
+        if resource.name == parsed.ocm_resource and isinstance(resource.access, ocm.OciAccess):
             break
     else:
         logger.error(f'did not find {parsed.ocm_resource=} in {component_name}:{greatest_version}')


### PR DESCRIPTION
## Summary

- The `install_testrunner.py` script looked up the `tm-run` resource by name only, breaking on `0.328.0` of `github.com/gardener/test-infra` with `AttributeError: 'LocalBlobAccess' object has no attribute 'imageReference'`
- Root cause: since `oci-ocm.yaml` added CBOM generation (commit `7f0337eb`), the component descriptor contains multiple resources named `tm-run` (CBOM blob, SBOM blobs, and the OCI image). In `0.328.0` the CBOM `localBlob` resource happened to appear before the OCI image resource due to non-deterministic artifact ordering in `merge-ocm-fragments`, causing the script to hit the wrong resource first
- Fix: add `isinstance(resource.access, ocm.OciAccess)` to the lookup condition so non-OCI resources are skipped regardless of ordering

## Test plan

- [x] Verified fix correctly resolves `tm-run` OCI image resource from the `0.328.0` component descriptor (where CBOM localBlob appears before the OCI image)
- [x] Verified no regression against `0.327.0` component descriptor

**Release note**:
```bugfix developer
setup-testrunner: fix AttributeError when component descriptor contains non-OCI resources named tm-run (e.g. CBOM blobs)
```