### PR TITLE
feat(cbom): add Go module crypto inference

### DIFF
--- a/.github/actions/sbom-upload/scan_gobinary.py
+++ b/.github/actions/sbom-upload/scan_gobinary.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Post-hoc Go module CBOM scan for OCI images in an OCM component tree.
+
+For each OCI image resource that does not yet have a go-module-inferred CBOM referrer,
+fetch its existing CycloneDX SBOM from the OCI referrers API, infer crypto usage from
+Go module dependencies, and push the result as an additional CBOM referrer manifest
+annotated with `gardener.cloud/cbom/analysis-method: go-binary-inference`.
+
+Images are skipped when:
+  - they already have a go-module-inferred CBOM referrer (idempotent re-runs are cheap)
+  - no CycloneDX SBOM referrer exists (scan.py has not yet run for this image)
+  - the SBOM contains no Go module dependencies
+
+No image layer downloads are performed — the SBOM blobs are small JSON documents already
+stored as OCI referrers by the main pipeline.
+
+This script fills the gap for images that were scanned before the pipeline-integrated
+inference (in scan.py / sbom/inject.py) was deployed.  It becomes progressively less
+useful as the pipeline integration runs on new images, and can be retired once all
+images in the target landscape have been re-scanned.
+'''
+import argparse
+import os
+import sys
+
+_cc_utils_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, _cc_utils_root)
+
+import cnudie.retrieve
+import hashlib
+import oci.auth
+import oci.client
+import oci.model as om
+import ocm
+import ocm.iter as ocm_iter
+import sbom.cbom as scbom
+import sbom.gobinary as sgob
+
+
+def _resolve_single_arch_ref(
+    image_ref: str | om.OciImageReference,
+    oci_client: oci.client.Client,
+) -> str | None:
+    try:
+        ref = om.OciImageReference.to_image_ref(image_ref)
+        manifest = oci_client.manifest(ref, accept=om.MimeTypes.prefer_multiarch)
+        if isinstance(manifest, om.OciImageManifestList):
+            entries = [
+                e for e in manifest.manifests
+                if e.platform and e.platform.os == 'linux'
+                and e.platform.architecture == 'amd64'
+            ]
+            entry = entries[0] if entries else (
+                manifest.manifests[0] if manifest.manifests else None
+            )
+            if entry is None:
+                return None
+            return f'{ref.ref_without_tag}@{entry.digest}'
+        digest = f'sha256:{hashlib.sha256(oci_client.manifest_raw(ref).content).hexdigest()}'
+        return f'{ref.ref_without_tag}@{digest}'
+    except Exception as exc:
+        print(f'warning: cannot resolve {image_ref}: {exc}', file=sys.stderr)
+        return None
+
+
+def _write_summary(summary: str, append: bool = True) -> None:
+    path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if not path:
+        return
+    with open(path, 'a' if append else 'w') as f:
+        f.write(summary + '\n')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            'Post-hoc Go module CBOM inference for OCI images lacking an inferred CBOM referrer.'
+        ),
+    )
+    parser.add_argument('--ocm-component', required=True, metavar='NAME:VERSION')
+    parser.add_argument(
+        '--ocm-repository',
+        required=True,
+        action='append',
+        dest='ocm_repositories',
+        metavar='URL',
+    )
+    args = parser.parse_args()
+
+    if ':' not in args.ocm_component:
+        print(
+            f'error: --ocm-component must be name:version, got: {args.ocm_component!r}',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    name, version = args.ocm_component.rsplit(':', 1)
+    ocm_repositories = [r for r in args.ocm_repositories if r.strip()]
+
+    oci_client = oci.client.Client(
+        credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
+    )
+
+    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
+    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+        lookups=(
+            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+            ),
+            cnudie.retrieve.oci_component_descriptor_lookup(
+                ocm_repository_lookup=ocm_repo_lookup,
+                oci_client=oci_client,
+            ),
+        ),
+        ocm_repository_lookup=ocm_repo_lookup,
+    )
+
+    root_component = lookup(
+        ocm.ComponentIdentity(name=name, version=version),
+    ).component
+
+    all_nodes = list(ocm_iter.iter_resources(component=root_component, lookup=lookup))
+    print(f'discovered {len(all_nodes)} resources total', file=sys.stderr)
+
+    scanned = skipped_cached = skipped_no_sbom = skipped_no_go = failed = 0
+
+    for node in all_nodes:
+        resource = node.resource
+        access = resource.access
+        if not isinstance(access, ocm.OciAccess):
+            continue
+        if resource.type is not ocm.ArtefactType.OCI_IMAGE:
+            continue
+
+        image_ref = om.OciImageReference.to_image_ref(access.imageReference)
+        digest_ref = _resolve_single_arch_ref(image_ref, oci_client)
+        if digest_ref is None:
+            print(
+                f'warning: skipping {resource.name!r} — cannot resolve single-arch ref',
+                file=sys.stderr,
+            )
+            continue
+
+        # Skip cheaply if an inferred CBOM referrer already exists.
+        if sgob.has_inferred_cbom(digest_ref, oci_client):
+            skipped_cached += 1
+            print(f'skip (cached): {resource.name}', file=sys.stderr)
+            continue
+
+        # Fetch the existing CycloneDX SBOM — no layer download needed.
+        cdx_bytes = sgob.fetch_cdx_sbom(digest_ref, oci_client)
+        if cdx_bytes is None:
+            skipped_no_sbom += 1
+            print(f'skip (no CycloneDX SBOM): {resource.name}', file=sys.stderr)
+            continue
+
+        inference = sgob.infer_from_cdx(cdx_bytes)
+        if inference is None:
+            skipped_no_go += 1
+            print(f'skip (no Go modules): {resource.name}', file=sys.stderr)
+            continue
+
+        print(
+            f'scanning: {resource.name}  '
+            f'modules={inference["module_count"]}  ref={digest_ref}',
+            file=sys.stderr,
+        )
+        inferred_cbom_bytes = sgob.build_inferred_cbom(
+            image_ref=digest_ref,
+            inference=inference,
+        )
+        try:
+            scbom.push_cbom_referrer(
+                cbom_bytes=inferred_cbom_bytes,
+                image_reference=digest_ref,
+                oci_client=oci_client,
+                tool_version=sgob.TOOL_NAME,
+                extra_annotations={
+                    sgob.ANALYSIS_METHOD_ANNOTATION: sgob.ANALYSIS_METHOD_VALUE,
+                },
+            )
+        except Exception as exc:
+            print(f'error: {resource.name}: push failed: {exc}', file=sys.stderr)
+            failed += 1
+            continue
+
+        print(
+            f'ok: {resource.name}  '
+            f'algorithms={len(inference["algorithms"])}  '
+            f'protocols={len(inference["protocols"])}',
+            file=sys.stderr,
+        )
+        scanned += 1
+
+    summary_lines = [
+        f'## Go module CBOM inference — {name}:{version}',
+        '',
+        '| | count |',
+        '|---|---|',
+        f'| discovered resources | {len(all_nodes)} |',
+        f'| skipped (inferred CBOM exists) | {skipped_cached} |',
+        f'| skipped (no CycloneDX SBOM) | {skipped_no_sbom} |',
+        f'| skipped (no Go modules) | {skipped_no_go} |',
+        f'| inferred + pushed | {scanned} |',
+        f'| failed | {failed} |',
+    ]
+    summary = '\n'.join(summary_lines)
+    print(f'\n{summary}', file=sys.stderr)
+    _write_summary(summary)
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/oci-ocm.yaml
+++ b/.github/workflows/oci-ocm.yaml
@@ -739,6 +739,47 @@ jobs:
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f'cbom-referrer-ref={cbom_ref}\n')
 
+      - name: 'push go-module CBOM referrer / ${{ matrix.args.platform-name }}'
+        if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
+        shell: python
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          import oci.auth
+          import oci.client
+          import oci.model
+          import sbom.cbom as scbom
+          import sbom.gobinary as sgob
+
+          oci_client = oci.client.Client(
+              credentials_lookup=oci.auth.docker_credentials_lookup(),
+          )
+          image_ref = oci.model.OciImageReference.to_image_ref(
+              '${{ matrix.args.image-reference }}',
+          )
+
+          with open('sbom.cdx.json', 'rb') as f:
+              cdx_bytes = f.read()
+
+          inference = sgob.infer_from_cdx(cdx_bytes)
+          if not inference:
+              print('no Go modules found — skipping go-module CBOM')
+          else:
+              cbom_bytes = sgob.build_inferred_cbom(image_ref=image_ref, inference=inference)
+              scbom.push_cbom_referrer(
+                  cbom_bytes=cbom_bytes,
+                  image_reference=image_ref,
+                  oci_client=oci_client,
+                  tool_version=sgob.TOOL_NAME,
+                  extra_annotations={sgob.ANALYSIS_METHOD_ANNOTATION: sgob.ANALYSIS_METHOD_VALUE},
+              )
+              print(
+                  f'pushed go-module CBOM: '
+                  f'{inference["module_count"]} modules, '
+                  f'{len(inference["algorithms"])} algorithms, '
+                  f'{len(inference["protocols"])} protocols'
+              )
+
       - name: 'build CBOM OCM fragments / ${{ matrix.args.platform-name }}'
         if: ${{ inputs.generate-sbom && needs.preprocess.outputs.push == 'true' }}
         shell: python

--- a/sbom/cbom.py
+++ b/sbom/cbom.py
@@ -19,6 +19,7 @@ import sbom.oci as _oci
 logger = logging.getLogger(__name__)
 
 CBOM_ARTIFACT_TYPE = 'application/vnd.cyclonedx+json;profile=cbom'
+ANALYSIS_METHOD_ANNOTATION = 'gardener.cloud/cbom/analysis-method'
 # layer media-type is plain CycloneDX JSON (profile is an artifact-level distinction only)
 CBOM_LAYER_MEDIA_TYPE = _oci.CYCLONEDX_JSON_MEDIA_TYPE
 
@@ -28,6 +29,7 @@ def push_cbom_referrer(
     image_reference: str | om.OciImageReference,
     oci_client: oc.Client,
     tool_version: str | None = None,
+    extra_annotations: dict | None = None,
 ) -> str:
     '''
     Push a CBOM document as an OCI referrer manifest for the given image.
@@ -37,6 +39,10 @@ def push_cbom_referrer(
     subject_digest, subject_media_type, subject_size, repo_ref = _oci._resolve_subject(
         image_reference, oci_client,
     )
+    annotations = {
+        **(extra_annotations or {}),
+        **({'gardener.cloud/cbom/tool-version': tool_version} if tool_version else {}),
+    }
     return _oci._push_referrer(
         doc_bytes=cbom_bytes,
         doc_media_type=CBOM_LAYER_MEDIA_TYPE,
@@ -46,9 +52,7 @@ def push_cbom_referrer(
         subject_media_type=subject_media_type,
         subject_size=subject_size,
         oci_client=oci_client,
-        annotations=(
-            {'gardener.cloud/cbom/tool-version': tool_version} if tool_version else None
-        ),
+        annotations=annotations or None,
     )
 
 

--- a/sbom/gobinary.py
+++ b/sbom/gobinary.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Go module-based crypto inference for OCI container images.
+
+Complements cbomkit-theia, which is filesystem-level only and produces zero findings for
+scratch/distroless images that contain only compiled Go binaries, and misleading CA-bundle
+noise for Debian-based images.
+
+Primary approach — SBOM-driven (no extra I/O)
+---------------------------------------------
+`infer_from_cdx(cdx_bytes)` parses the CycloneDX SBOM that syft has already produced,
+extracts `pkg:golang/...` purl components, and maps known crypto-relevant Go modules to
+algorithms and protocols.  Both the pipeline integration (scan_image in inject.py) and the
+post-hoc scan (scan_gobinary.py) use this path — no additional layer downloads or subprocess
+calls are needed.
+
+Limitation: BoringCrypto (FIPS-validated Go crypto backend) detection requires scanning
+binary bytes for linker-embedded markers, which are not captured by syft.  The SBOM-driven
+path emits `boringcrypto: false`; a separate binary-analysis run is needed for FIPS
+certification annotations.
+
+Public interface
+----------------
+  TOOL_NAME                  str  identifier used in tool-version annotations
+  ANALYSIS_METHOD_ANNOTATION str  OCI manifest annotation key
+  ANALYSIS_METHOD_VALUE      str  OCI manifest annotation value
+
+  infer_from_cdx(cdx_bytes)                        -> dict | None
+  fetch_cdx_sbom(image_ref, oci_client)             -> bytes | None
+  build_inferred_cbom(image_ref, inference)          -> bytes
+  has_inferred_cbom(image_ref, oci_client)           -> bool
+'''
+import datetime
+import json
+import logging
+
+import oci.client as oc
+import oci.model as om
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = 'go-binary-inference'
+ANALYSIS_METHOD_ANNOTATION = 'gardener.cloud/cbom/analysis-method'
+ANALYSIS_METHOD_VALUE = 'go-binary-inference'
+
+# artifact type shared with cbomkit-theia; distinguished by manifest annotation
+CBOM_ARTIFACT_TYPE = 'application/vnd.cyclonedx+json;profile=cbom'
+_CDX_SBOM_ARTIFACT_TYPE = 'application/vnd.cyclonedx+json'
+
+_PURL_GOLANG_PREFIX = 'pkg:golang/'
+
+
+# ---------------------------------------------------------------------------
+# Module → crypto inference rules
+# (prefix, algorithms, protocols, description)
+# ---------------------------------------------------------------------------
+
+_CRYPTO_MODULE_RULES = [
+    ('golang.org/x/crypto',
+     ['AES', 'ChaCha20', 'ChaCha20-Poly1305', 'BLAKE2s', 'BLAKE2b',
+      'Ed25519', 'X25519', 'HKDF', 'SHA-256', 'SHA-512', 'bcrypt', 'scrypt', 'Argon2'],
+     [],
+     'golang.org/x/crypto: extended primitives'),
+
+    ('k8s.io/apiserver',
+     ['RSA', 'ECDSA', 'AES-128-GCM', 'AES-256-GCM', 'ChaCha20-Poly1305', 'SHA-256', 'SHA-384'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'k8s.io/apiserver: TLS server + mTLS client auth'),
+
+    ('k8s.io/client-go',
+     ['RSA', 'ECDSA', 'AES-128-GCM', 'AES-256-GCM', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'k8s.io/client-go: TLS to API server'),
+
+    ('k8s.io/kms',
+     ['AES-128-GCM', 'AES-256-GCM', 'RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'k8s.io/kms: encrypted secrets at rest + gRPC TLS'),
+
+    ('go.etcd.io/etcd',
+     ['AES-128-GCM', 'AES-256-GCM', 'RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'etcd: TLS client + peer communication'),
+
+    ('google.golang.org/grpc',
+     ['AES-128-GCM', 'AES-256-GCM', 'ChaCha20-Poly1305', 'ECDSA', 'RSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'gRPC: TLS transport'),
+
+    ('github.com/go-jose/go-jose',
+     ['RSA', 'ECDSA', 'AES-128-KW', 'AES-256-KW', 'AES-128-GCM', 'AES-256-GCM',
+      'SHA-256', 'SHA-384', 'SHA-512', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512'],
+     [],
+     'go-jose: JOSE (JWE/JWS) primitives'),
+
+    ('github.com/golang-jwt/jwt',
+     ['RSA', 'ECDSA', 'Ed25519', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512', 'SHA-256'],
+     [],
+     'golang-jwt: JWT signing'),
+
+    ('github.com/coreos/go-oidc',
+     ['RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'go-oidc: OIDC verification (HTTPS + JWT)'),
+
+    ('golang.org/x/oauth2',
+     ['RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'OAuth2: HTTPS + token signing'),
+
+    ('github.com/containerd/containerd',
+     ['AES-128-GCM', 'RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'containerd: TLS registry communication'),
+
+    ('github.com/docker/distribution',
+     ['RSA', 'ECDSA', 'AES-128-GCM', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'docker/distribution: TLS registry communication'),
+
+    ('github.com/cert-manager',
+     ['RSA', 'ECDSA', 'Ed25519', 'SHA-256', 'SHA-384', 'AES-128-GCM'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'cert-manager: PKI / certificate management'),
+
+    ('sigs.k8s.io/controller-runtime',
+     ['RSA', 'ECDSA', 'AES-128-GCM', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'controller-runtime: TLS webhook server'),
+
+    ('github.com/projectcalico',
+     ['AES-128-GCM', 'RSA', 'ECDSA', 'SHA-256'],
+     ['TLS/1.2', 'TLS/1.3'],
+     'Calico: TLS for API + Felix'),
+
+    ('golang.org/x/net/ssh',
+     ['RSA', 'ECDSA', 'Ed25519', 'AES-128-CTR', 'AES-256-CTR',
+      'ChaCha20-Poly1305', 'SHA-256', 'HMAC-SHA256'],
+     ['SSH/2'],
+     'golang.org/x/net/ssh: SSH protocol'),
+]
+
+# Deduplicated rule index: prefix → (alg_set, proto_set, first_description)
+_RULE_INDEX = {}
+for _prefix, _algs, _protos, _note in _CRYPTO_MODULE_RULES:
+    if _prefix not in _RULE_INDEX:
+        _RULE_INDEX[_prefix] = (set(), set(), _note)
+    _RULE_INDEX[_prefix][0].update(_algs)
+    _RULE_INDEX[_prefix][1].update(_protos)
+
+
+_FIPS_ALGS = frozenset({
+    'AES-128-GCM', 'AES-256-GCM', 'AES-128-CTR', 'AES-256-CTR',
+    'RSA', 'ECDSA', 'SHA-256', 'SHA-384', 'SHA-512',
+    'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512',
+})
+
+
+# ---------------------------------------------------------------------------
+# Inference helpers
+# ---------------------------------------------------------------------------
+
+def _infer_crypto(modules: list) -> tuple:
+    '''Return (alg_set, proto_set) inferred from the given module path list.'''
+    algs = set()
+    protos = set()
+    for mod in modules:
+        for prefix, (rule_algs, rule_protos, _) in _RULE_INDEX.items():
+            if mod == prefix or mod.startswith(prefix + '/') or mod.startswith(prefix + '@'):
+                algs.update(rule_algs)
+                protos.update(rule_protos)
+                break
+    return algs, protos
+
+
+def _modules_from_cdx(doc: dict) -> list:
+    '''Extract Go module paths from a parsed CycloneDX SBOM document.'''
+    modules = []
+    for comp in doc.get('components', []):
+        purl = comp.get('purl', '')
+        if not purl.startswith(_PURL_GOLANG_PREFIX):
+            continue
+        mod_path = purl[len(_PURL_GOLANG_PREFIX):]
+        if '@' in mod_path:
+            mod_path = mod_path[:mod_path.index('@')]
+        modules.append(mod_path)
+    return modules
+
+
+# ---------------------------------------------------------------------------
+# CycloneDX CBOM builder
+# ---------------------------------------------------------------------------
+
+def _alg_to_primitive(name: str) -> str:
+    n = name.upper()
+    if 'AES' in n:     return 'AE'
+    if 'CHACHA' in n:  return 'AE'
+    if 'ECDSA' in n:   return 'SIGNATURE'
+    if 'RSA' in n:     return 'PKE'
+    if 'ECDH' in n:    return 'KA'
+    if 'X25519' in n:  return 'KA'
+    if 'ED25519' in n: return 'SIGNATURE'
+    if 'HMAC' in n:    return 'MAC'
+    if 'SHA' in n:     return 'HASH'
+    if 'BLAKE' in n:   return 'HASH'
+    if 'BCRYPT' in n:  return 'HASH'
+    if 'SCRYPT' in n:  return 'HASH'
+    if 'ARGON' in n:   return 'HASH'
+    if 'HKDF' in n:    return 'KDF'
+    return 'OTHER'
+
+
+def _parse_proto(proto: str) -> tuple:
+    if '/' in proto:
+        t, v = proto.split('/', 1)
+        return t, v
+    return proto, ''
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def infer_from_cdx(cdx_bytes: bytes) -> dict | None:
+    '''
+    Infer crypto usage from a syft CycloneDX SBOM.
+
+    Parses `pkg:golang/...` purl components and applies the module→crypto inference
+    rules.  No network I/O, no subprocess calls, no binary access.
+
+    Returns an inference dict:
+      { 'algorithms': [...], 'protocols': [...], 'boringcrypto': False,
+        'source': 'cdx-sbom', 'module_count': N }
+    or None when no Go modules are present in the SBOM.
+
+    Note: BoringCrypto detection is not possible from the SBOM; the flag is always
+    False.  Binary-level scanning is needed for FIPS certification annotations.
+    '''
+    try:
+        doc = json.loads(cdx_bytes)
+    except Exception as exc:
+        logger.warning('gobinary: cannot parse CycloneDX SBOM: %s', exc)
+        return None
+
+    modules = _modules_from_cdx(doc)
+    if not modules:
+        return None
+
+    algs, protos = _infer_crypto(modules)
+    return {
+        'algorithms':   sorted(algs),
+        'protocols':    sorted(protos),
+        'boringcrypto': False,
+        'source':       'cdx-sbom',
+        'module_count': len(modules),
+    }
+
+
+def fetch_cdx_sbom(
+    image_ref: str | om.OciImageReference,
+    oci_client: oc.Client,
+) -> bytes | None:
+    '''
+    Fetch the CycloneDX SBOM referrer for an image from the OCI registry.
+
+    Returns the raw SBOM document bytes, or None if no referrer is found or fetching fails.
+    Used by the post-hoc scan to avoid pulling image layers.
+    '''
+    try:
+        ref = om.OciImageReference.to_image_ref(image_ref)
+        repo = ref.ref_without_tag
+        referrers = oci_client.referrers(
+            image_reference=image_ref,
+            artifact_type=_CDX_SBOM_ARTIFACT_TYPE,
+            absent_ok=True,
+        )
+        if not referrers:
+            return None
+        manifest_bytes = oci_client.manifest_raw(f'{repo}@{referrers[0].digest}').content
+        manifest = json.loads(manifest_bytes)
+        blob_digest = manifest['layers'][0]['digest']
+        return oci_client.blob(image_reference=repo, digest=blob_digest).content
+    except Exception as exc:
+        logger.debug('gobinary: cannot fetch CycloneDX SBOM for %s: %s', image_ref, exc)
+        return None
+
+
+def build_inferred_cbom(
+    image_ref: str | om.OciImageReference,
+    inference: dict,
+) -> bytes:
+    '''
+    Build a CycloneDX 1.6 CBOM from an inference result dict.
+
+    The `inference` dict is the output of `infer_from_cdx()`.  The document is tagged
+    with `analysis-method: go-binary-inference` in both metadata properties and the
+    referrer manifest annotation (the caller is responsible for the latter).
+    '''
+    components = []
+
+    for alg_name in inference.get('algorithms', []):
+        comp = {
+            'type': 'cryptographic-asset',
+            'name': alg_name,
+            'cryptoProperties': {
+                'assetType': 'algorithm',
+                'algorithmProperties': {
+                    'primitive': _alg_to_primitive(alg_name),
+                },
+            },
+        }
+        if inference.get('boringcrypto') and alg_name in _FIPS_ALGS:
+            comp['cryptoProperties']['nistQuantumSecurityLevel'] = 0
+            comp['cryptoProperties']['certificationLevel'] = ['FIPS140-2', 'FIPS140-3']
+        components.append(comp)
+
+    for proto in inference.get('protocols', []):
+        proto_type, proto_ver = _parse_proto(proto)
+        components.append({
+            'type': 'cryptographic-asset',
+            'name': proto,
+            'cryptoProperties': {
+                'assetType': 'protocol',
+                'protocolProperties': {
+                    'type':    proto_type,
+                    'version': proto_ver,
+                },
+            },
+        })
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    properties = [
+        {'name': ANALYSIS_METHOD_ANNOTATION, 'value': ANALYSIS_METHOD_VALUE},
+        {'name': 'gardener.cloud/cbom/source-image', 'value': str(image_ref)},
+        {'name': 'gardener.cloud/cbom/inference-source', 'value': inference.get('source', '')},
+        {'name': 'gardener.cloud/cbom/go-module-count',
+         'value': str(inference.get('module_count', 0))},
+    ]
+    if inference.get('boringcrypto'):
+        properties.append(
+            {'name': 'gardener.cloud/cbom/boringcrypto-detected', 'value': 'true'},
+        )
+
+    doc = {
+        'bomFormat':   'CycloneDX',
+        'specVersion': '1.6',
+        'version':     1,
+        'metadata': {
+            'timestamp': now,
+            'tools': [{'name': TOOL_NAME, 'version': '0.1.0'}],
+            'properties': properties,
+        },
+        'components': components,
+    }
+    return json.dumps(doc, indent=2).encode()
+
+
+def has_inferred_cbom(
+    image_ref: str | om.OciImageReference,
+    oci_client: oc.Client,
+) -> bool:
+    '''
+    Return True if the image already has a go-binary-inferred CBOM referrer.
+
+    Checks the OCI referrers API for any CBOM referrer annotated with
+    analysis-method: go-binary-inference.  Fast: no layer or blob downloads.
+    '''
+    try:
+        referrers = oci_client.referrers(
+            image_reference=image_ref,
+            artifact_type=CBOM_ARTIFACT_TYPE,
+            absent_ok=True,
+        )
+    except Exception as exc:
+        logger.debug('gobinary: referrers check failed for %s: %s', image_ref, exc)
+        return False
+
+    if not referrers:
+        return False
+
+    return any(
+        r.annotations.get(ANALYSIS_METHOD_ANNOTATION) == ANALYSIS_METHOD_VALUE
+        for r in referrers
+    )

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -28,6 +28,7 @@ import oci.client as oc
 import oci.model as om
 import ocm
 import sbom.cbom as scbom
+import sbom.gobinary as sgob
 import sbom.oci as soci
 import sbom.s3 as ss3
 
@@ -333,6 +334,30 @@ def scan_image(
         oci_client=oci_client,
         tool_version=cbom_tool_ver,
     )
+
+    # Go module inference — complements cbomkit-theia for scratch/distroless images and
+    # Debian-based images where cbomkit-theia only finds OS CA-bundle certs.
+    # Uses the CycloneDX SBOM already in memory; no extra I/O.
+    inference = sgob.infer_from_cdx(cdx_bytes)
+    if inference:
+        inferred_cbom_bytes = sgob.build_inferred_cbom(
+            image_ref=image_ref,
+            inference=inference,
+        )
+        scbom.push_cbom_referrer(
+            cbom_bytes=inferred_cbom_bytes,
+            image_reference=image_ref,
+            oci_client=oci_client,
+            tool_version=sgob.TOOL_NAME,
+            extra_annotations={sgob.ANALYSIS_METHOD_ANNOTATION: sgob.ANALYSIS_METHOD_VALUE},
+        )
+        logger.info(
+            '%s: pushed go-module-inferred CBOM (%d modules → %d algorithms, %d protocols)',
+            image_ref,
+            inference['module_count'],
+            len(inference['algorithms']),
+            len(inference['protocols']),
+        )
 
     return (
         spdx_bytes, cdx_bytes, cbom_bytes,


### PR DESCRIPTION
## Summary

- Adds `sbom/gobinary.py`: infers crypto usage from Go module purls in the syft CycloneDX SBOM (already in memory — no extra I/O). Maps 16 known crypto-relevant Go module prefixes to algorithms and protocols.
- Modifies `sbom/inject.py`: after cbomkit-theia, calls `infer_from_cdx(cdx_bytes)` and pushes a second CBOM referrer annotated `gardener.cloud/cbom/analysis-method: go-binary-inference`.
- Modifies `sbom/cbom.py`: adds `extra_annotations` parameter to `push_cbom_referrer()` and exports `ANALYSIS_METHOD_ANNOTATION` constant.
- Adds `.github/actions/sbom-upload/scan_gobinary.py`: post-hoc standalone script for images scanned before this change — fetches the existing CycloneDX SBOM referrer (no layer download), infers, pushes. Skips images that already have an inferred CBOM referrer.

**Why**: cbomkit-theia is filesystem-level only. For scratch/distroless images (e.g. hyperkube, ecr-credential-provider) it finds zero crypto assets. For Debian-based images (e.g. kube-apiserver) it finds only OS CA-bundle certs. In both cases, the actual application-level crypto (TLS, gRPC, JWT, etc.) is invisible. Analysis of `landscape-live-garden v0.630.0` (447 images): 1 genuinely assessed, 385 CA-bundle noise, 51 scanner gap.

**Release note**:
```feature operator
CBOM scanning now also emits a Go module-inferred CBOM referrer alongside the
cbomkit-theia CBOM, covering scratch/distroless images and supplementing Debian-based
images.  No additional I/O: inference runs directly from the syft CycloneDX SBOM
already in memory.  A post-hoc scan_gobinary.py script is provided for backfilling
existing images.
```