### PR TITLE
fix(release): capture release-commit digest inside release action

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -198,6 +198,10 @@ outputs:
       name of the GHA artifact containing the published component-descriptor
       (same artifact as uploaded by the `release` action: `component-descriptor`).
     value: component-descriptor
+  release-commit-digest:
+    description: |
+      the digest of the release commit (as imported from release-commit-objects)
+    value: ${{ steps.save-release-commit-digest.outputs.digest }}
 
 defaults:
   run:
@@ -231,6 +235,12 @@ runs:
         commit-objects: ${{ inputs.release-commit-objects }}
         commit-digest: ${{ inputs.release-commit-digest }}
         after-import: rebase
+    - name: save-release-commit-digest
+      id: save-release-commit-digest
+      shell: bash
+      run: |
+        # capture before create-bump-commit overwrites refs/capture-commit
+        echo "digest=$(git rev-parse refs/capture-commit)" >> $GITHUB_OUTPUT
     - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
     - name: write-component-descriptor-from-input
       if: ${{ inputs.component-descriptor-artifact == '' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -398,15 +398,6 @@ jobs:
           print(f'INFO: "automatic" version operation has been resolved to {next_version=}')
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f'next-version={next_version}\n')
-      - name: save-release-commit-digest
-        id: save-release-commit-digest
-        if: ${{ inputs.create-release-branch && steps.prep-next-version.outputs.next-version != 'bump-patch' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          # save now: the release action will call version with commit-to-head for the bump-commit,
-          # which overwrites refs/capture-commit - so we must read it before that happens
-          echo "digest=$(git rev-parse refs/capture-commit)" >> $GITHUB_OUTPUT
       - uses: gardener/cc-utils/.github/actions/github-auth@master
         if: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER != '' }}
         id: fed-token
@@ -508,7 +499,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git reset --hard "${{ steps.save-release-commit-digest.outputs.digest }}"
+          git reset --hard "${{ steps.release.outputs.release-commit-digest }}"
 
       - name: create-release-branch-bump-commit
         if: ${{ inputs.create-release-branch && steps.prep-next-version.outputs.next-version != 'bump-patch' }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

`refs/capture-commit` is first populated **inside** the `release` action (by
`import-release-commit`), then overwritten by `create-bump-commit`.

The previous fix (#1655) added a `save-release-commit-digest` step to
`release.yaml` that read the ref *before* the `release` action ran — at which
point the ref does not yet exist in a fresh runner environment.  On
self-hosted runners with a persistent workspace it would read a stale value
from the previous run, causing the release branch to be based on the wrong
(bump-minor) commit, resulting in `VERSION` containing e.g. `v1.74.1-dev`
instead of the expected `v1.73.1-dev`.

**Fix**: save `refs/capture-commit` immediately after `import-release-commit`
(inside `release/action.yaml`), before `create-bump-commit` can overwrite it,
and expose it as a new `release-commit-digest` output.  The workflow
`reset-repository-to-release-commit` step now uses that output instead of the
broken pre-action read.

**Release note**:
```bugfix operator
fix release-branch VERSION: was e.g. v1.74.1-dev instead of v1.73.1-dev when
using create-release-branch: true
```