### PR TITLE
fix(signingserver): retry on connection errors, configurable connect timeout

### DIFF
--- a/signingserver.py
+++ b/signingserver.py
@@ -8,6 +8,7 @@ import hashlib
 import io
 import logging
 import re
+import time
 import typing
 import urllib.parse
 
@@ -46,6 +47,7 @@ class SigningserverClientCfg:
     client_certificate_key: str
     server_certificate_ca: str
     validate_tls_certificate: bool = True
+    connect_timeout: int = 12
 
 
 @dataclasses.dataclass
@@ -158,7 +160,7 @@ class SigningserverClient:
                     'Accept': 'application/x-pem-file',
                 },
                 data=digest,
-                timeout=(4, 31),
+                timeout=(self.cfg.connect_timeout, 31),
                 cert=(self.cfg.client_certificate, self.cfg.client_certificate_key,),
                 **kwargs,
             )
@@ -168,6 +170,7 @@ class SigningserverClient:
                 raise SigningserverException(e)
 
             logger.warning(f'caught http error, going to retry... ({remaining_retries=}); {e}')
+            time.sleep(2 ** (3 - remaining_retries))
             return self.sign(
                 digest=digest,
                 hash_algorithm=hash_algorithm,
@@ -175,7 +178,17 @@ class SigningserverClient:
                 remaining_retries=remaining_retries - 1,
             )
         except Exception as e:
-            raise SigningserverException(e)
+            if remaining_retries == 0:
+                raise SigningserverException(e)
+
+            logger.warning(f'caught connection error, going to retry... ({remaining_retries=}); {e}')
+            time.sleep(2 ** (3 - remaining_retries))
+            return self.sign(
+                digest=digest,
+                hash_algorithm=hash_algorithm,
+                signing_algorithm=signing_algorithm,
+                remaining_retries=remaining_retries - 1,
+            )
 
         return SigningResponse(
             raw=resp.text,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Signing pipeline failures were observed when both signing servers (NaaS and internal/port-forward) experienced transient connectivity issues simultaneously. The client had no retry on connection-level failures (only on HTTP errors), and the 4s connect timeout was too short for the external NaaS endpoint.

- `SigningserverClientCfg.connect_timeout` field (default 12s, was hardcoded 4s) — configurable per signing-server entry
- `sign()` now retries on all exceptions, not just `HTTPError`, with exponential backoff (1s/2s/4s)

**Release note**:
```bugfix operator
signingserver client retries on connection failures (not just HTTP errors); connect timeout is now configurable (default 12s, was 4s)
```