### PR TITLE
add ocm.access; deprecate cnudie.access and ocm.util access helpers

### DIFF
--- a/cnudie/access.py
+++ b/cnudie/access.py
@@ -1,91 +1,21 @@
-import hashlib
+import warnings
 
-import ocm
-
-import ioutil
-import oci.client
-import oci.model
+import ocm.access
 
 
-def s3_access_as_blob_descriptor(
-    s3_client: 'botocore.client.S3',
-    s3_access: ocm.S3Access | ocm.LegacyS3Access,
-    chunk_size: int=8192,
-    name: str=None,
-) -> ioutil.BlobDescriptor:
-    if not s3_client:
-        raise ValueError('must pass-in s3-client')
-
-    if isinstance(s3_access, ocm.LegacyS3Access):
-        bucket = s3_access.bucketName
-        key = s3_access.objectKey
-    else:
-        bucket = s3_access.bucket
-        key = s3_access.key
-
-    blob = s3_client.get_object(Bucket=bucket, Key=key)
-
-    size = blob['ContentLength']
-    body = blob['Body']
-
-    return ioutil.BlobDescriptor(
-        content=body.iter_chunks(chunk_size=chunk_size),
-        size=size,
-        name=name or f's3://{bucket}/{key}',
+def s3_access_as_blob_descriptor(*args, **kwargs):
+    warnings.warn(
+        'cnudie.access is deprecated - use ocm.access',
+        DeprecationWarning,
+        stacklevel=2,
     )
+    return ocm.access.s3_access_as_blob_descriptor(*args, **kwargs)
 
 
-def access_to_digest_lookup(
-    access: ocm.Access,
-    oci_client: oci.client.Client=None,
-    s3_client: 'botocore.client.S3'=None,
-    chunk_size: int=8192,
-) -> ocm.DigestSpec:
-    if access.type is ocm.AccessType.OCI_REGISTRY:
-        image_reference = oci.model.OciImageReference(
-            image_reference=oci_client.to_digest_hash(
-                image_reference=access.imageReference,
-                accept=oci.model.MimeTypes.prefer_multiarch,
-            )
-        )
-
-        digest = image_reference.digest
-
-        return ocm.DigestSpec(
-            hashAlgorithm='SHA-256',
-            normalisationAlgorithm=ocm.NormalisationAlgorithm.OCI_ARTIFACT_DIGEST,
-            value=digest,
-        )
-
-    elif access.type is ocm.AccessType.LOCAL_BLOB:
-        reference = access.globalAccess.digest if access.globalAccess else access.localReference
-
-        digest = reference.lower().removeprefix('sha256:')
-
-        return ocm.DigestSpec(
-            hashAlgorithm='SHA-256',
-            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
-            value=digest,
-        )
-
-    elif access.type is ocm.AccessType.S3:
-        if isinstance(access, ocm.LegacyS3Access):
-            bucket = access.bucketName
-            key = access.objectKey
-        else:
-            bucket = access.bucket
-            key = access.key
-
-        blob = s3_client.get_object(Bucket=bucket, Key=key)['Body']
-
-        digest = hashlib.sha256()
-        for chunk in blob.iter_chunks(chunk_size=chunk_size):
-            digest.update(chunk)
-
-        return ocm.DigestSpec(
-            hashAlgorithm='SHA-256',
-            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
-            value=digest.hexdigest(),
-        )
-
-    return ocm.ExcludeFromSignatureDigest()
+def access_to_digest_lookup(*args, **kwargs):
+    warnings.warn(
+        'cnudie.access is deprecated - use ocm.access',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ocm.access.access_to_digest_lookup(*args, **kwargs)

--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -22,12 +22,12 @@ import cryptography.hazmat.primitives.hashes
 import cryptography.x509
 import dacite
 
-import cnudie.access
 import cnudie.retrieve
 import ctt.__main__
 import oci.client
 import oci.model
 import ocm
+import ocm.access
 import ocm.gardener
 import ocm.helm
 import ocm.iter
@@ -843,7 +843,7 @@ def _normalise(parsed) -> tuple[ocm.ComponentDescriptor, str]:
     component_descriptor = component_descriptor_lookup(parsed.name)
 
     access_to_digest_lookup = functools.partial(
-        cnudie.access.access_to_digest_lookup,
+        ocm.access.access_to_digest_lookup,
         oci_client=oci_client,
     )
 

--- a/ocm/access.py
+++ b/ocm/access.py
@@ -1,0 +1,147 @@
+import hashlib
+import urllib.parse
+
+import ocm
+
+import ioutil
+import oci.client
+import oci.model
+
+
+def s3_access_as_blob_descriptor(
+    s3_client: 'botocore.client.S3',
+    s3_access: ocm.S3Access | ocm.LegacyS3Access,
+    chunk_size: int=8192,
+    name: str=None,
+) -> ioutil.BlobDescriptor:
+    if not s3_client:
+        raise ValueError('must pass-in s3-client')
+
+    if isinstance(s3_access, ocm.LegacyS3Access):
+        bucket = s3_access.bucketName
+        key = s3_access.objectKey
+    else:
+        bucket = s3_access.bucket
+        key = s3_access.key
+
+    blob = s3_client.get_object(Bucket=bucket, Key=key)
+
+    size = blob['ContentLength']
+    body = blob['Body']
+
+    return ioutil.BlobDescriptor(
+        content=body.iter_chunks(chunk_size=chunk_size),
+        size=size,
+        name=name or f's3://{bucket}/{key}',
+    )
+
+
+def access_to_digest_lookup(
+    access: ocm.Access,
+    oci_client: oci.client.Client=None,
+    s3_client: 'botocore.client.S3'=None,
+    chunk_size: int=8192,
+) -> ocm.DigestSpec:
+    if access.type is ocm.AccessType.OCI_REGISTRY:
+        image_reference = oci.model.OciImageReference(
+            image_reference=oci_client.to_digest_hash(
+                image_reference=access.imageReference,
+                accept=oci.model.MimeTypes.prefer_multiarch,
+            )
+        )
+
+        digest = image_reference.digest
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.OCI_ARTIFACT_DIGEST,
+            value=digest,
+        )
+
+    elif access.type is ocm.AccessType.LOCAL_BLOB:
+        reference = access.globalAccess.digest if access.globalAccess else access.localReference
+
+        digest = reference.lower().removeprefix('sha256:')
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
+            value=digest,
+        )
+
+    elif access.type is ocm.AccessType.S3:
+        if isinstance(access, ocm.LegacyS3Access):
+            bucket = access.bucketName
+            key = access.objectKey
+        else:
+            bucket = access.bucket
+            key = access.key
+
+        blob = s3_client.get_object(Bucket=bucket, Key=key)['Body']
+
+        digest = hashlib.sha256()
+        for chunk in blob.iter_chunks(chunk_size=chunk_size):
+            digest.update(chunk)
+
+        return ocm.DigestSpec(
+            hashAlgorithm='SHA-256',
+            normalisationAlgorithm=ocm.NormalisationAlgorithm.GENERIC_BLOB_DIGEST,
+            value=digest.hexdigest(),
+        )
+
+    return ocm.ExcludeFromSignatureDigest()
+
+
+def artifact_url(
+    component: ocm.Component,
+    artifact: ocm.Resource | ocm.Source,
+) -> str:
+    access = artifact.access
+
+    if isinstance(access, ocm.GithubAccess):
+        return access.repoUrl
+
+    elif isinstance(access, ocm.LocalBlobAccess):
+        image_reference = component.current_ocm_repo.component_oci_ref(component.name)
+        return f'{image_reference}@{access.localReference}'
+
+    elif isinstance(access, ocm.OciAccess):
+        return access.imageReference
+
+    elif isinstance(access, ocm.RelativeOciAccess):
+        return access.reference
+
+    elif isinstance(access, ocm.S3Access):
+        return f'http://{access.bucket}.s3.amazonaws.com/{access.key}'
+
+    elif isinstance(access, ocm.LegacyS3Access):
+        return f'http://{access.bucketName}.s3.amazonaws.com/{access.objectKey}'
+
+    elif isinstance(access, ocm.LocalBlobGlobalAccess):
+        return access.ref
+
+    else:
+        raise ValueError(access)
+
+
+def to_absolute_oci_access(
+    access: ocm.OciAccess | ocm.RelativeOciAccess,
+    ocm_repo: ocm.OciOcmRepository | None=None,
+) -> ocm.OciAccess:
+    if access.type is ocm.AccessType.OCI_REGISTRY:
+        pass
+
+    elif access.type is ocm.AccessType.RELATIVE_OCI_REFERENCE:
+        if not '://' in ocm_repo.baseUrl:
+            base_url = urllib.parse.urlparse(f'x://{ocm_repo.baseUrl}').netloc
+        else:
+            base_url = urllib.parse.urlparse(ocm_repo.baseUrl).netloc
+
+        access = ocm.OciAccess(
+            imageReference=f'{base_url.rstrip('/')}/{access.reference.lstrip('/')}',
+        )
+
+    else:
+        raise ValueError(f'Unsupported access type: {access.type}')
+
+    return access

--- a/ocm/util.py
+++ b/ocm/util.py
@@ -1,6 +1,7 @@
-import urllib.parse
+import warnings
 
 import ocm
+import ocm.access
 
 
 def as_component(
@@ -52,52 +53,21 @@ def artifact_url(
     component: ocm.Component,
     artifact: ocm.Resource | ocm.Source,
 ) -> str:
-    access = artifact.access
-
-    if isinstance(access, ocm.GithubAccess):
-        return access.repoUrl
-
-    elif isinstance(access, ocm.LocalBlobAccess):
-        image_reference = component.current_ocm_repo.component_oci_ref(component.name)
-        return f'{image_reference}@{access.localReference}'
-
-    elif isinstance(access, ocm.OciAccess):
-        return access.imageReference
-
-    elif isinstance(access, ocm.RelativeOciAccess):
-        return access.reference
-
-    elif isinstance(access, ocm.S3Access):
-        return f'http://{access.bucket}.s3.amazonaws.com/{access.key}'
-
-    elif isinstance(access, ocm.LegacyS3Access):
-        return f'http://{access.bucketName}.s3.amazonaws.com/{access.objectKey}'
-
-    elif isinstance(access, ocm.LocalBlobGlobalAccess):
-        return access.ref
-
-    else:
-        raise ValueError(access)
+    warnings.warn(
+        'ocm.util.artifact_url is deprecated - use ocm.access.artifact_url',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ocm.access.artifact_url(component, artifact)
 
 
 def to_absolute_oci_access(
     access: ocm.OciAccess | ocm.RelativeOciAccess,
     ocm_repo: ocm.OciOcmRepository | None=None,
 ) -> ocm.OciAccess:
-    if access.type is ocm.AccessType.OCI_REGISTRY:
-        pass
-
-    elif access.type is ocm.AccessType.RELATIVE_OCI_REFERENCE:
-        if not '://' in ocm_repo.baseUrl:
-            base_url = urllib.parse.urlparse(f'x://{ocm_repo.baseUrl}').netloc
-        else:
-            base_url = urllib.parse.urlparse(ocm_repo.baseUrl).netloc
-
-        access = ocm.OciAccess(
-            imageReference=f'{base_url.rstrip('/')}/{access.reference.lstrip('/')}',
-        )
-
-    else:
-        raise ValueError(f'Unsupported access type: {access.type}')
-
-    return access
+    warnings.warn(
+        'ocm.util.to_absolute_oci_access is deprecated - use ocm.access.to_absolute_oci_access',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ocm.access.to_absolute_oci_access(access, ocm_repo)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Adds `ocm.access` as the canonical home for access-resolution utilities, consolidating:

- `cnudie.access.s3_access_as_blob_descriptor` → `ocm.access`
- `cnudie.access.access_to_digest_lookup` → `ocm.access`
- `ocm.util.artifact_url` → `ocm.access`
- `ocm.util.to_absolute_oci_access` → `ocm.access`

`cnudie.access` and the two `ocm.util` functions are kept as thin deprecation shims (forwarding + `DeprecationWarning`) for backwards compatibility.

One known external caller (`landscape-setup/lib/landscape/commands/validate_signature.py`) still uses `cnudie.access` and will need a follow-up update.

**Release note**:
```other developer
add `ocm.access` module; `cnudie.access` and `ocm.util.artifact_url` / `ocm.util.to_absolute_oci_access` are deprecated and will be removed in a future release
```