### PR TITLE
ctt: add local_blobs target option for copy-by-reference replication

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -75,6 +75,20 @@ class PruningMode(enum.StrEnum):
     FORCE_OVERWRITE_DESCRIPTORS = 'force-overwrite-descriptors'  # overwrite descriptors, skip images
 
 
+class LocalBlobsMode(enum.StrEnum):
+    '''
+    Controls how local blobs (inlined into the component descriptor OCI artifact as layers) are
+    handled when replicating to a target registry.
+
+    COPY_BY_VALUE (default): replicate blob data as layers into the target manifest.
+    COPY_BY_REFERENCE: omit local blob layers from the target manifest and instead populate
+        globalAccess on each LocalBlobAccess resource, pointing back to the source artifact.
+        Use this for registries that impose a layer limit (e.g. AWS ECR).
+    '''
+    COPY_BY_VALUE = 'copy_by_value'
+    COPY_BY_REFERENCE = 'copy_by_reference'
+
+
 @functools.cache
 def create_component_descriptor_lookup_for_ocm_repo(
     ocm_repo_url: str,
@@ -212,13 +226,18 @@ def parse_processing_cfg(path: str):
     return raw_cfg
 
 
+_TARGET_ONLY_KWARGS = {'local_blobs'}
+
+
 def _target(target_cfg: dict):
     target_type = target_cfg['type']
     target_ctor = getattr(targets, target_type, None)
     if not target_ctor:
         logger.critical(f'no such target: {target_type}')
         exit(1)
-    target = target_ctor(**target_cfg.get('kwargs', {}))
+    kwargs = {k: v for k, v in target_cfg.get('kwargs', {}).items()
+              if k not in _TARGET_ONLY_KWARGS}
+    target = target_ctor(**kwargs)
     return target
 
 
@@ -660,6 +679,8 @@ def process_images(
         logger.warning('dry-run: not downloading or uploading any images')
 
     registries_by_ocm_repository: dict[str, set[str]] = collections.defaultdict(set)
+    local_blobs_by_ocm_repository: dict[str, LocalBlobsMode] = {}
+
     for target_cfg in processing_cfg['targets'].values():
         target_cfg = target_cfg['kwargs']
 
@@ -685,6 +706,9 @@ def process_images(
             ))
 
         registries_by_ocm_repository[ocm_repository].update(registries)
+        local_blobs_by_ocm_repository[ocm_repository] = LocalBlobsMode(
+            target_cfg.get('local_blobs', LocalBlobsMode.COPY_BY_VALUE)
+        )
 
     replication_plan = ctt.model.ReplicationPlan()
 
@@ -719,6 +743,11 @@ def process_images(
             oci_client=oci_client,
         )
 
+        local_blobs_mode = local_blobs_by_ocm_repository.get(
+            replication_plan_step.target_ocm_repository,
+            LocalBlobsMode.COPY_BY_VALUE,
+        )
+
         yield from process_replication_plan_step(
             replication_plan_step=replication_plan_step,
             root_component_descriptor=root_component_descriptor,
@@ -735,6 +764,7 @@ def process_images(
             overwrite_descriptors=pruning_mode is PruningMode.FORCE_OVERWRITE_DESCRIPTORS,
             max_workers=max_workers,
             inject_s3_sboms=inject_s3_sboms,
+            local_blobs_mode=local_blobs_mode,
         )
 
 
@@ -754,6 +784,7 @@ def process_replication_plan_step(
     overwrite_descriptors: bool=False,
     max_workers: int=16,
     inject_s3_sboms: bool=False,
+    local_blobs_mode: LocalBlobsMode=LocalBlobsMode.COPY_BY_VALUE,
 ) -> collections.abc.Generator[ocm.iter.Node, None, None]:
     def process_replication_resource_element(
         replication_resource_element: ctt.model.ReplicationResourceElement,
@@ -1192,6 +1223,7 @@ def process_replication_plan_step(
             src_ocm_repo=orig_ocm_repo,
             oci_client=oci_client,
             overwrite=overwrite_descriptors,
+            rewrite_local_blobs=local_blobs_mode is LocalBlobsMode.COPY_BY_REFERENCE,
         )
 
     if processing_mode is ProcessingMode.DRY_RUN:

--- a/ctt/replicate.py
+++ b/ctt/replicate.py
@@ -24,6 +24,7 @@ def replicate_oci_artifact_with_patched_component_descriptor(
     src_ocm_repo: ocm.OciOcmRepository,
     oci_client: oci.client.Client,
     overwrite: bool=False,
+    rewrite_local_blobs: bool=False,
 ):
     if isinstance(src_ocm_repo, str):
         src_ocm_repo = ocm.OciOcmRepository(baseUrl=src_ocm_repo)
@@ -47,6 +48,31 @@ def replicate_oci_artifact_with_patched_component_descriptor(
     src_manifest = oci_client.manifest(
         image_reference=src_ref,
     )
+
+    layer_sizes = {layer.digest: layer.size for layer in src_manifest.layers}
+    blobs_to_skip = frozenset()
+
+    if rewrite_local_blobs:
+        skip = set()
+        for artefact in component.iter_artefacts():
+            access = artefact.access
+            if not isinstance(access, ocm.LocalBlobAccess):
+                continue
+            digest = access.localReference
+            if digest not in layer_sizes:
+                logger.warning(
+                    f'{digest=} not found in src manifest layers - skipping globalAccess patch'
+                )
+                continue
+            access.globalAccess = ocm.LocalBlobGlobalAccess(
+                digest=digest,
+                mediaType=access.mediaType,
+                ref=str(src_ref),
+                size=layer_sizes[digest],
+                type=ocm.AccessType.OCI_BLOB,
+            )
+            skip.add(digest)
+        blobs_to_skip = frozenset(skip)
 
     raw_fobj = ocm.oci.component_descriptor_to_tarfileobj(patched_component_descriptor)
 
@@ -85,6 +111,7 @@ def replicate_oci_artifact_with_patched_component_descriptor(
             src_component_descriptor_oci_blob_ref: raw_fobj,
             src_manifest.config: cfg_raw,
         },
+        blobs_to_skip=blobs_to_skip,
     )
 
     target_manifest_dict = target_manifest.as_dict()

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -7,6 +7,24 @@ import sbom.inject as sbom_inject
 import ocm
 
 
+def test_target_with_local_blobs_kwarg():
+    '''
+    RegistriesTarget does not accept local_blobs as a constructor argument.
+    _target() must strip it (and other target-only kwargs) before instantiation.
+    '''
+    target_cfg = {
+        'type': 'RegistriesTarget',
+        'kwargs': {
+            'registries': ['registry.example.com'],
+            'local_blobs': 'copy_by_reference',
+        },
+    }
+
+    # must not raise TypeError
+    target = process_dependencies._target(target_cfg)
+    assert target is not None
+
+
 def test_processor_instantiation(tmpdir):
     tmpfile = tmpdir.join('a_file')
     tmpfile.write('')  # touch

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -436,6 +436,7 @@ def replicate_blobs(
     tgt_ref: str,
     oci_client: oc.Client,
     blob_overwrites: dict[om.OciBlobRef, bytes | io.BytesIO],
+    blobs_to_skip: frozenset[str]=frozenset(),
 ) -> om.OciImageManifest:
     '''
     replicates blobs from given oci-image-ref to the specified target-ref, optionally replacing
@@ -518,5 +519,9 @@ def replicate_blobs(
 
     return om.OciImageManifest(
         config=replicate_blob(src_oci_manifest.config),
-        layers=[replicate_blob(blob) for blob in src_oci_manifest.layers],
+        layers=[
+            replicate_blob(blob)
+            for blob in src_oci_manifest.layers
+            if blob.digest not in blobs_to_skip
+        ],
     )


### PR DESCRIPTION
Registries such as AWS ECR impose a layer limit on OCI manifests. Component
descriptors with many inlined local blobs (e.g. SBOMs in LSS) can exceed this
limit, causing replication to fail.

Add a \`local_blobs\` option to ctt target configuration (enum: \`copy_by_value\` /
\`copy_by_reference\`, default: \`copy_by_value\`). When set to \`copy_by_reference\`,
local blob layers are omitted from the replicated manifest and each
\`LocalBlobAccess\` resource receives a \`globalAccess\` entry pointing back to the
source OCI artifact + blob digest, so consumers can still resolve the content.

Also filters \`local_blobs\` from the kwargs passed to \`RegistriesTarget.__init__()\`
via \`_target()\`, which does not accept it as a constructor argument.