### PR TITLE
ocm-upgrade: add component-policies input

### DIFF
--- a/.github/actions/ocm-upgrade/action.yaml
+++ b/.github/actions/ocm-upgrade/action.yaml
@@ -93,6 +93,26 @@ inputs:
       - strictly-follow
       - accept-hotfixes
     default: strictly-follow
+  component-policies:
+    description: |
+      A YAML-formatted list of per-component policies controlling upstream-gating. Each entry
+      requires a `components` selector (list of component names / regexes) and an optional
+      `upstream-component-name` (empty string disables upstream-gating for that component,
+      causing it to fall back to greatest-version lookup) and an optional
+      `upstream-update-policy` override.
+
+      Example:
+      ```
+      - components:
+          - acme.org/my-extra-component
+        upstream-component-name: ''
+      - components:
+          - acme.org/my-other-component
+        upstream-component-name: acme.org/other-upstream
+        upstream-update-policy: accept-hotfixes
+      ```
+    type: string
+    required: false
   pr-naming-pattern:
     description: |
       Pattern to use for naming the created pull requests. Allowed values are:
@@ -209,6 +229,14 @@ runs:
           for merge_policy_config_raw in merge_policy_configs_raw
         ]
 
+        component_policies_raw = yaml.safe_load('''\
+        ${{ inputs.component-policies }}
+        ''') or []
+        component_policies = [
+          ocm_upgrade.ComponentPolicy.from_dict(component_policy_raw)
+          for component_policy_raw in component_policies_raw
+        ]
+
         with open('/tmp/github-token') as f:
           github_token = f.read().strip()
 
@@ -252,7 +280,8 @@ runs:
             upstream_component_name=upstream_component,
             upstream_update_policy=upstream_update_policy,
             ignore_prerelease_versions=True,
-            pr_naming_pattern='${{ inputs.pr-naming-pattern }}'
+            pr_naming_pattern='${{ inputs.pr-naming-pattern }}',
+            component_policies=component_policies,
           ):
           if isinstance(result, ocm_upgrade.UpgradeError):
             upgrade_errors.append(result)

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -84,6 +84,44 @@ class MergePolicyConfig:
 
 
 @dataclasses.dataclass
+class ComponentPolicy:
+    '''
+    Per-component upstream-gating policy. Matched by component name (regex).
+
+    upstream_component_name:
+      - absent (None): inherit global upstream_component_name
+      - empty string '': disable upstream-gating for this component (use find-latest)
+      - non-empty: gate against this specific upstream component
+    upstream_update_policy:
+      - absent (None): inherit global upstream_update_policy
+    '''
+    components: list[str] | str
+    upstream_component_name: str | None = None
+    upstream_update_policy: UpstreamUpdatePolicy | None = None
+
+    def __post_init__(self):
+        if isinstance(self.components, str):
+            self.components = [self.components]
+
+    @staticmethod
+    def from_dict(raw: dict) -> typing.Self:
+        return dacite.from_dict(
+            data_class=ComponentPolicy,
+            data=raw,
+            config=dacite.Config(
+                cast=[enum.Enum],
+                convert_key=lambda key: key.replace('_', '-'),
+            ),
+        )
+
+    def matches(self, component_name: str) -> bool:
+        for component in self.components:
+            if re.fullmatch(component, component_name):
+                return True
+        return False
+
+
+@dataclasses.dataclass
 class UpgradeError:
     upgrade_vector: 'ocm.gardener.UpgradeVector'
     error: Exception
@@ -396,6 +434,7 @@ def create_upgrade_pullrequests(
     upstream_component_name: str | None=None,
     upstream_update_policy: UpstreamUpdatePolicy = UpstreamUpdatePolicy.STRICTLY_FOLLOW,
     ignore_prerelease_versions: bool=True,
+    component_policies: list[ComponentPolicy] | None=None,
 ) -> collections.abc.Iterable[github.pullrequest.UpgradePullRequest]:
     for cref in ocm.gardener.iter_greatest_component_references(
         references=ocm.gardener.iter_component_references(component=component),
@@ -412,19 +451,29 @@ def create_upgrade_pullrequests(
             current_merge_policy = merge_policy
             current_merge_method = merge_method
 
-        if upstream_component_name:
+        effective_upstream_component_name = upstream_component_name
+        effective_upstream_update_policy = upstream_update_policy
+        for component_policy in (component_policies or ()):
+            if component_policy.matches(cref.componentName):
+                if component_policy.upstream_component_name is not None:
+                    effective_upstream_component_name = component_policy.upstream_component_name
+                if component_policy.upstream_update_policy is not None:
+                    effective_upstream_update_policy = component_policy.upstream_update_policy
+                break
+
+        if effective_upstream_component_name:
             upstream_version = version.greatest_version(
-                versions=version_lookup(upstream_component_name),
+                versions=version_lookup(effective_upstream_component_name),
                 ignore_prerelease_versions=ignore_prerelease_versions
             )
 
             if not upstream_version:
-                logger.warning(f'no versions for upstream {upstream_component_name=}')
+                logger.warning(f'no versions for upstream {effective_upstream_component_name=}')
                 continue
 
             upstream_cd: ocm.ComponentDescriptor = component_descriptor_lookup(
                 ocm.ComponentIdentity(
-                    name=upstream_component_name,
+                    name=effective_upstream_component_name,
                     version=upstream_version,
                 )
             )
@@ -436,9 +485,9 @@ def create_upgrade_pullrequests(
                 logger.info(f'upstream has no reference for {cref.componentName}')
                 continue
 
-            if upstream_update_policy  is UpstreamUpdatePolicy.STRICTLY_FOLLOW:
+            if effective_upstream_update_policy is UpstreamUpdatePolicy.STRICTLY_FOLLOW:
                 candidates = (upstream_target_version,)
-            elif upstream_update_policy is UpstreamUpdatePolicy.ACCEPT_HOTFIXES:
+            elif effective_upstream_update_policy is UpstreamUpdatePolicy.ACCEPT_HOTFIXES:
                 cref_versions = version_lookup(cref.componentName)
                 hotfix = version.greatest_version_with_matching_minor(
                     reference_version=cref.version,
@@ -450,7 +499,7 @@ def create_upgrade_pullrequests(
                 else:
                     candidates = (upstream_target_version,)
             else:
-                raise ValueError(f'unknown {upstream_update_policy=}')
+                raise ValueError(f'unknown {effective_upstream_update_policy=}')
 
             for target in candidates:
                 tv = version.parse_to_semver(target)

--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -99,6 +99,25 @@ on:
         type: string
         description: strictly-follow | accept-hotfixes
         default: strictly-follow
+      component-policies:
+        required: false
+        type: string
+        description: |
+          A YAML-formatted list of per-component policies controlling upstream-gating. Each entry
+          requires a `components` selector (list of component names / regexes) and an optional
+          `upstream-component-name` (empty string disables upstream-gating, falling back to
+          greatest-version lookup) and an optional `upstream-update-policy` override.
+
+          Example:
+          ```
+          - components:
+              - acme.org/my-extra-component
+            upstream-component-name: ''
+          - components:
+              - acme.org/my-other-component
+            upstream-component-name: acme.org/other-upstream
+            upstream-update-policy: accept-hotfixes
+          ```
       github-environment:
         required: false
         default: ""
@@ -161,3 +180,4 @@ jobs:
           pr-naming-pattern: ${{ inputs.pr-naming-pattern }}
           upstream-component-name: ${{ inputs.upstream-component-name }}
           upstream-update-policy: ${{ inputs.upstream-update-policy }}
+          component-policies: ${{ inputs.component-policies }}

--- a/test/actions/ocm-upgrade/test_ocm_upgrade.py
+++ b/test/actions/ocm-upgrade/test_ocm_upgrade.py
@@ -2,8 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+import os
+import unittest.mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../../.github/actions/ocm-upgrade'))
+
 import ocm
 import ocm.gardener
+import ocm_upgrade
 
 
 def test_find_upgrade_vector_newer_available():
@@ -90,3 +97,198 @@ def test_upstream_no_matching_cref_returns_none():
     )
 
     assert result is None
+
+
+# --- ComponentPolicy tests ---
+
+def test_component_policy_matches_exact():
+    policy = ocm_upgrade.ComponentPolicy(components=['example.com/foo'])
+    assert policy.matches('example.com/foo')
+    assert not policy.matches('example.com/bar')
+
+
+def test_component_policy_matches_regex():
+    policy = ocm_upgrade.ComponentPolicy(components=['example\\.com/.*'])
+    assert policy.matches('example.com/foo')
+    assert policy.matches('example.com/bar')
+    assert not policy.matches('other.org/foo')
+
+
+def test_component_policy_normalises_string_to_list():
+    policy = ocm_upgrade.ComponentPolicy(components='example.com/foo')
+    assert policy.components == ['example.com/foo']
+    assert policy.matches('example.com/foo')
+
+
+def test_component_policy_from_dict_full():
+    raw = {
+        'components': ['example.com/foo'],
+        'upstream-component-name': 'example.com/upstream',
+        'upstream-update-policy': 'accept-hotfixes',
+    }
+    policy = ocm_upgrade.ComponentPolicy.from_dict(raw)
+    assert policy.components == ['example.com/foo']
+    assert policy.upstream_component_name == 'example.com/upstream'
+    assert policy.upstream_update_policy is ocm_upgrade.UpstreamUpdatePolicy.ACCEPT_HOTFIXES
+
+
+def test_component_policy_from_dict_empty_upstream_disables_gating():
+    raw = {
+        'components': ['example.com/foo'],
+        'upstream-component-name': '',
+    }
+    policy = ocm_upgrade.ComponentPolicy.from_dict(raw)
+    assert policy.upstream_component_name == ''
+
+
+def test_component_policy_from_dict_minimal():
+    policy = ocm_upgrade.ComponentPolicy.from_dict({'components': ['example.com/foo']})
+    assert policy.upstream_component_name is None
+    assert policy.upstream_update_policy is None
+
+
+# --- create_upgrade_pullrequests behavioural tests ---
+
+def _make_component(name, version, crefs):
+    return ocm.Component(
+        name=name,
+        version=version,
+        componentReferences=crefs,
+        resources=[],
+        sources=[],
+        repositoryContexts=[],
+        provider='test',
+    )
+
+
+def _run_create_upgrade_pullrequests(**kwargs):
+    '''Call create_upgrade_pullrequests with mocked GitHub/git layers.'''
+    created = []
+
+    def fake_create_upgrade_pullrequest(upgrade_vector, **_kw):
+        created.append(upgrade_vector)
+        return unittest.mock.MagicMock()
+
+    mock_repository = unittest.mock.MagicMock()
+
+    with (
+        unittest.mock.patch.object(
+            ocm_upgrade, 'create_upgrade_pullrequest', fake_create_upgrade_pullrequest,
+        ),
+        unittest.mock.patch('github.pullrequest.iter_upgrade_pullrequests', return_value=iter([])),
+        unittest.mock.patch('github.pullrequest.reset_worktree'),
+        unittest.mock.patch('gitutil.GitHelper'),
+    ):
+        list(ocm_upgrade.create_upgrade_pullrequests(
+            upgrade_pullrequests=[],
+            repo_dir='/tmp',
+            repo_url='https://github.com/example/repo',
+            repository=mock_repository,
+            merge_policy=ocm_upgrade.MergePolicy.MANUAL,
+            merge_method=ocm_upgrade.MergeMethod.MERGE,
+            merge_policy_configs=[],
+            branch='main',
+            oci_client=unittest.mock.MagicMock(),
+            pr_naming_pattern='component-name',
+            **kwargs,
+        ))
+
+    return created
+
+
+def _make_upstream_lookup(upstream_name, upstream_crefs):
+    '''Returns (component_descriptor_lookup, version_lookup) where upstream has given crefs.'''
+    upstream_component = _make_component(upstream_name, '1.0.0', upstream_crefs)
+    upstream_cd = ocm.ComponentDescriptor(
+        meta=ocm.Metadata(),
+        component=upstream_component,
+    )
+
+    def component_descriptor_lookup(cid, absent_ok=False):
+        if cid.name == upstream_name:
+            return upstream_cd
+        raise ValueError(f'unexpected lookup: {cid}')
+
+    return component_descriptor_lookup
+
+
+def test_upstream_gating_skips_component_not_in_upstream():
+    '''Existing behaviour: component absent from upstream is skipped.'''
+    component = _make_component(
+        'example.com/my-comp', '1.0.0',
+        [_make_cref('dep', 'example.com/dep', '1.0.0')],
+    )
+    cd_lookup = _make_upstream_lookup('example.com/upstream', [])  # upstream has no refs
+
+    created = _run_create_upgrade_pullrequests(
+        component=component,
+        component_descriptor_lookup=cd_lookup,
+        version_lookup=lambda _: ['1.0.0', '2.0.0'],
+        upstream_component_name='example.com/upstream',
+    )
+
+    assert created == []
+
+
+def test_component_policy_empty_upstream_uses_find_latest():
+    '''
+    Component with upstream-component-name='' in component_policies falls back
+    to find-latest instead of being skipped.
+    '''
+    component = _make_component(
+        'example.com/my-comp', '1.0.0',
+        [_make_cref('dep', 'example.com/dep', '1.0.0')],
+    )
+    cd_lookup = _make_upstream_lookup('example.com/upstream', [])  # upstream has no refs
+
+    policies = [
+        ocm_upgrade.ComponentPolicy(
+            components=['example.com/dep'],
+            upstream_component_name='',
+        )
+    ]
+
+    created = _run_create_upgrade_pullrequests(
+        component=component,
+        component_descriptor_lookup=cd_lookup,
+        version_lookup=lambda _: ['1.0.0', '2.0.0'],
+        upstream_component_name='example.com/upstream',
+        component_policies=policies,
+    )
+
+    assert len(created) == 1
+    assert created[0].whence.name == 'example.com/dep'
+    assert created[0].whither.version == '2.0.0'
+
+
+def test_component_policy_upstream_override():
+    '''component_policies can gate a component against a different upstream.'''
+    gated_cref = _make_cref('gated', 'example.com/gated', '1.0.0')
+    component = _make_component('example.com/my-comp', '1.0.0', [gated_cref])
+
+    alt_upstream_crefs = [_make_cref('gated', 'example.com/gated', '1.5.0')]
+    alt_upstream = _make_component('example.com/alt-upstream', '1.0.0', alt_upstream_crefs)
+    alt_upstream_cd = ocm.ComponentDescriptor(meta=ocm.Metadata(), component=alt_upstream)
+
+    def cd_lookup(cid, absent_ok=False):
+        if cid.name == 'example.com/alt-upstream':
+            return alt_upstream_cd
+        raise ValueError(f'unexpected lookup: {cid}')
+
+    policies = [
+        ocm_upgrade.ComponentPolicy(
+            components=['example.com/gated'],
+            upstream_component_name='example.com/alt-upstream',
+        )
+    ]
+
+    created = _run_create_upgrade_pullrequests(
+        component=component,
+        component_descriptor_lookup=cd_lookup,
+        version_lookup=lambda _: ['1.0.0', '1.5.0', '2.0.0'],
+        upstream_component_name='example.com/main-upstream',  # global — not used for this cref
+        component_policies=policies,
+    )
+
+    assert len(created) == 1
+    assert created[0].whither.version == '1.5.0'  # gated to alt-upstream, not latest (2.0.0)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Adds a `component-policies` input to the `ocm-upgrade` action and
`upgrade-dependencies` workflow. Entries select components by name (regex)
and carry an optional `upstream-component-name` override:

- empty string → disable upstream-gating for that component (use find-latest)
- non-empty → gate against a different upstream than the global one
- absent → inherit the global `upstream-component-name`

`upstream-update-policy` can also be overridden per component.

This addresses the case where a component follows an upstream landscape for
most dependencies but has one or more dependencies not tracked by that
upstream.

Example:
```yaml
component-policies: |
  - components:
      - acme.org/my-extra-component
    upstream-component-name: ''
```

**Release note**:
```feature operator
`upgrade-dependencies` workflow / `ocm-upgrade` action: new `component-policies`
input for per-component upstream-gating overrides.
```