### PR TITLE
oci: apply default read timeout to blob downloads

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -877,7 +877,6 @@ class Client:
                     scope=scope,
                     method='HEAD',
                     stream=False,
-                    timeout=None,
                 )
                 if (mediaType := res.headers['Content-Type']) == 'application/octet-stream':
                     # legacy container-images declare application/octet-stream as content-type,
@@ -1246,7 +1245,6 @@ class Client:
             scope=scope,
             method='GET',
             stream=stream,
-            timeout=None,
             raise_for_status=False,
         )
 


### PR DESCRIPTION
Two `_request()` calls in the OCI client passed `timeout=None`, disabling socket timeouts
entirely for blob HEAD (schema v1 path) and blob GET requests. When streaming a large blob
(`stream=True`), `iter_content()` blocks on the underlying socket read; without a timeout
a stalled connection hangs the replication worker indefinitely.

Removing the explicit `timeout=None` lets the default `(31, 121)` apply: 121 s maximum
between consecutive socket reads. A stalled connection will now raise
`requests.exceptions.Timeout`, which propagates as an error and lets the runner continue
with the next image rather than blocking forever.

**Release note**:
```bugfix operator
oci client: blob downloads now respect the default socket read-timeout (121 s), preventing
workers from hanging indefinitely on stalled connections
```