### PR TITLE
oci: adaptive per-host concurrency limit (AIMD)

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -358,6 +358,45 @@ def client_with_dockerauth(
     )
 
 
+class _PerHostThrottle:
+    '''
+    Adaptive per-host concurrency gate (AIMD).
+
+    Starts at `initial_limit` concurrent in-flight requests.  On each 429 the
+    limit is halved (minimum 1).  On each non-429/non-5xx success it grows by
+    one, up to `initial_limit`.  The slot is released *before* any retry sleep,
+    so waiting threads make forward progress while the caller backs off.
+    '''
+
+    def __init__(self, initial_limit: int):
+        self._initial_limit = initial_limit
+        self._limit = initial_limit
+        self._active = 0
+        self._cond = threading.Condition()
+
+    def __enter__(self):
+        with self._cond:
+            while self._active >= self._limit:
+                self._cond.wait()
+            self._active += 1
+        return self
+
+    def __exit__(self, *_):
+        with self._cond:
+            self._active -= 1
+            self._cond.notify_all()
+
+    def on_429(self):
+        with self._cond:
+            self._limit = max(1, self._limit // 2)
+
+    def on_success(self):
+        with self._cond:
+            if self._limit < self._initial_limit:
+                self._limit += 1
+                self._cond.notify()
+
+
 class Client:
     def __init__(
         self,
@@ -370,6 +409,7 @@ class Client:
         tag_postprocessing_callback: collections.abc.Callable[[str], str]=None,
         max_retries: int=5,
         default_backoff_base_seconds: float=1.0,
+        max_concurrent_per_host: int=8,
     ):
         '''
         :param Callable credentials_lookup:
@@ -388,6 +428,11 @@ class Client:
             how many times to retry a failed request (connection errors, 429, 5xx)
         :param float default_backoff_base_seconds:
             initial sleep before first retry; doubles on each subsequent attempt
+        :param int max_concurrent_per_host:
+            initial maximum number of simultaneous in-flight requests to any single registry host.
+            The limit is adaptive (AIMD): halved on each 429 response (minimum 1), incremented by
+            one on each successful non-429/non-5xx response, up to this initial value.  Prevents
+            burst concurrency from triggering per-client rate limits on registries such as Keppel.
         '''
         self.credentials_lookup = credentials_lookup
         self.token_cache = OauthTokenCache()
@@ -401,10 +446,25 @@ class Client:
         self.tag_postprocessing_callback = tag_postprocessing_callback
         self.max_retries = max_retries
         self.default_backoff_base_seconds = default_backoff_base_seconds
+        self._max_concurrent_per_host = max_concurrent_per_host
+        self._host_throttles: dict[str, '_PerHostThrottle'] = {}
+        self._host_throttles_lock = threading.Lock()
 
         if timeout_seconds:
             timeout_seconds = int(timeout_seconds)
         self.timeout_seconds = timeout_seconds
+
+    def _throttle_for(self, host: str) -> '_PerHostThrottle':
+        try:
+            return self._host_throttles[host]
+        except KeyError:
+            pass
+        with self._host_throttles_lock:
+            if host not in self._host_throttles:
+                self._host_throttles[host] = _PerHostThrottle(
+                    initial_limit=self._max_concurrent_per_host,
+                )
+            return self._host_throttles[host]
 
     def _authenticate(
         self,
@@ -679,21 +739,28 @@ class Client:
         except KeyError:
             timeout = (31, 121)
 
-        try:
-            res = self.session.request(
-                method=method,
-                url=url,
-                auth=auth,
-                headers=headers,
-                timeout=timeout,
-                **kwargs,
-            )
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        throttle = self._throttle_for(urllib.parse.urlparse(url).netloc)
+        conn_exc = None
+        with throttle:
+            try:
+                res = self.session.request(
+                    method=method,
+                    url=url,
+                    auth=auth,
+                    headers=headers,
+                    timeout=timeout,
+                    **kwargs,
+                )
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                conn_exc = e
+
+        if conn_exc is not None:
             if remaining_retries == 0:
-                raise
+                raise conn_exc
 
             logger.warning(
-                f'caught {type(e).__name__}, going to retry... ({remaining_retries=}); {e}'
+                f'caught {type(conn_exc).__name__}, going to retry... '
+                f'({remaining_retries=}); {conn_exc}'
             )
             if sleep_before_retry_seconds > 0:
                 time.sleep(sleep_before_retry_seconds)
@@ -719,6 +786,8 @@ class Client:
         if res.status_code == 429 and remaining_retries > 0:
             retry_after_seconds = _retry_after_seconds(res=res, fallback=sleep_before_retry_seconds)
             jitter = random.uniform(0, max(1.0, retry_after_seconds * 0.1))
+
+            throttle.on_429()
 
             logger.warning(
                 f'quota was exceeded, will retry after {retry_after_seconds + jitter:.1f}s '
@@ -762,6 +831,8 @@ class Client:
                 sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
                 **kwargs,
             )
+
+        throttle.on_success()
 
         if raise_for_status:
             if res.status_code != 404 and not res.ok:

--- a/test/oci/client_test.py
+++ b/test/oci/client_test.py
@@ -1,5 +1,8 @@
 import base64
+import threading
+import unittest.mock
 
+import requests
 
 import oci.client as co
 
@@ -15,3 +18,97 @@ def test_append_b64_padding_if_missing():
     encode_and_decode(b'ab')
     encode_and_decode(b'abc')
     encode_and_decode(b'abcd')
+
+
+def test_per_host_throttle_aimd():
+    t = co._PerHostThrottle(initial_limit=8)
+    assert t._limit == 8
+
+    t.on_429()
+    assert t._limit == 4
+
+    t.on_429()
+    assert t._limit == 2
+
+    t.on_429()
+    assert t._limit == 1
+
+    # minimum is 1
+    t.on_429()
+    assert t._limit == 1
+
+    # additive increase
+    t.on_success()
+    assert t._limit == 2
+
+    # does not exceed initial
+    t._limit = 7
+    t.on_success()
+    assert t._limit == 8
+    t.on_success()
+    assert t._limit == 8  # capped
+
+
+def test_per_host_throttle_blocks_at_limit():
+    t = co._PerHostThrottle(initial_limit=1)
+
+    results = []
+
+    with t:
+        # throttle slot is held; a second acquire should block
+        def try_acquire():
+            with t:
+                results.append('acquired')
+
+        thread = threading.Thread(target=try_acquire)
+        thread.start()
+        # give thread a moment to block
+        thread.join(timeout=0.1)
+        assert not results, 'second thread should not have acquired while slot is held'
+
+    thread.join(timeout=1)
+    assert results == ['acquired'], 'second thread should acquire after first releases'
+
+
+def _mock_response(status_code, headers=None):
+    r = unittest.mock.Mock(spec=requests.Response)
+    r.status_code = status_code
+    r.ok = (status_code < 400)
+    r.reason = 'mock'
+    r.content = b''
+    r.headers = headers or {}
+    return r
+
+
+def test_client_calls_throttle_on_429():
+    '''on_429() halves the limit on 429; on_success() recovers it after the retry succeeds.'''
+    client = co.Client(max_concurrent_per_host=4)
+
+    # pre-populate auth cache so _authenticate() exits early without network I/O
+    client.token_cache.set_auth_method(
+        image_reference='registry.example.com/repo:tag',
+        auth_method=co.AuthMethod.BASIC,
+    )
+
+    call_count = 0
+
+    def fake_request(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return _mock_response(429) if call_count == 1 else _mock_response(200)
+
+    throttle = co._PerHostThrottle(initial_limit=4)
+    client._throttle_for = lambda host: throttle
+
+    with unittest.mock.patch.object(client.session, 'request', side_effect=fake_request):
+        with unittest.mock.patch('oci.client.time.sleep'):
+            client._request(
+                url='https://registry.example.com/v2/repo/blobs/uploads/',
+                image_reference='registry.example.com/repo:tag',
+                scope='repository:repo:push',
+                method='POST',
+            )
+
+    # 4 → 2 from on_429, then 2 → 3 from on_success on the successful retry
+    assert throttle._limit == 3
+    assert call_count == 2


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Adds `_PerHostThrottle`, an AIMD-based concurrency gate in `oci/client.py`.

Each registry host gets its own semaphore, starting at `max_concurrent_per_host` (default 8) concurrent in-flight requests. On a 429 the limit is halved (minimum 1); on each successful response it grows by one back up to the initial limit. The throttle slot is released *before* the retry sleep so waiting threads make progress while the caller backs off.

This prevents burst concurrency from triggering per-client rate limits on registries that enforce per-client request quotas.

**Release note**:
\`\`\`feature operator
OCI client now throttles concurrency per registry host using AIMD: starts at 8
parallel requests, halves on 429, recovers additively on success. Avoids
triggering per-client rate limits on registries that enforce request quotas.
\`\`\`