### PR TITLE
scan_gobinary: add --force flag to re-push existing inferred CBOMs

### DIFF
--- a/.github/actions/sbom-upload/scan_gobinary.py
+++ b/.github/actions/sbom-upload/scan_gobinary.py
@@ -139,6 +139,11 @@ def main() -> None:
         dest='ocm_repositories',
         metavar='URL',
     )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Re-push even when an inferred CBOM referrer already exists.',
+    )
     args = parser.parse_args()
 
     if ':' not in args.ocm_component:
@@ -216,7 +221,7 @@ def main() -> None:
             continue
 
         # Skip cheaply if an inferred CBOM referrer already exists.
-        if sgob.has_inferred_cbom(digest_ref, oci_client):
+        if not args.force and sgob.has_inferred_cbom(digest_ref, oci_client):
             skipped_cached += 1
             elapsed = time.monotonic() - t0
             print(f'{prefix} skip (cached): {resource.name}  ({elapsed:.1f}s)', file=sys.stderr)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Adds a `--force` flag to `scan_gobinary.py` that bypasses the `has_inferred_cbom` check, allowing re-push of updated CBOMs when the inference logic or evidence data has changed (e.g. after syft starts emitting `evidence.occurrences`).

Without `--force` the script skips any image that already has an inferred CBOM referrer, which is the right default for incremental runs. `--force` is for one-off backfills.

**Release note**:
```other operator
NONE
```