### PR TITLE
oci: only call throttle.on_success() on 2xx responses

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -843,7 +843,8 @@ class Client:
                 **kwargs,
             )
 
-        throttle.on_success()
+        if res.ok:
+            throttle.on_success()
 
         if raise_for_status:
             if res.status_code != 404 and not res.ok:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

`throttle.on_success()` was unconditionally called before `raise_for_status()`,
meaning it was also called when all retries were exhausted on a 429 or 5xx — incorrectly
incrementing the per-host concurrency limit after a persistent failure.

Fix: guard the call with `if res.ok`.

**Release note**:
```bugfix operator
Fix _PerHostThrottle.on_success() being called on exhausted-retry 429/5xx responses.
The concurrency limit now only grows back when the response is actually successful (2xx).
```