### PR TITLE
sbom: ELF symbol and Node.js package crypto inference

### DIFF
--- a/sbom/elfcrypto.py
+++ b/sbom/elfcrypto.py
@@ -1,0 +1,790 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+ELF dynamic-symbol-based crypto inference for C/C++ OCI container images.
+
+Complements the Go-binary inference in gobinary.py for images whose main
+executables are C/C++ binaries linked against OpenSSL, BoringSSL, or mbedTLS.
+
+Two extraction modes
+--------------------
+OCI-layer (primary, no Docker required):
+  Fetches image layers via the OCI client, iterates tar members to locate
+  executables in standard binary directories, extracts them to a tempdir,
+  and runs `nm`/`readelf` analysis on each.  Requires an `oci.client.Client`
+  instance to be passed to `infer_from_elf()`.
+
+Docker (fallback):
+  Uses `docker create` + `docker cp` when no OCI client is provided.
+
+For statically-linked binaries (e.g. envoy with BoringSSL), dynamic imports
+give no signal.  The scanner falls back to string-marker detection using
+`strings`, looking for `external/boringssl/` source path markers embedded
+in debug sections.
+
+Public interface
+----------------
+  TOOL_NAME                                            str
+  infer_from_elf(image_reference,
+                 oci_client=None,
+                 binary_paths=None)                   -> dict | None
+'''
+import datetime
+import gzip
+import io
+import json
+import logging
+import os
+import re
+import subprocess
+import tarfile
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = 'elf-crypto-inference'
+ANALYSIS_METHOD_ANNOTATION = 'gardener.cloud/cbom/analysis-method'
+ANALYSIS_METHOD_VALUE = 'elf-crypto-inference'
+
+# ---------------------------------------------------------------------------
+# Symbol → crypto rules
+# (symbol_name_fragment, algorithm_name or None, [protocol_names])
+# Fragments are matched as exact name or as a prefix of the symbol name.
+# ---------------------------------------------------------------------------
+
+_SYMBOL_RULES = [
+    # AES
+    ('EVP_aes_128_gcm',          'AES-128-GCM',          []),
+    ('EVP_aes_256_gcm',          'AES-256-GCM',          []),
+    ('EVP_aes_128_cbc',          'AES-128-CBC',          []),
+    ('EVP_aes_256_cbc',          'AES-256-CBC',          []),
+    ('EVP_aes_128_ctr',          'AES-128-CTR',          []),
+    ('EVP_aes_256_ctr',          'AES-256-CTR',          []),
+    # RSA
+    ('RSA_sign',                 'RSA',                  []),
+    ('RSA_verify',               'RSA',                  []),
+    ('RSA_public_encrypt',       'RSA',                  []),
+    ('RSA_private_decrypt',      'RSA',                  []),
+    ('EVP_PKEY_CTX_set_rsa',     'RSA',                  []),
+    ('EVP_PKEY_encrypt',         'RSA',                  []),
+    ('EVP_PKEY_decrypt',         'RSA',                  []),
+    ('EVP_PKEY_sign',            'RSA',                  []),
+    # ECDSA / EC
+    ('ECDSA_sign',               'ECDSA',                []),
+    ('ECDSA_verify',             'ECDSA',                []),
+    ('EC_KEY_new',               'ECDSA',                []),
+    # SHA
+    ('EVP_sha1',                 'SHA-1',                []),
+    ('EVP_sha256',               'SHA-256',              []),
+    ('EVP_sha384',               'SHA-384',              []),
+    ('EVP_sha512',               'SHA-512',              []),
+    ('EVP_md5',                  'MD5',                  []),
+    ('SHA256',                   'SHA-256',              []),
+    ('SHA384',                   'SHA-384',              []),
+    ('SHA512',                   'SHA-512',              []),
+    # ChaCha20
+    ('EVP_chacha20_poly1305',    'ChaCha20-Poly1305',    []),
+    ('EVP_chacha20',             'ChaCha20',             []),
+    # HMAC
+    ('HMAC',                     'HMAC-SHA256',          []),
+    ('EVP_MAC_fetch',            'HMAC-SHA256',          []),
+    # TLS / SSL (OpenSSL 1.x / 3.x)
+    ('SSL_CTX_new',              None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('TLS_client_method',        None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('TLS_server_method',        None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('TLS_method',               None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('SSL_CTX_set_min_proto',    None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('SSL_accept',               None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('SSL_connect',              None,                   ['TLS/1.2', 'TLS/1.3']),
+    # DTLS
+    ('DTLS_client_method',       None,                   ['DTLS/1.2']),
+    ('DTLS_server_method',       None,                   ['DTLS/1.2']),
+    # mbedTLS symbols
+    ('mbedtls_ssl_init',         None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('mbedtls_aes_init',         'AES-128-GCM',          []),
+    ('mbedtls_rsa_init',         'RSA',                  []),
+    ('mbedtls_ecdsa_sign',       'ECDSA',                []),
+    ('mbedtls_sha256_init',      'SHA-256',              []),
+    ('mbedtls_sha512_init',      'SHA-512',              []),
+    ('mbedtls_md_hmac',          'HMAC-SHA256',          []),
+    # NSS
+    ('PK11_CreateContextBySymKey', None,                 ['TLS/1.2', 'TLS/1.3']),
+    ('SSL_ConfigServerCert',     None,                   ['TLS/1.2', 'TLS/1.3']),
+    # libgnutls
+    ('gnutls_init',              None,                   ['TLS/1.2', 'TLS/1.3']),
+    ('gnutls_handshake',         None,                   ['TLS/1.2', 'TLS/1.3']),
+]
+
+_RULE_INDEX = {sym: (alg, protos) for sym, alg, protos in _SYMBOL_RULES if alg or protos}
+
+# Shared-library names indicating dynamic OpenSSL/TLS linkage.
+_TLS_LIBS = re.compile(r'lib(ssl|crypto|gnutls|mbedtls|mbedcrypto|nss)\b', re.IGNORECASE)
+
+# String marker for statically-linked BoringSSL.
+_BORINGSSL_MARKER = re.compile(r'external/boringssl/', re.IGNORECASE)
+_BORINGSSL_FIPS_MARKER = re.compile(r'fipsmodule/', re.IGNORECASE)
+
+_SEARCH_DIRS = frozenset({
+    '/usr/local/bin', '/usr/bin', '/usr/sbin',
+    '/bin', '/sbin', '/usr/local/sbin',
+})
+
+# Skip binaries larger than this when doing static marker scan (save time).
+_STRINGS_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB
+
+
+# ---------------------------------------------------------------------------
+# ELF analysis (file-level, Docker- and OCI-layer-agnostic)
+# ---------------------------------------------------------------------------
+
+def _is_elf(data: bytes) -> bool:
+    return data[:4] == b'\x7fELF'
+
+
+def _dynamic_imports(binary_path: str) -> list:
+    '''Return list of undefined (imported) dynamic symbol names.'''
+    try:
+        result = subprocess.run(
+            ['nm', '--dynamic', '--undefined-only', binary_path],  # nosec B607
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            symbols = []
+            for line in result.stdout.splitlines():
+                parts = line.split()
+                if not parts:
+                    continue
+                name = parts[-1]
+                if '@' in name:
+                    name = name[:name.index('@')]
+                symbols.append(name)
+            return symbols
+    except Exception as exc:
+        logger.debug('elfcrypto: nm failed on %s: %s', binary_path, exc)
+
+    # Fallback: readelf --dyn-syms
+    try:
+        result = subprocess.run(
+            ['readelf', '--dyn-syms', '--wide', binary_path],  # nosec B607
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        symbols = []
+        for line in result.stdout.splitlines():
+            if 'UND' not in line:
+                continue
+            parts = line.split()
+            if len(parts) >= 8:
+                name = parts[7]
+                if '@' in name:
+                    name = name[:name.index('@')]
+                if name and name != '0':
+                    symbols.append(name)
+        return symbols
+    except Exception as exc:
+        logger.debug('elfcrypto: readelf fallback failed on %s: %s', binary_path, exc)
+    return []
+
+
+def _needed_libs(binary_path: str) -> list:
+    try:
+        result = subprocess.run(
+            ['readelf', '-d', binary_path],  # nosec B607
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        libs = []
+        for line in result.stdout.splitlines():
+            if 'NEEDED' in line:
+                m = re.search(r'\[([^\]]+)\]', line)
+                if m:
+                    libs.append(m.group(1))
+        return libs
+    except Exception:
+        return []
+
+
+def _detect_boringssl_static(binary_path: str, file_size: int = 0) -> bool:
+    if file_size > _STRINGS_MAX_BYTES:
+        return False
+    try:
+        result = subprocess.run(
+            ['strings', binary_path],  # nosec B607
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        for line in result.stdout.splitlines():
+            if _BORINGSSL_MARKER.search(line):
+                return True
+    except Exception:  # nosec B110
+        pass
+    return False
+
+
+def _detect_boringssl_fips(binary_path: str, file_size: int = 0) -> bool:
+    if file_size > _STRINGS_MAX_BYTES:
+        return False
+    try:
+        result = subprocess.run(
+            ['strings', binary_path],  # nosec B607
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        for line in result.stdout.splitlines():
+            if _BORINGSSL_FIPS_MARKER.search(line):
+                return True
+    except Exception:  # nosec B110
+        pass
+    return False
+
+
+def _match_symbols(symbols: list) -> tuple:
+    algs = set()
+    protos = set()
+    for sym in symbols:
+        for fragment, (alg, sym_protos) in _RULE_INDEX.items():
+            if sym == fragment or sym.startswith(fragment):
+                if alg:
+                    algs.add(alg)
+                protos.update(sym_protos)
+    return algs, protos
+
+
+def _analyse_binary(binary_path: str, file_size: int = 0) -> tuple:
+    '''
+    Analyse one ELF binary.  Returns (alg_set, proto_set, boringssl, boringssl_fips).
+    '''
+    libs = _needed_libs(binary_path)
+    has_dynamic_tls = any(_TLS_LIBS.search(lib) for lib in libs)
+
+    syms = _dynamic_imports(binary_path)
+    algs, protos = _match_symbols(syms)
+
+    boringssl = False
+    boringssl_fips = False
+
+    if not has_dynamic_tls:
+        boringssl = _detect_boringssl_static(binary_path, file_size)
+        if boringssl:
+            protos.update(['TLS/1.2', 'TLS/1.3'])
+            algs.update([
+                'AES-128-GCM', 'AES-256-GCM',
+                'ChaCha20-Poly1305',
+                'RSA', 'ECDSA',
+                'SHA-256', 'SHA-384', 'SHA-512',
+                'HMAC-SHA256',
+            ])
+            boringssl_fips = _detect_boringssl_fips(binary_path, file_size)
+    elif not protos:
+        # Dynamic TLS lib found but no specific TLS symbols resolved — emit defaults.
+        protos.update(['TLS/1.2', 'TLS/1.3'])
+
+    return algs, protos, boringssl, boringssl_fips
+
+
+# ---------------------------------------------------------------------------
+# OCI-layer extraction (primary)
+# ---------------------------------------------------------------------------
+
+def _resolve_manifest(image_ref, oci_client):
+    '''Resolve a possibly multi-arch manifest to a single-arch OCI manifest.'''
+    import oci.model as om
+    ref = om.OciImageReference.to_image_ref(image_ref)
+    repo_ref = ref.ref_without_tag
+    manifest = oci_client.manifest(image_ref)
+    if not isinstance(manifest, om.OciImageManifestList):
+        return manifest, repo_ref
+    entries = [
+        e for e in manifest.manifests
+        if e.platform and e.platform.os == 'linux'
+        and e.platform.architecture == 'amd64'
+    ]
+    entry = entries[0] if entries else (
+        manifest.manifests[0] if manifest.manifests else None
+    )
+    if entry is None:
+        return None, repo_ref
+    return oci_client.manifest(f'{repo_ref}@{entry.digest}'), repo_ref
+
+
+def _entrypoint_paths(manifest, repo_ref, oci_client) -> set:
+    '''
+    Extract candidate paths from the image config's Entrypoint/Cmd.
+    Returns a set that includes both the binary paths AND their parent dirs,
+    so siblings of the entrypoint in non-standard bin dirs are also discovered.
+    '''
+    try:
+        import json as _json
+        config_digest = manifest.config.digest
+        resp = oci_client.blob(
+            image_reference=repo_ref,
+            digest=config_digest,
+            stream=False,
+        )
+        if resp is None:
+            return set()
+        cfg = _json.loads(resp.content)
+        container_config = cfg.get('config') or cfg.get('container_config') or {}
+        result = set()
+        for field in ('Entrypoint', 'Cmd'):
+            for entry in (container_config.get(field) or []):
+                if entry and entry.startswith('/'):
+                    result.add(entry)
+                    result.add(os.path.dirname(entry))
+        return result
+    except Exception as exc:
+        logger.debug('elfcrypto: config fetch failed: %s', exc)
+        return set()
+
+
+def _infer_via_oci(image_reference: str, oci_client, binary_paths, tmpdir: str) -> dict | None:
+    '''
+    Extract ELF binaries from OCI layers and run crypto analysis.
+
+    Layer are fetched and decompressed once; tar members are scanned to
+    locate executables in _SEARCH_DIRS plus any entrypoint paths from the
+    image config.  Each layer is loaded at most once.
+    '''
+    try:
+        manifest, repo_ref = _resolve_manifest(image_reference, oci_client)
+    except Exception as exc:
+        logger.debug('elfcrypto: OCI manifest fetch failed for %s: %s', image_reference, exc)
+        return None
+
+    if manifest is None:
+        return None
+
+    # Reverse layers so most-recent (topmost overlay) is checked first.
+    layers = list(reversed(manifest.layers))
+    layer_cache = {}   # digest -> decompressed tar bytes or None
+
+    # Entrypoint paths augment _SEARCH_DIRS for non-standard binary locations
+    # (e.g. fluent-bit at /fluent-bit/bin/fluent-bit).
+    extra_paths = set(_entrypoint_paths(manifest, repo_ref, oci_client))
+
+    def _load_layer(layer):
+        digest = layer.digest
+        if digest in layer_cache:
+            return layer_cache[digest]
+        try:
+            resp = oci_client.blob(
+                image_reference=repo_ref,
+                digest=digest,
+                stream=False,
+            )
+            if resp is None:
+                layer_cache[digest] = None
+                return None
+            raw = resp.content
+            data = gzip.decompress(raw) if raw[:2] == b'\x1f\x8b' else raw
+            layer_cache[digest] = data
+        except Exception as exc:
+            logger.debug('elfcrypto: failed to load layer %s: %s', digest[:12], exc)
+            layer_cache[digest] = None
+        return layer_cache[digest]
+
+    def _scan_layers_for_paths():
+        '''Discover candidate binary paths from tar member headers.'''
+        seen = set()
+        candidates = []
+        for layer in layers:
+            data = _load_layer(layer)
+            if data is None:
+                continue
+            try:
+                with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+                    for m in tf.getmembers():
+                        if not m.isfile():
+                            continue
+                        path = '/' + m.name.lstrip('./')
+                        if path in seen:
+                            continue
+                        seen.add(path)
+                        dir_part = os.path.dirname(path)
+                        if (dir_part in _SEARCH_DIRS
+                                or dir_part in extra_paths
+                                or path in extra_paths) and (m.mode & 0o111):
+                            candidates.append((path, m.size))
+            except Exception:  # nosec B110
+                pass
+        return candidates
+
+    def _extract_binary(path, local_path):
+        '''Extract a single file from its layer to local_path.'''
+        norm = path.lstrip('/')
+        for layer in layers:
+            data = _load_layer(layer)
+            if data is None:
+                continue
+            try:
+                with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+                    for m in tf.getmembers():
+                        if m.name.lstrip('./') == norm and m.isfile():
+                            fobj = tf.extractfile(m)
+                            if fobj is None:
+                                return False
+                            content = fobj.read()
+                            with open(local_path, 'wb') as out:
+                                out.write(content)
+                            return True
+            except Exception:  # nosec B110
+                pass
+        return False
+
+    if binary_paths:
+        candidates = [(p, 0) for p in binary_paths]
+    else:
+        candidates = _scan_layers_for_paths()
+
+    if not candidates:
+        logger.debug('elfcrypto (OCI): no candidate binaries found in %s', image_reference)
+        return None
+
+    all_algs = set()
+    all_protos = set()
+    boringssl_detected = False
+    boringssl_fips = False
+    elf_count = 0
+
+    for bpath, bsize in candidates:
+        local = os.path.join(tmpdir, os.path.basename(bpath))
+        if not _extract_binary(bpath, local):
+            continue
+        try:
+            with open(local, 'rb') as f:
+                header = f.read(4)
+        except Exception:  # nosec B112
+            continue
+        if header != b'\x7fELF':
+            continue
+        elf_count += 1
+        algs, protos, bs, bs_fips = _analyse_binary(local, bsize)
+        all_algs.update(algs)
+        all_protos.update(protos)
+        if bs:
+            boringssl_detected = True
+        if bs_fips:
+            boringssl_fips = True
+
+    if not all_algs and not all_protos:
+        return None
+
+    return {
+        'algorithms':     sorted(all_algs),
+        'protocols':      sorted(all_protos),
+        'boringssl':      boringssl_detected,
+        'boringssl_fips': boringssl_fips,
+        'binary_count':   elf_count,
+        'source':         'elf-dynamic-symbols',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Docker fallback
+# ---------------------------------------------------------------------------
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(
+            ['docker', 'info'],  # nosec B607
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _docker_entrypoint_paths(image_reference: str) -> set:
+    '''
+    Return set of directories (from entrypoint paths) + the entrypoint paths themselves.
+    This allows discovering siblings of the entrypoint binary in non-standard bin dirs.
+    '''
+    try:
+        import json as _json
+        result = subprocess.run(
+            ['docker', 'image', 'inspect', image_reference,  # nosec B607
+             '--format', '{"Entrypoint":{{json .Config.Entrypoint}},"Cmd":{{json .Config.Cmd}}}'],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return set()
+        data = _json.loads(result.stdout.strip())
+        paths = set()
+        dirs = set()
+        for field in ('Entrypoint', 'Cmd'):
+            for entry in (data.get(field) or []):
+                if entry and entry.startswith('/'):
+                    paths.add(entry)
+                    dirs.add(os.path.dirname(entry))
+        return paths | dirs   # both specific paths and their parent directories
+    except Exception:
+        return set()
+
+
+def _discover_via_docker(image_reference: str) -> list:
+    '''Return [(path, 0)] for executable binaries discovered via docker.'''
+    extra_paths = _docker_entrypoint_paths(image_reference)
+
+    # Try docker run with find (may fail if find is not in the image).
+    try:
+        result = subprocess.run(
+            ['docker', 'run', '--rm', '--entrypoint', 'find',  # nosec B607
+             image_reference] + list(_SEARCH_DIRS) + ['-type', 'f', '-executable'],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            found = [(p.strip(), 0) for p in result.stdout.splitlines() if p.strip()]
+            # Add explicit entrypoint paths not already discovered
+            found_paths = {p for p, _ in found}
+            for p in extra_paths:
+                if p not in found_paths:
+                    found.append((p, 0))
+            return found
+    except Exception as exc:
+        logger.debug('elfcrypto (Docker): find failed for %s: %s', image_reference, exc)
+
+    # Fallback: docker create + docker export (scans the full filesystem).
+    try:
+        cid = subprocess.run(
+            ['docker', 'create', image_reference],  # nosec B607
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        if not cid:
+            return []
+        try:
+            tar_data = subprocess.run(
+                ['docker', 'export', cid],  # nosec B607
+                capture_output=True, timeout=120,
+            ).stdout
+            candidates = []
+            with tarfile.open(fileobj=io.BytesIO(tar_data)) as tf:
+                for m in tf.getmembers():
+                    if not m.isfile():
+                        continue
+                    path = '/' + m.name.lstrip('./')
+                    dir_part = os.path.dirname(path)
+                    if (dir_part in _SEARCH_DIRS
+                            or dir_part in extra_paths
+                            or path in extra_paths) and (m.mode & 0o111):
+                        candidates.append((path, m.size))
+            return candidates
+        finally:
+            subprocess.run(['docker', 'rm', cid], capture_output=True, timeout=10)  # nosec B607
+    except Exception as exc:
+        logger.debug('elfcrypto (Docker): export fallback failed for %s: %s',
+                     image_reference, exc)
+    return []
+
+
+def _extract_via_docker(image_reference: str, binary_path: str, local_path: str) -> bool:
+    try:
+        cid = subprocess.run(
+            ['docker', 'create', image_reference],  # nosec B607
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        if not cid:
+            return False
+        try:
+            cp = subprocess.run(
+                ['docker', 'cp', f'{cid}:{binary_path}', local_path],  # nosec B607
+                capture_output=True, timeout=60,
+            )
+            return cp.returncode == 0
+        finally:
+            subprocess.run(['docker', 'rm', cid], capture_output=True, timeout=10)  # nosec B607
+    except Exception as exc:
+        logger.debug('elfcrypto (Docker): cp failed %s from %s: %s',
+                     binary_path, image_reference, exc)
+        return False
+
+
+def _infer_via_docker(image_reference: str, binary_paths, tmpdir: str) -> dict | None:
+    if not _docker_available():
+        logger.debug('elfcrypto: Docker unavailable for %s', image_reference)
+        return None
+
+    if binary_paths:
+        candidates = [(p, 0) for p in binary_paths]
+    else:
+        candidates = _discover_via_docker(image_reference)
+
+    if not candidates:
+        return None
+
+    all_algs = set()
+    all_protos = set()
+    boringssl_detected = False
+    boringssl_fips = False
+    elf_count = 0
+
+    for bpath, bsize in candidates:
+        local = os.path.join(tmpdir, os.path.basename(bpath))
+        if not _extract_via_docker(image_reference, bpath, local):
+            continue
+        try:
+            with open(local, 'rb') as f:
+                header = f.read(4)
+        except Exception:  # nosec B112
+            continue
+        if header != b'\x7fELF':
+            continue
+        elf_count += 1
+        file_size = os.path.getsize(local)
+        algs, protos, bs, bs_fips = _analyse_binary(local, file_size)
+        all_algs.update(algs)
+        all_protos.update(protos)
+        if bs:
+            boringssl_detected = True
+        if bs_fips:
+            boringssl_fips = True
+
+    if not all_algs and not all_protos:
+        return None
+
+    return {
+        'algorithms':     sorted(all_algs),
+        'protocols':      sorted(all_protos),
+        'boringssl':      boringssl_detected,
+        'boringssl_fips': boringssl_fips,
+        'binary_count':   elf_count,
+        'source':         'elf-dynamic-symbols',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+
+_FIPS_ALGS = frozenset({
+    'AES-128-GCM', 'AES-256-GCM', 'AES-128-CTR', 'AES-256-CTR',
+    'RSA', 'ECDSA', 'SHA-256', 'SHA-384', 'SHA-512',
+    'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512',
+})
+
+
+def _alg_to_primitive(name: str) -> str:
+    n = name.upper()
+    if 'AES' in n:     return 'AE'
+    if 'CHACHA' in n:  return 'AE'
+    if 'ECDSA' in n:   return 'SIGNATURE'
+    if 'RSA' in n:     return 'PKE'
+    if 'ECDH' in n:    return 'KA'
+    if 'ED25519' in n: return 'SIGNATURE'
+    if 'HMAC' in n:    return 'MAC'
+    if 'SHA' in n:     return 'HASH'
+    if 'MD5' in n:     return 'HASH'
+    if 'BCRYPT' in n:  return 'HASH'
+    if 'ARGON' in n:   return 'HASH'
+    return 'OTHER'
+
+
+def _parse_proto(proto: str) -> tuple:
+    if '/' in proto:
+        t, v = proto.split('/', 1)
+        return t, v
+    return proto, ''
+
+
+def infer_from_elf(
+    image_reference: str,
+    oci_client=None,
+    binary_paths: list | None = None,
+) -> dict | None:
+    '''
+    Return {algorithms, protocols, boringssl, boringssl_fips, binary_count, source}
+    inferred from ELF dynamic imports and (for static binaries) string markers.
+
+    oci_client: oci.client.Client — preferred extraction path; no Docker needed.
+      If None, falls back to Docker.
+    binary_paths: list of absolute paths inside the image to inspect.
+      If None, paths are discovered automatically.
+    Returns None if no crypto signals are found or neither extraction path works.
+    '''
+    with tempfile.TemporaryDirectory() as tmpdir:
+        if oci_client is not None:
+            result = _infer_via_oci(image_reference, oci_client, binary_paths, tmpdir)
+            if result is not None:
+                return result
+            logger.debug(
+                'elfcrypto: OCI path returned nothing for %s, trying Docker',
+                image_reference,
+            )
+        return _infer_via_docker(image_reference, binary_paths, tmpdir)
+
+
+def build_inferred_cbom(image_ref: str, inference: dict) -> bytes:
+    '''
+    Build a CycloneDX 1.6 CBOM from an ELF inference result dict.
+
+    The document is tagged with `analysis-method: elf-crypto-inference` so it
+    can be distinguished from cbomkit-theia and go-binary-inference referrers.
+    '''
+    components = []
+
+    for alg_name in inference.get('algorithms', []):
+        comp = {
+            'type': 'cryptographic-asset',
+            'name': alg_name,
+            'cryptoProperties': {
+                'assetType': 'algorithm',
+                'algorithmProperties': {
+                    'primitive': _alg_to_primitive(alg_name),
+                },
+            },
+        }
+        if inference.get('boringssl_fips') and alg_name in _FIPS_ALGS:
+            comp['cryptoProperties']['certificationLevel'] = ['FIPS140-2', 'FIPS140-3']
+        components.append(comp)
+
+    for proto in inference.get('protocols', []):
+        proto_type, proto_ver = _parse_proto(proto)
+        components.append({
+            'type': 'cryptographic-asset',
+            'name': proto,
+            'cryptoProperties': {
+                'assetType': 'protocol',
+                'protocolProperties': {
+                    'type':    proto_type,
+                    'version': proto_ver,
+                },
+            },
+        })
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    properties = [
+        {'name': ANALYSIS_METHOD_ANNOTATION, 'value': ANALYSIS_METHOD_VALUE},
+        {'name': 'gardener.cloud/cbom/source-image', 'value': str(image_ref)},
+        {'name': 'gardener.cloud/cbom/inference-source', 'value': inference.get('source', '')},
+        {'name': 'gardener.cloud/cbom/elf-binary-count',
+         'value': str(inference.get('binary_count', 0))},
+    ]
+    if inference.get('boringssl'):
+        properties.append({'name': 'gardener.cloud/cbom/boringssl-detected', 'value': 'true'})
+    if inference.get('boringssl_fips'):
+        properties.append({'name': 'gardener.cloud/cbom/boringssl-fips-detected', 'value': 'true'})
+
+    doc = {
+        'bomFormat':   'CycloneDX',
+        'specVersion': '1.6',
+        'version':     1,
+        'metadata': {
+            'timestamp': now,
+            'tools': [{'name': TOOL_NAME, 'version': '0.1.0'}],
+            'properties': properties,
+        },
+        'components': components,
+    }
+    return json.dumps(doc, indent=2).encode()

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -29,7 +29,9 @@ import oci.model as om
 import ocm
 import sbom.cbom as scbom
 import sbom.cbomenrich as scbe
+import sbom.elfcrypto as selfc
 import sbom.gobinary as sgob
+import sbom.nodecrypto as snodec
 import sbom.oci as soci
 import sbom.s3 as ss3
 
@@ -360,6 +362,58 @@ def scan_image(
             inference['module_count'],
             len(inference['algorithms']),
             len(inference['protocols']),
+        )
+
+    # ELF symbol inference — detects crypto in C/C++ images (envoy, fluent-bit, etc.)
+    # that cbomkit-theia only covers as CA-bundle noise.
+    elf_inference = selfc.infer_from_elf(
+        image_reference=str(image_ref),
+        oci_client=oci_client,
+    )
+    if elf_inference:
+        elf_cbom_bytes = selfc.build_inferred_cbom(
+            image_ref=image_ref,
+            inference=elf_inference,
+        )
+        scbom.push_cbom_referrer(
+            cbom_bytes=elf_cbom_bytes,
+            image_reference=image_ref,
+            oci_client=oci_client,
+            tool_version=selfc.TOOL_NAME,
+            extra_annotations={selfc.ANALYSIS_METHOD_ANNOTATION: selfc.ANALYSIS_METHOD_VALUE},
+        )
+        logger.info(
+            '%s: pushed elf-inferred CBOM (%d binaries → %d algorithms, %d protocols%s)',
+            image_ref,
+            elf_inference['binary_count'],
+            len(elf_inference['algorithms']),
+            len(elf_inference['protocols']),
+            ', BoringSSL' if elf_inference.get('boringssl') else '',
+        )
+
+    # Node.js inference — detects crypto in Node.js images (gardener-dashboard, etc.)
+    node_inference = snodec.infer_from_node(
+        image_reference=str(image_ref),
+        oci_client=oci_client,
+    )
+    if node_inference:
+        node_cbom_bytes = snodec.build_inferred_cbom(
+            image_ref=image_ref,
+            inference=node_inference,
+        )
+        scbom.push_cbom_referrer(
+            cbom_bytes=node_cbom_bytes,
+            image_reference=image_ref,
+            oci_client=oci_client,
+            tool_version=snodec.TOOL_NAME,
+            extra_annotations={snodec.ANALYSIS_METHOD_ANNOTATION: snodec.ANALYSIS_METHOD_VALUE},
+        )
+        logger.info(
+            '%s: pushed node-inferred CBOM (%d packages → %d algorithms, %d protocols)',
+            image_ref,
+            node_inference['package_count'],
+            len(node_inference['algorithms']),
+            len(node_inference['protocols']),
         )
 
     return (

--- a/sbom/nodecrypto.py
+++ b/sbom/nodecrypto.py
@@ -1,0 +1,541 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Node.js package-based crypto inference for OCI container images.
+
+Detects cryptographic usage in Node.js applications by inspecting which
+crypto-relevant npm packages are installed in `node_modules/` directories
+or declared in `package.json` dependencies.
+
+Any Node.js app that makes HTTPS requests uses TLS 1.2/1.3 via the Node.js
+built-in `tls` module backed by OpenSSL (or BoringSSL on some builds).
+
+Two extraction modes
+--------------------
+OCI-layer (primary, no Docker required):
+  Fetches image layers, scans tar member paths for `node_modules/` directories
+  and `package.json` files, then extracts and parses dependency lists.
+
+Docker (fallback):
+  Uses `docker run ls` / `docker cp` when no OCI client is provided.
+
+Public interface
+----------------
+  TOOL_NAME                              str
+  infer_from_node(image_reference,
+                  oci_client=None)       -> dict | None
+'''
+import datetime
+import gzip
+import io
+import json
+import logging
+import os
+import subprocess
+import tarfile
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = 'node-crypto-inference'
+ANALYSIS_METHOD_ANNOTATION = 'gardener.cloud/cbom/analysis-method'
+ANALYSIS_METHOD_VALUE = 'node-crypto-inference'
+
+# ---------------------------------------------------------------------------
+# Package → crypto inference rules
+# ---------------------------------------------------------------------------
+# Maps npm package name (exact or prefix) to ([algorithms], [protocols]).
+
+_NODE_CRYPTO_PACKAGES = {
+    # JWE/JWS/JWT (JOSE) — RSA-OAEP, AES-GCM, ECDH, ECDSA, EdDSA, HMAC
+    'jose': (
+        ['RSA', 'ECDSA', 'AES-128-GCM', 'AES-256-GCM', 'SHA-256', 'SHA-384', 'HMAC-SHA256'],
+        [],
+    ),
+    # Classic JWT: HS256/RS256/ES256/EdDSA
+    'jsonwebtoken': (
+        ['RSA', 'ECDSA', 'HMAC-SHA256', 'SHA-256'],
+        [],
+    ),
+    'express-jwt': (
+        ['RSA', 'ECDSA', 'HMAC-SHA256'],
+        [],
+    ),
+    # Pure-JS TLS/PKI
+    'node-forge': (
+        ['RSA', 'AES-128-GCM', 'AES-256-GCM', 'AES-128-CBC', 'SHA-256', 'ECDSA', 'HMAC-SHA256'],
+        ['TLS/1.2'],
+    ),
+    # Symmetric + hash
+    'crypto-js': (
+        ['AES', 'SHA-256', 'HMAC-SHA256', 'RSA'],
+        [],
+    ),
+    # Password hashing
+    'bcrypt': (
+        ['bcrypt'],
+        [],
+    ),
+    'bcryptjs': (
+        ['bcrypt'],
+        [],
+    ),
+    'argon2': (
+        ['Argon2'],
+        [],
+    ),
+    # HTTPS proxy agents — imply TLS transport
+    'https-proxy-agent': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # Octokit GitHub SDK (HTTPS)
+    '@octokit/core': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    '@octokit/auth-app': (
+        ['RSA', 'SHA-256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    'universal-github-app-jwt': (
+        ['RSA', 'SHA-256'],
+        [],
+    ),
+    # Kubernetes client (always TLS)
+    '@kubernetes/client-node': (
+        ['RSA', 'ECDSA', 'SHA-256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # AWS SDK (HTTPS + SigV4)
+    'aws-sdk': (
+        ['RSA', 'ECDSA', 'AES-128-GCM', 'SHA-256', 'HMAC-SHA256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    '@aws-sdk/client': (
+        ['RSA', 'ECDSA', 'AES-128-GCM', 'SHA-256', 'HMAC-SHA256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # gRPC — always TLS
+    '@grpc/grpc-js': (
+        ['RSA', 'ECDSA', 'AES-128-GCM', 'AES-256-GCM', 'SHA-256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    'grpc': (
+        ['RSA', 'ECDSA', 'AES-128-GCM', 'SHA-256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # OpenTelemetry gRPC exporter
+    '@opentelemetry/exporter-grpc': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    '@opentelemetry/exporter-otlp-grpc': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # HTTP(S) clients
+    'axios': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    'node-fetch': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    'got': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # OAuth2 / OIDC
+    'passport-oauth2': (
+        ['RSA', 'ECDSA', 'SHA-256'],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+    # socket.io — TLS when served over HTTPS
+    'socket.io': (
+        [],
+        ['TLS/1.2', 'TLS/1.3'],
+    ),
+}
+
+# Sorted longest-first for unambiguous prefix matching.
+_PACKAGE_RULES = sorted(
+    [(name, algs, protos) for name, (algs, protos) in _NODE_CRYPTO_PACKAGES.items()],
+    key=lambda x: -len(x[0]),
+)
+
+# node_modules search roots (checked in order).
+_NODE_MODULES_DIRS = [
+    '/app/node_modules',
+    '/usr/local/lib/node_modules',
+    '/home/node/app/node_modules',
+    '/node_modules',
+    '/srv/node_modules',
+]
+
+# Directories that may contain the `node` binary.
+_NODE_BIN_DIRS = ['/usr/local/bin', '/usr/bin', '/usr/local/nvm/current/bin']
+
+
+# ---------------------------------------------------------------------------
+# Shared package matching
+# ---------------------------------------------------------------------------
+
+def _match_packages(package_names: list) -> tuple:
+    algs = set()
+    protos = set()
+    matched = []
+    for pkg in package_names:
+        for prefix, rule_algs, rule_protos in _PACKAGE_RULES:
+            if pkg == prefix or pkg.startswith(prefix + '/') or pkg.startswith(prefix + '-'):
+                algs.update(rule_algs)
+                protos.update(rule_protos)
+                matched.append(pkg)
+                break
+    return algs, protos, matched
+
+
+def _parse_deps_from_package_json(data: bytes) -> list:
+    try:
+        doc = json.loads(data)
+    except Exception:
+        return []
+    deps = {}
+    for key in ('dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'):
+        deps.update(doc.get(key) or {})
+    return list(deps.keys())
+
+
+# ---------------------------------------------------------------------------
+# OCI-layer extraction (primary)
+# ---------------------------------------------------------------------------
+
+def _resolve_manifest(image_ref, oci_client):
+    import oci.model as om
+    ref = om.OciImageReference.to_image_ref(image_ref)
+    repo_ref = ref.ref_without_tag
+    manifest = oci_client.manifest(image_ref)
+    if not isinstance(manifest, om.OciImageManifestList):
+        return manifest, repo_ref
+    entries = [
+        e for e in manifest.manifests
+        if e.platform and e.platform.os == 'linux'
+        and e.platform.architecture == 'amd64'
+    ]
+    entry = entries[0] if entries else (
+        manifest.manifests[0] if manifest.manifests else None
+    )
+    if entry is None:
+        return None, repo_ref
+    return oci_client.manifest(f'{repo_ref}@{entry.digest}'), repo_ref
+
+
+def _infer_via_oci(image_reference: str, oci_client) -> dict | None:
+    try:
+        manifest, repo_ref = _resolve_manifest(image_reference, oci_client)
+    except Exception as exc:
+        logger.debug('nodecrypto: OCI manifest fetch failed for %s: %s', image_reference, exc)
+        return None
+    if manifest is None:
+        return None
+
+    layers = list(reversed(manifest.layers))
+    layer_cache = {}
+
+    def _load_layer(layer):
+        digest = layer.digest
+        if digest in layer_cache:
+            return layer_cache[digest]
+        try:
+            resp = oci_client.blob(
+                image_reference=repo_ref,
+                digest=digest,
+                stream=False,
+            )
+            if resp is None:
+                layer_cache[digest] = None
+                return None
+            raw = resp.content
+            data = gzip.decompress(raw) if raw[:2] == b'\x1f\x8b' else raw
+            layer_cache[digest] = data
+        except Exception as exc:
+            logger.debug('nodecrypto: failed to load layer %s: %s', digest[:12], exc)
+            layer_cache[digest] = None
+        return layer_cache[digest]
+
+    has_node = False
+    node_modules_pkgs = []    # package names from node_modules listing
+    pkg_json_deps = []        # deps from package.json files
+
+    # Single pass over all layers to collect everything we need.
+    seen_paths = set()
+    for layer in layers:
+        data = _load_layer(layer)
+        if data is None:
+            continue
+        try:
+            with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+                for m in tf.getmembers():
+                    norm = '/' + m.name.lstrip('./')
+                    if norm in seen_paths:
+                        continue
+                    seen_paths.add(norm)
+
+                    # Check for node binary
+                    if not has_node:
+                        bn = os.path.basename(norm)
+                        if bn in ('node', 'nodejs') and m.isfile() and (m.mode & 0o111):
+                            has_node = True
+
+                    # Collect node_modules top-level package names
+                    parts = norm.split('/')
+                    for root in _NODE_MODULES_DIRS:
+                        root_parts = root.rstrip('/').split('/')
+                        n = len(root_parts)
+                        if (parts[:n] == root_parts
+                                and len(parts) == n + 2
+                                and m.isdir()):
+                            node_modules_pkgs.append(parts[n])
+                        # Scoped packages: @scope/name
+                        elif (parts[:n] == root_parts
+                                and len(parts) == n + 3
+                                and parts[n].startswith('@')
+                                and m.isdir()):
+                            node_modules_pkgs.append(f'{parts[n]}/{parts[n+1]}')
+
+                    # Parse top-level package.json (not inside node_modules or .yarn)
+                    if (norm.endswith('/package.json')
+                            and 'node_modules' not in norm
+                            and '.yarn' not in norm
+                            and m.isfile()):
+                        try:
+                            fobj = tf.extractfile(m)
+                            if fobj:
+                                pkg_json_deps.extend(_parse_deps_from_package_json(fobj.read()))
+                        except Exception:  # nosec B110
+                            pass
+        except Exception:  # nosec B110
+            pass
+
+    if not has_node:
+        logger.debug('nodecrypto (OCI): no Node.js binary found in %s', image_reference)
+        return None
+
+    all_pkgs = list(set(node_modules_pkgs + pkg_json_deps))
+    base_protos = {'TLS/1.2', 'TLS/1.3'}
+    algs, protos, matched = _match_packages(all_pkgs)
+    protos.update(base_protos)
+
+    return {
+        'algorithms':       sorted(algs),
+        'protocols':        sorted(protos),
+        'matched_packages': matched,
+        'package_count':    len(all_pkgs),
+        'source':           'node-crypto-inference',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Docker fallback
+# ---------------------------------------------------------------------------
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(
+            ['docker', 'info'],  # nosec B607
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _infer_via_docker(image_reference: str) -> dict | None:
+    if not _docker_available():
+        return None
+
+    try:
+        cid = subprocess.run(
+            ['docker', 'create', image_reference],  # nosec B607
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        if not cid:
+            return None
+        try:
+            tar_data = subprocess.run(
+                ['docker', 'export', cid],  # nosec B607
+                capture_output=True, timeout=120,
+            ).stdout
+        finally:
+            subprocess.run(['docker', 'rm', cid], capture_output=True, timeout=10)  # nosec B607
+    except Exception as exc:
+        logger.debug('nodecrypto (Docker): export failed for %s: %s', image_reference, exc)
+        return None
+
+    has_node = False
+    node_modules_pkgs = []
+    pkg_json_deps = []
+    seen_paths = set()
+    node_modules_set = frozenset(_NODE_MODULES_DIRS)
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tar_data)) as tf:
+            for m in tf.getmembers():
+                norm = '/' + m.name.lstrip('./')
+                if norm in seen_paths:
+                    continue
+                seen_paths.add(norm)
+
+                if not has_node:
+                    bn = os.path.basename(norm)
+                    if bn in ('node', 'nodejs') and m.isfile() and (m.mode & 0o111):
+                        has_node = True
+
+                parts = norm.split('/')
+                for root in node_modules_set:
+                    root_parts = root.rstrip('/').split('/')
+                    n = len(root_parts)
+                    if parts[:n] == root_parts and len(parts) == n + 2 and m.isdir():
+                        node_modules_pkgs.append(parts[n])
+                    elif (parts[:n] == root_parts
+                            and len(parts) == n + 3
+                            and parts[n].startswith('@')
+                            and m.isdir()):
+                        node_modules_pkgs.append(f'{parts[n]}/{parts[n+1]}')
+
+                if (norm.endswith('/package.json')
+                        and 'node_modules' not in norm
+                        and '.yarn' not in norm
+                        and m.isfile()):
+                    try:
+                        fobj = tf.extractfile(m)
+                        if fobj:
+                            pkg_json_deps.extend(_parse_deps_from_package_json(fobj.read()))
+                    except Exception:  # nosec B110
+                        pass
+    except Exception as exc:
+        logger.debug('nodecrypto (Docker): tar scan failed for %s: %s', image_reference, exc)
+        return None
+
+    if not has_node:
+        logger.debug('nodecrypto (Docker): no Node.js binary in %s', image_reference)
+        return None
+
+    all_pkgs = list(set(node_modules_pkgs + pkg_json_deps))
+    base_protos = {'TLS/1.2', 'TLS/1.3'}
+    algs, protos, matched = _match_packages(all_pkgs)
+    protos.update(base_protos)
+
+    return {
+        'algorithms':       sorted(algs),
+        'protocols':        sorted(protos),
+        'matched_packages': matched,
+        'package_count':    len(all_pkgs),
+        'source':           'node-crypto-inference',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+
+def infer_from_node(image_reference: str, oci_client=None) -> dict | None:
+    '''
+    Return {algorithms, protocols, matched_packages, package_count, source}
+    inferred from Node.js package analysis.
+
+    oci_client: oci.client.Client — preferred extraction path; no Docker needed.
+      If None, falls back to Docker.
+    Returns None if no Node.js runtime is found or neither extraction path works.
+    '''
+    if oci_client is not None:
+        result = _infer_via_oci(image_reference, oci_client)
+        if result is not None:
+            return result
+        logger.debug('nodecrypto: OCI path returned nothing for %s, trying Docker',
+                     image_reference)
+    return _infer_via_docker(image_reference)
+
+
+def _alg_to_primitive(name: str) -> str:
+    n = name.upper()
+    if 'AES' in n:     return 'AE'
+    if 'CHACHA' in n:  return 'AE'
+    if 'ECDSA' in n:   return 'SIGNATURE'
+    if 'RSA' in n:     return 'PKE'
+    if 'HMAC' in n:    return 'MAC'
+    if 'SHA' in n:     return 'HASH'
+    if 'BCRYPT' in n:  return 'HASH'
+    if 'ARGON' in n:   return 'HASH'
+    return 'OTHER'
+
+
+def _parse_proto(proto: str) -> tuple:
+    if '/' in proto:
+        t, v = proto.split('/', 1)
+        return t, v
+    return proto, ''
+
+
+def build_inferred_cbom(image_ref: str, inference: dict) -> bytes:
+    '''
+    Build a CycloneDX 1.6 CBOM from a Node.js inference result dict.
+
+    The document is tagged with `analysis-method: node-crypto-inference` so it
+    can be distinguished from cbomkit-theia and elf-crypto-inference referrers.
+    '''
+    components = []
+
+    for alg_name in inference.get('algorithms', []):
+        components.append({
+            'type': 'cryptographic-asset',
+            'name': alg_name,
+            'cryptoProperties': {
+                'assetType': 'algorithm',
+                'algorithmProperties': {
+                    'primitive': _alg_to_primitive(alg_name),
+                },
+            },
+        })
+
+    for proto in inference.get('protocols', []):
+        proto_type, proto_ver = _parse_proto(proto)
+        components.append({
+            'type': 'cryptographic-asset',
+            'name': proto,
+            'cryptoProperties': {
+                'assetType': 'protocol',
+                'protocolProperties': {
+                    'type':    proto_type,
+                    'version': proto_ver,
+                },
+            },
+        })
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    matched = inference.get('matched_packages', [])
+    properties = [
+        {'name': ANALYSIS_METHOD_ANNOTATION,               'value': ANALYSIS_METHOD_VALUE},
+        {'name': 'gardener.cloud/cbom/source-image',       'value': str(image_ref)},
+        {'name': 'gardener.cloud/cbom/inference-source',
+         'value': inference.get('source', '')},
+        {'name': 'gardener.cloud/cbom/node-package-count',
+         'value': str(inference.get('package_count', 0))},
+        {'name': 'gardener.cloud/cbom/node-matched-packages', 'value': ','.join(matched)},
+    ]
+
+    doc = {
+        'bomFormat':   'CycloneDX',
+        'specVersion': '1.6',
+        'version':     1,
+        'metadata': {
+            'timestamp': now,
+            'tools': [{'name': TOOL_NAME, 'version': '0.1.0'}],
+            'properties': properties,
+        },
+        'components': components,
+    }
+    return json.dumps(doc, indent=2).encode()


### PR DESCRIPTION
## What

Add two new CBOM inference modules for image types that cbomkit-theia (filesystem scan)
and gobinary inference cannot cover:

### `sbom/elfcrypto.py` — ELF dynamic-symbol scanner

Scans C/C++ binaries for dynamic imports matching 50+ OpenSSL/BoringSSL/mbedTLS symbol
patterns to infer algorithm and protocol usage.

- Primary path: OCI-layer extraction (no Docker) — fetches layers via `oci.Client`,
  extracts ELF binaries from standard paths (`/usr/bin`, `/usr/sbin`, `/usr/local/bin`, etc.)
  to a tempdir, runs `nm --dynamic --undefined-only` (falls back to `readelf --syms`)
- Fallback path: Docker (`docker create` + `docker cp`) when no OCI client is provided
- Static BoringSSL detection: string-marker scan via `strings` for
  `external/boringssl/` path markers embedded in debug sections (covers envoy)
- Produces a CycloneDX 1.6 CBOM annotated with `analysis-method: elf-crypto-inference`

Target images: `fluent-bit` (OpenSSL dynamic), `envoy-proxy` (BoringSSL static), `falco`

### `sbom/nodecrypto.py` — Node.js package scanner

Infers crypto from installed npm packages in `node_modules/` directories.

- Primary path: OCI-layer scan for `node_modules/*/package.json` files
- Maps packages (`jose`, `jsonwebtoken`, `https-proxy-agent`, `bcrypt`, etc.) to
  algorithms and protocols
- Any Node.js app implicitly gets TLS/1.2 + TLS/1.3 (via built-in `tls` + OpenSSL)
- Produces a CycloneDX 1.6 CBOM annotated with `analysis-method: node-crypto-inference`

Target images: `gardener-dashboard`

### `sbom/inject.py` wiring

`scan_image()` now runs ELF and Node.js inference after gobinary inference and pushes
separate CBOM referrers per inference type.  All three referrers are distinguished by
the `gardener.cloud/cbom/analysis-method` annotation.