### PR TITLE
oci/client: block all new requests per host during retry-after window

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -360,12 +360,13 @@ def client_with_dockerauth(
 
 class _PerHostThrottle:
     '''
-    Adaptive per-host concurrency gate (AIMD).
+    Adaptive per-host concurrency gate (AIMD) with rate-limit awareness.
 
     Starts at `initial_limit` concurrent in-flight requests.  On each 429 the
-    limit is halved (minimum 1).  On each non-429/non-5xx success it grows by
-    one, up to `initial_limit`.  The slot is released *before* any retry sleep,
-    so waiting threads make forward progress while the caller backs off.
+    limit is halved (minimum 1) AND all new slot acquisitions are blocked until
+    the `Retry-After` window expires — preventing other threads from hammering
+    the host while one thread backs off.  On each success the limit grows by
+    one, up to `initial_limit`.
     '''
 
     def __init__(self, host: str, initial_limit: int):
@@ -373,12 +374,20 @@ class _PerHostThrottle:
         self._initial_limit = initial_limit
         self._limit = initial_limit
         self._active = 0
+        self._resume_at: float = 0.0  # time.monotonic() timestamp; 0 = no pause
         self._cond = threading.Condition()
 
     def __enter__(self):
         with self._cond:
-            while self._active >= self._limit:
-                self._cond.wait()
+            while True:
+                now = time.monotonic()
+                pause_remaining = self._resume_at - now
+                if self._active < self._limit and pause_remaining <= 0:
+                    break
+                if pause_remaining > 0:
+                    self._cond.wait(timeout=pause_remaining)
+                else:
+                    self._cond.wait()
             self._active += 1
         return self
 
@@ -387,13 +396,16 @@ class _PerHostThrottle:
             self._active -= 1
             self._cond.notify_all()
 
-    def on_429(self):
+    def on_429(self, retry_after: float = 1.0):
         with self._cond:
             prev = self._limit
             self._limit = max(1, self._limit // 2)
+            self._resume_at = max(self._resume_at, time.monotonic() + retry_after)
+            self._cond.notify_all()
             logger.warning(
                 f'per-host concurrency limit for {self._host} '
-                f'reduced {prev} -> {self._limit} after 429'
+                f'reduced {prev} -> {self._limit} after 429; '
+                f'blocking new requests for {retry_after:.1f}s'
             )
 
     def on_success(self):
@@ -798,7 +810,7 @@ class Client:
             retry_after_seconds = _retry_after_seconds(res=res, fallback=sleep_before_retry_seconds)
             jitter = random.uniform(0, max(1.0, retry_after_seconds * 0.1))
 
-            throttle.on_429()
+            throttle.on_429(retry_after=retry_after_seconds)
 
             logger.warning(
                 f'quota was exceeded, will retry after {retry_after_seconds + jitter:.1f}s '

--- a/test/oci/client_test.py
+++ b/test/oci/client_test.py
@@ -1,5 +1,6 @@
 import base64
 import threading
+import time
 import unittest.mock
 
 import requests
@@ -70,6 +71,26 @@ def test_per_host_throttle_blocks_at_limit():
     assert results == ['acquired'], 'second thread should acquire after first releases'
 
 
+def test_per_host_throttle_resume_at_blocks():
+    '''on_429 with retry_after > 0 prevents new __enter__ calls until the window elapses.'''
+    t = co._PerHostThrottle(host='test.example.com', initial_limit=4)
+    t.on_429(retry_after=0.15)
+
+    acquired_at = []
+
+    def acquire():
+        with t:
+            acquired_at.append(time.monotonic())
+
+    before = time.monotonic()
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    thread.join(timeout=2.0)
+
+    assert len(acquired_at) == 1
+    assert acquired_at[0] - before >= 0.10, 'thread should have been blocked for at least ~0.1s'
+
+
 def _mock_response(status_code, headers=None):
     r = unittest.mock.Mock(spec=requests.Response)
     r.status_code = status_code
@@ -95,7 +116,9 @@ def test_client_calls_throttle_on_429():
     def fake_request(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        return _mock_response(429) if call_count == 1 else _mock_response(200)
+        if call_count == 1:
+            return _mock_response(429, headers={'Retry-After': '0'})
+        return _mock_response(200)
 
     throttle = co._PerHostThrottle(host='registry.example.com', initial_limit=4)
     client._throttle_for = lambda host: throttle


### PR DESCRIPTION
## Summary

- When any thread receives a 429, `_PerHostThrottle` now sets a `_resume_at` monotonic timestamp equal to `now + retry_after`
- `__enter__` waits until both the slot is free **and** `_resume_at` has passed
- Previously only the AIMD concurrency limit was halved, but the released slot was immediately re-acquired by another thread — causing continued hammering at one-request-per-RTT even at `limit=1`
- `on_429` now calls `notify_all()` so waiting threads wake up with the correct timeout

## Test plan

- [ ] `test_per_host_throttle_aimd` — AIMD limit behaviour unchanged
- [ ] `test_per_host_throttle_blocks_at_limit` — semaphore behaviour unchanged
- [ ] `test_per_host_throttle_resume_at_blocks` — new: verifies `__enter__` is blocked for the `retry_after` duration
- [ ] `test_client_calls_throttle_on_429` — end-to-end: `on_429` called, retry succeeds