### PR TITLE
ci: pre-push hook lints worktree, not main checkout

### DIFF
--- a/.ci/git-hooks/pre-push
+++ b/.ci/git-hooks/pre-push
@@ -3,5 +3,6 @@
 set -e
 
 repo_dir=$(readlink -f $(dirname $0)/../..)
+work_dir=$(git rev-parse --show-toplevel)
 
-${repo_dir}/.ci/lint
+${repo_dir}/.ci/lint ${work_dir}


### PR DESCRIPTION
Pass `$(git rev-parse --show-toplevel)` as the `src_dir` argument to `.ci/lint` so the
hook lints the actual git worktree being pushed, rather than always resolving to the main
checkout root via the hook's own path.

Without this, pushing from a git worktree runs linters against the main checkout, which
may contain untracked local files unrelated to the branch being pushed.