### PR TITLE
ctt: configurable per-host concurrency limit (processing.cfg + CLI)

### DIFF
--- a/ctt/__main__.py
+++ b/ctt/__main__.py
@@ -63,6 +63,15 @@ def configure_parser(parser):
         help='initial sleep before first retry; doubles on each subsequent attempt',
     )
     parser.add_argument(
+        '--max-concurrency-per-host',
+        type=int,
+        default=8,
+        help=(
+            'initial maximum number of simultaneous in-flight requests to any single registry '
+            'host. Per-target overrides in processing.cfg (max_concurrency) take precedence.'
+        ),
+    )
+    parser.add_argument(
         '--pruning-mode',
         type=ctt.process_dependencies.PruningMode,
         choices=ctt.process_dependencies.PruningMode,
@@ -99,6 +108,7 @@ def replicate(parsed):
         ),
         max_retries=parsed.retries,
         default_backoff_base_seconds=parsed.retry_backoff_seconds,
+        max_concurrency_per_host=parsed.max_concurrency_per_host,
     )
 
     component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -18,6 +18,7 @@ import os
 import requests
 import threading
 import tempfile
+import urllib.parse
 
 import dacite
 import yaml
@@ -226,7 +227,7 @@ def parse_processing_cfg(path: str):
     return raw_cfg
 
 
-_TARGET_ONLY_KWARGS = {'local_blobs'}
+_TARGET_ONLY_KWARGS = {'local_blobs', 'max_concurrency'}
 
 
 def _target(target_cfg: dict):
@@ -709,6 +710,12 @@ def process_images(
         local_blobs_by_ocm_repository[ocm_repository] = LocalBlobsMode(
             target_cfg.get('local_blobs', LocalBlobsMode.COPY_BY_VALUE)
         )
+
+        if max_concurrency := target_cfg.get('max_concurrency'):
+            for reg in registries:
+                host = urllib.parse.urlparse(f'//{reg}').netloc
+                oci_client.set_host_initial_limit(host, int(max_concurrency))
+                logger.info(f'per-target max_concurrency for {host} set to {max_concurrency}')
 
     replication_plan = ctt.model.ReplicationPlan()
 

--- a/oci/client.py
+++ b/oci/client.py
@@ -431,7 +431,7 @@ class Client:
         tag_postprocessing_callback: collections.abc.Callable[[str], str]=None,
         max_retries: int=5,
         default_backoff_base_seconds: float=1.0,
-        max_concurrent_per_host: int=8,
+        max_concurrency_per_host: int=8,
     ):
         '''
         :param Callable credentials_lookup:
@@ -450,7 +450,7 @@ class Client:
             how many times to retry a failed request (connection errors, 429, 5xx)
         :param float default_backoff_base_seconds:
             initial sleep before first retry; doubles on each subsequent attempt
-        :param int max_concurrent_per_host:
+        :param int max_concurrency_per_host:
             initial maximum number of simultaneous in-flight requests to any single registry host.
             The limit is adaptive (AIMD): halved on each 429 response (minimum 1), incremented by
             one on each successful non-429/non-5xx response, up to this initial value.  Prevents
@@ -468,7 +468,8 @@ class Client:
         self.tag_postprocessing_callback = tag_postprocessing_callback
         self.max_retries = max_retries
         self.default_backoff_base_seconds = default_backoff_base_seconds
-        self._max_concurrent_per_host = max_concurrent_per_host
+        self._max_concurrency_per_host = max_concurrency_per_host
+        self._per_host_initial_limits: dict[str, int] = {}
         self._host_throttles: dict[str, '_PerHostThrottle'] = {}
         self._host_throttles_lock = threading.Lock()
 
@@ -485,9 +486,24 @@ class Client:
             if host not in self._host_throttles:
                 self._host_throttles[host] = _PerHostThrottle(
                     host=host,
-                    initial_limit=self._max_concurrent_per_host,
+                    initial_limit=self._per_host_initial_limits.get(
+                        host,
+                        self._max_concurrency_per_host,
+                    ),
                 )
             return self._host_throttles[host]
+
+    def set_host_initial_limit(self, host: str, limit: int):
+        '''Set the initial (max) per-host concurrency limit for `host`.
+
+        Must be called before the first request to `host`.  If the throttle was
+        already created (i.e. requests already in flight), the initial cap is
+        updated but the current active count is not disturbed.
+        '''
+        with self._host_throttles_lock:
+            self._per_host_initial_limits[host] = limit
+            if host in self._host_throttles:
+                self._host_throttles[host]._initial_limit = limit
 
     def _authenticate(
         self,

--- a/test/oci/client_test.py
+++ b/test/oci/client_test.py
@@ -103,7 +103,7 @@ def _mock_response(status_code, headers=None):
 
 def test_client_calls_throttle_on_429():
     '''on_429() halves the limit on 429; on_success() recovers it after the retry succeeds.'''
-    client = co.Client(max_concurrent_per_host=4)
+    client = co.Client(max_concurrency_per_host=4)
 
     # pre-populate auth cache so _authenticate() exits early without network I/O
     client.token_cache.set_auth_method(


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Replication pipelines targeting Keppel are hitting HTTP 429 (Too Many Requests) repeatedly, because Keppel is optimised for reads and rate-limits writes aggressively. The existing `_PerHostThrottle` AIMD gate halves concurrency after each 429, but the *initial* limit of 8 is already above Keppel's tolerance — so every run starts by triggering rate-limits before backing off.

This PR makes the initial per-host concurrency limit configurable at two levels:

**`processing.cfg` (per target)** — takes precedence, allows setting a lower limit for specific registries (e.g. Keppel) without throttling faster targets:
```yaml
targets:
  keppel-target:
    type: OciRegistryTarget
    kwargs:
      registry: keppel.eu1.example.com
      local_blobs: copy_by_reference
      max_concurrent: 2   # new
```

**CLI `--max-concurrent-per-host`** — global default for all hosts (default: 8, unchanged from before).

### Changes
- `oci/client.Client`: add `_per_host_initial_limits` dict; `_throttle_for` uses it as an override over `_max_concurrent_per_host`; new `set_host_initial_limit(host, limit)` method
- `ctt/__main__.py`: expose `--max-concurrent-per-host` arg, pass to `Client`
- `ctt/process_dependencies.py`: parse `max_concurrent` from each target's kwargs in `process_images`, call `oci_client.set_host_initial_limit` for the target's registry hosts; add `max_concurrent` to `_TARGET_ONLY_KWARGS`

**Release note**:
```feature operator
ctt: the initial per-host concurrency limit is now configurable via `max_concurrent` in each target's `processing.cfg` kwargs, and globally via `--max-concurrent-per-host` (default: 8). Useful for registries with strict write rate-limits (e.g. Keppel).
```