### PR TITLE
gardener-oci: drop python3.10 support

### DIFF
--- a/oci/auth.py
+++ b/oci/auth.py
@@ -14,11 +14,11 @@ import oci.util
 logger = logging.getLogger(__name__)
 
 
-class AuthType(str, enum.Enum):
+class AuthType(enum.StrEnum):
     BASIC_AUTH = 'basic_auth'
 
 
-class CredentialHelperPolicy(str, enum.Enum):
+class CredentialHelperPolicy(enum.StrEnum):
     DISABLED     = 'disabled'      # skip helpers entirely — static auths only
     STATIC_FIRST = 'static_first'  # static auths → helpers (safe default)
     WARN         = 'warn'          # helpers → static; missing/broken helper → log warning

--- a/oci/model.py
+++ b/oci/model.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import collections.abc
 import dataclasses
 import enum
 import functools
 import json
-import typing
 import urllib.parse
 
 import dacite
@@ -54,7 +55,7 @@ class OciRegistryType(enum.Enum):
 
     @staticmethod
     def from_image_ref(
-        image_reference: typing.Union[str, 'OciImageReference'],
+        image_reference: str | 'OciImageReference',
     ) -> 'OciRegistryType':
         netloc = OciImageReference.to_image_ref(image_reference=image_reference).netloc
 
@@ -83,7 +84,7 @@ class OciRegistryType(enum.Enum):
 class OciImageReference:
     @staticmethod
     def to_image_ref(
-        image_reference: typing.Union[str, 'OciImageReference'],
+        image_reference: str | 'OciImageReference',
         normalise: bool=True,
     ):
         if isinstance(image_reference, OciImageReference):
@@ -96,7 +97,7 @@ class OciImageReference:
 
     def __init__(
         self,
-        image_reference: typing.Union[str, 'OciImageReference'],
+        image_reference: str | 'OciImageReference',
         normalise: bool=True,
     ):
         if isinstance(image_reference, OciImageReference):

--- a/setup.oci.py
+++ b/setup.oci.py
@@ -30,7 +30,7 @@ setuptools.setup(
     description='Gardener OCI lib',
     long_description='Gardener OCI lib',
     long_description_content_type='text/markdown',
-    python_requires='>=3.10',
+    python_requires='>=3.11',
     py_modules=modules(),
     packages=['oci'],
     package_data={


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Bump the minimum Python requirement for the `gardener-oci` package from 3.10 to 3.11.

**Release note**:
```breaking dependency
gardener-oci now requires Python >= 3.11; Python 3.10 is no longer supported.
```