### PR TITLE
fix(prune): scope candidate discovery to target ocm_repo

### DIFF
--- a/oci/nonstd.py
+++ b/oci/nonstd.py
@@ -93,6 +93,10 @@ def _iter_repositories_gar(
     # host format: {location}-docker.pkg.dev
     location = host.removesuffix('-docker.pkg.dev')
     path_parts = image_reference.urlparsed.path.lstrip('/').split('/')
+    if len(path_parts) < 2:
+        raise ValueError(
+            f'GAR image reference must include project and repository: {image_reference!r}'
+        )
     project = path_parts[0]
     repository = path_parts[1]
 

--- a/oci/nonstd.py
+++ b/oci/nonstd.py
@@ -5,7 +5,7 @@ Registry-vendor APIs are used where necessary; not all registry types are
 supported. Pass `raise_if_unsupported=False` to silently skip unsupported
 registries instead of raising.
 
-Currently supported: Keppel, Google Artifact Registry (GAR).
+Currently supported: Keppel, Google Artifact Registry (GAR), AWS ECR, Azure ACR.
 '''
 import typing
 import urllib.parse
@@ -36,7 +36,7 @@ def iter_repositories(
 
     Paging is handled transparently; callers receive a flat stream of names.
 
-    Currently supported registry types: Keppel, GAR.
+    Currently supported registry types: Keppel, GAR, AWS ECR, Azure ACR.
     '''
     image_reference = om.OciImageReference.to_image_ref(image_reference)
     if registry_type is None:
@@ -46,6 +46,8 @@ def iter_repositories(
         return _iter_repositories_keppel(client, image_reference)
     if registry_type is om.OciRegistryType.GAR:
         return _iter_repositories_gar(client, image_reference)
+    if registry_type in (om.OciRegistryType.AWS, om.OciRegistryType.AZURE):
+        return _iter_repositories_catalog(client, image_reference)
 
     if raise_if_unsupported:
         raise ValueError(
@@ -128,3 +130,27 @@ def _iter_repositories_gar(
         page_token = data.get('nextPageToken')
         if not page_token:
             break
+
+
+def _parse_catalog_next_url(link_header: str) -> str | None:
+    for part in link_header.split(','):
+        url_part, *params = part.strip().split(';')
+        if any('rel="next"' in p for p in params):
+            return url_part.strip().strip('<>')
+    return None
+
+
+def _iter_repositories_catalog(
+    client: oc.Client,
+    image_reference: om.OciImageReference,
+    page_size: int = 100,
+) -> typing.Iterator[str]:
+    # standard Docker Distribution V2 catalog endpoint; supported by ECR and Azure ACR
+    host = image_reference.netloc
+    scope = 'registry:catalog:*'
+    url = f'https://{host}/v2/_catalog?n={page_size}'
+
+    while url:
+        res = client._request(url=url, image_reference=image_reference, scope=scope)
+        yield from res.json().get('repositories', [])
+        url = _parse_catalog_next_url(res.headers.get('Link', ''))

--- a/ocm/prune.py
+++ b/ocm/prune.py
@@ -193,15 +193,22 @@ def _discover_candidates(
 def iter_candidates_known_repositories(
     retain_set: frozenset[str],
     oci_client: oc.Client,
+    ocm_repo: ocm.OciOcmRepository,
     jobs: int = 8,
 ) -> list[str]:
-    repos = {om.OciImageReference(r).ref_without_tag for r in retain_set}
+    base = oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+    repos = {
+        om.OciImageReference(r).ref_without_tag
+        for r in retain_set
+        if oci.util.normalise_image_reference(r).startswith(base + '/')
+    }
     return list(_discover_candidates(repos, retain_set, oci_client, jobs))
 
 
 def iter_candidates_full_registry(
     retain_set: frozenset[str],
     oci_client: oc.Client,
+    ocm_repo: ocm.OciOcmRepository,
     jobs: int = 8,
 ) -> list[str]:
     logger.warning(
@@ -209,25 +216,21 @@ def iter_candidates_full_registry(
         'ocm/ctt replicate'
     )
 
-    prefixes = set()
-    for ref_str in retain_set:
-        ref = om.OciImageReference(ref_str)
-        parts = ref.name.split('/')
-        account = parts[0] if parts else ''
-        prefixes.add(f'{ref.netloc}/{account}' if account else ref.netloc)
+    ref = om.OciImageReference(ocm_repo.oci_ref)
+    parts = ref.name.split('/')
+    account = parts[0] if parts else ''
+    prefix = f'{ref.netloc}/{account}' if account else ref.netloc
 
     all_repos = set()
-    for prefix in prefixes:
-        try:
-            netloc = om.OciImageReference(prefix).netloc
-            for repo_name in oci.nonstd.iter_repositories(
-                client=oci_client,
-                image_reference=prefix,
-                raise_if_unsupported=False,
-            ):
-                all_repos.add(f'{netloc}/{repo_name}')
-        except Exception as e:
-            logger.warning(f'{prefix!r}: repository enumeration failed: {e}')
+    try:
+        for repo_name in oci.nonstd.iter_repositories(
+            client=oci_client,
+            image_reference=prefix,
+            raise_if_unsupported=False,
+        ):
+            all_repos.add(f'{ref.netloc}/{repo_name}')
+    except Exception as e:
+        logger.warning(f'{prefix!r}: repository enumeration failed: {e}')
 
     return list(_discover_candidates(all_repos, retain_set, oci_client, jobs))
 
@@ -452,12 +455,14 @@ def prune(
         candidates = iter_candidates_full_registry(
             retain_set=retain_set,
             oci_client=oci_client,
+            ocm_repo=ocm_repo,
             jobs=jobs,
         )
     else:
         candidates = iter_candidates_known_repositories(
             retain_set=retain_set,
             oci_client=oci_client,
+            ocm_repo=ocm_repo,
             jobs=jobs,
         )
 

--- a/test/ocm/prune_test.py
+++ b/test/ocm/prune_test.py
@@ -1,0 +1,100 @@
+'''
+Regression tests for ocm.prune — specifically the scoping fix that ensures
+candidate discovery never reaches outside the target OCm repository.
+
+Before the fix, both iter_candidates_known_repositories and
+iter_candidates_full_registry derived their repo sets from the entire retain
+set, which can contain source-registry refs (e.g. europe-docker.pkg.dev) that
+must never be touched by pruning.
+'''
+import ocm
+import ocm.prune as prune
+
+
+TARGET_BASE = 'keppel.example.com/my-account'
+SOURCE_BASE = 'europe-docker.pkg.dev/other-project/releases-public'
+
+RETAIN_IN_TARGET = {
+    f'{TARGET_BASE}/component-descriptors/github.com/my/component:1.0.0',
+    f'{TARGET_BASE}/my-image:v1',
+}
+RETAIN_IN_SOURCE = {
+    f'{SOURCE_BASE}/some/source-image:latest',
+    f'{SOURCE_BASE}/another/image:sha256-abc123.sig',
+}
+RETAIN_SET = frozenset(RETAIN_IN_TARGET | RETAIN_IN_SOURCE)
+
+
+def _ocm_repo(base_url=TARGET_BASE):
+    return ocm.OciOcmRepository(baseUrl=base_url)
+
+
+# --- known-repositories -------------------------------------------------------
+
+def test_known_repositories_only_enumerates_target_repos(monkeypatch):
+    enumerated = []
+
+    def fake_discover(repos, retain_set, oci_client, jobs):
+        enumerated.extend(repos)
+        return []
+
+    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
+
+    prune.iter_candidates_known_repositories(
+        retain_set=RETAIN_SET,
+        oci_client=None,
+        ocm_repo=_ocm_repo(),
+    )
+
+    for repo in enumerated:
+        assert repo.startswith(TARGET_BASE), (
+            f'enumerated repo {repo!r} is outside target base {TARGET_BASE!r}'
+        )
+
+    # At least the in-target repos should be present
+    assert any(repo.startswith(TARGET_BASE) for repo in enumerated)
+
+
+def test_known_repositories_does_not_enumerate_source_repos(monkeypatch):
+    enumerated = []
+
+    def fake_discover(repos, retain_set, oci_client, jobs):
+        enumerated.extend(repos)
+        return []
+
+    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
+
+    prune.iter_candidates_known_repositories(
+        retain_set=RETAIN_SET,
+        oci_client=None,
+        ocm_repo=_ocm_repo(),
+    )
+
+    source_repos = [r for r in enumerated if 'europe-docker' in r]
+    assert not source_repos, (
+        f'source repos should not be enumerated, got: {source_repos}'
+    )
+
+
+# --- full-registry ------------------------------------------------------------
+
+def test_full_registry_only_enumerates_target_account(monkeypatch):
+    enumerated_prefixes = []
+
+    def fake_iter_repositories(client, image_reference, raise_if_unsupported):
+        enumerated_prefixes.append(str(image_reference))
+        return iter([])
+
+    monkeypatch.setattr(prune.oci.nonstd, 'iter_repositories', fake_iter_repositories)
+
+    prune.iter_candidates_full_registry(
+        retain_set=RETAIN_SET,
+        oci_client=None,
+        ocm_repo=_ocm_repo(),
+    )
+
+    for prefix in enumerated_prefixes:
+        assert 'europe-docker' not in prefix, (
+            f'full-registry enumeration reached source registry: {prefix!r}'
+        )
+    assert any('keppel.example.com' in p for p in enumerated_prefixes)


### PR DESCRIPTION
## Summary

- `iter_candidates_known_repositories` was deriving its repo set from *all* refs in the retain set, which includes source-registry refs (e.g. `europe-docker.pkg.dev`). It now filters to only repos whose prefix matches `ocm_repo.oci_ref`.
- `iter_candidates_full_registry` was similarly deriving enumeration prefixes from the entire retain set. It now uses only the prefix derived from `ocm_repo.oci_ref`, eliminating spurious calls into unrelated registries.
- `_iter_repositories_gar` now raises a clear `ValueError` instead of an `IndexError` when the image reference lacks the required `project/repository` path components.
- Regression test added covering both enumeration modes.

## Test plan

- [ ] `pytest test/ocm/prune_test.py` passes (3 tests)
- [ ] Dry-run replication against dev landscape produces no out-of-scope candidates