### PR TITLE
fix(prune): full-registry repo refs must include account prefix

### DIFF
--- a/ocm/prune.py
+++ b/ocm/prune.py
@@ -228,7 +228,7 @@ def iter_candidates_full_registry(
             image_reference=prefix,
             raise_if_unsupported=False,
         ):
-            all_repos.add(f'{ref.netloc}/{repo_name}')
+            all_repos.add(f'{prefix}/{repo_name}')
     except Exception as e:
         logger.warning(f'{prefix!r}: repository enumeration failed: {e}')
 

--- a/test/ocm/prune_test.py
+++ b/test/ocm/prune_test.py
@@ -98,3 +98,31 @@ def test_full_registry_only_enumerates_target_account(monkeypatch):
             f'full-registry enumeration reached source registry: {prefix!r}'
         )
     assert any('keppel.example.com' in p for p in enumerated_prefixes)
+
+
+def test_full_registry_repo_refs_include_account(monkeypatch):
+    '''Keppel API returns repo names without the account prefix; the constructed
+    OCI refs must include it (e.g. keppel.../account/repo, not keppel.../repo).'''
+    collected_repos = []
+
+    def fake_iter_repositories(client, image_reference, raise_if_unsupported):
+        # simulate Keppel returning bare names without the account prefix
+        return iter(['component-descriptors/foo', 'some-image'])
+
+    def fake_discover(repos, retain_set, oci_client, jobs):
+        collected_repos.extend(repos)
+        return []
+
+    monkeypatch.setattr(prune.oci.nonstd, 'iter_repositories', fake_iter_repositories)
+    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
+
+    prune.iter_candidates_full_registry(
+        retain_set=RETAIN_SET,
+        oci_client=None,
+        ocm_repo=_ocm_repo(),
+    )
+
+    for repo in collected_repos:
+        assert repo.startswith(TARGET_BASE + '/'), (
+            f'repo {repo!r} is missing the account prefix {TARGET_BASE!r}'
+        )


### PR DESCRIPTION
## Problem

`iter_candidates_full_registry` constructed full OCI refs by prepending only
`{netloc}/` to the names returned by `iter_repositories`. For Keppel (and GAR),
the API returns repository names *without* the account prefix, so the resulting
refs were missing the account component:

```
keppel.../component-descriptors/foo   # wrong — resolves to component-descriptors account
keppel.../my-account/component-descriptors/foo   # correct
```

This caused tag-listing requests to hit the wrong account (401 Unauthorized)
and would have caused pruning to target the wrong repos.

## Fix

Use `prefix` (`netloc/account`) instead of just `ref.netloc` when constructing
repo refs from the `iter_repositories` output.

## Tests

Added `test_full_registry_repo_refs_include_account` regression test that
simulates a registry API returning bare repo names (without account prefix) and
asserts the constructed refs include the account prefix.