### PR TITLE
fix(oci): request delete scope in delete_manifest

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -1278,7 +1278,7 @@ class Client:
         tags referencing the same manifest.
         '''
         image_reference = om.OciImageReference(image_reference)
-        scope = _scope(image_reference=image_reference, action='push,pull')
+        scope = _scope(image_reference=image_reference, action='push,pull,delete')
 
         if not purge or image_reference.has_digest_tag:
             if accept:


### PR DESCRIPTION
`delete_manifest` was requesting `push,pull` scope during token exchange. Keppel
requires an explicit `delete` scope even for accounts with admin permissions.

Changed the `action` parameter to `push,pull,delete`.