### PR TITLE
feat(prune): EnumerationMode IntFlag for enumeration and scoping control

### DIFF
--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -1415,12 +1415,17 @@ def main():
             type=ocm.OciAccess,
             baseUrl=parsed.ocm_repo,
         )
+        mode = ocm.prune.EnumerationMode(0)
+        if not parsed.full_registry:
+            mode |= ocm.prune.EnumerationMode.KNOWN_REPOSITORIES
+        if parsed.restrict_to_ocm_repo:
+            mode |= ocm.prune.EnumerationMode.RESTRICT_TO_OCM_REPO
         ocm.prune.prune(
             component_refs=parsed.ocm_component,
             ocm_repo=ocm_repo,
             oci_client=oci_client,
             keep_versions=parsed.keep_versions,
-            enumeration_mode=parsed.enumeration_mode,
+            enumeration_mode=mode,
             dry_run=parsed.dry_run,
             jobs=parsed.jobs,
             retained_outfile=parsed.retained_outfile,
@@ -1455,14 +1460,21 @@ def main():
         ),
     )
     prune_parser.add_argument(
-        '--enumeration-mode',
-        choices=('known-repositories', 'full-registry'),
-        default='known-repositories',
+        '--full-registry',
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help=(
-            'known-repositories (default): inspect only repositories already '
-            'referenced by the retain set; '
-            'full-registry: enumerate all repositories via vendor API (Keppel) '
-            '— may purge artefacts not managed by ocm/ctt replicate'
+            'enumerate all repositories via vendor API (Keppel/GAR); '
+            'default: inspect only repositories referenced by the retain set'
+        ),
+    )
+    prune_parser.add_argument(
+        '--restrict-to-ocm-repo',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            'skip OCI resource refs outside the target OCM repository prefix; '
+            'default: true'
         ),
     )
     prune_parser.add_argument(

--- a/ocm/prune.py
+++ b/ocm/prune.py
@@ -19,6 +19,7 @@ Two enumeration modes are supported:
 '''
 import collections.abc
 import concurrent.futures
+import enum
 import logging
 import threading
 
@@ -32,6 +33,14 @@ import ocm.retrieve
 import version as version_mod
 
 logger = logging.getLogger(__name__)
+
+
+class EnumerationMode(enum.IntFlag):
+    KNOWN_REPOSITORIES = 1  # unset → full-registry enumeration via vendor API
+    RESTRICT_TO_OCM_REPO = 2  # unset → allow external OCI refs outside OCM repo prefix
+
+
+_DEFAULT_MODE = EnumerationMode.KNOWN_REPOSITORIES | EnumerationMode.RESTRICT_TO_OCM_REPO
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +270,7 @@ def _delete_component_subtree(
     deleted: set,
     lock: threading.Lock,
     executor: concurrent.futures.ThreadPoolExecutor,
+    mode: EnumerationMode = _DEFAULT_MODE,
 ) -> threading.Event | None:
     '''
     Recursively delete a component subtree, resources-first, bottom-up.
@@ -319,6 +329,7 @@ def _delete_component_subtree(
                     deleted=deleted,
                     lock=lock,
                     executor=executor,
+                    mode=mode,
                 )
                 if ev is not None:
                     child_events.append(ev)
@@ -336,6 +347,10 @@ def _delete_component_subtree(
                 if not isinstance(node, ocm_iter.ResourceNode):
                     continue
                 for ref in _iter_resource_refs(node, ocm_repo):
+                    if mode & EnumerationMode.RESTRICT_TO_OCM_REPO:
+                        base = oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+                        if not oci.util.normalise_image_reference(ref).startswith(base + '/'):
+                            continue
                     norm_ref = oci.util.normalise_image_reference(ref)
                     if norm_ref in retain_set:
                         continue
@@ -361,6 +376,7 @@ def delete_candidates(
     oci_client: oc.Client,
     retain_set: frozenset[str],
     jobs: int = 8,
+    mode: EnumerationMode = _DEFAULT_MODE,
 ):
     '''
     Delete all candidates.
@@ -396,6 +412,7 @@ def delete_candidates(
                 deleted=deleted,
                 lock=lock,
                 executor=executor,
+                mode=mode,
             )
             if ev is not None:
                 completion_events.append(ev)
@@ -427,7 +444,7 @@ def prune(
     ocm_repo: ocm.OciOcmRepository,
     oci_client: oc.Client,
     keep_versions: int = 1,
-    enumeration_mode: str = 'known-repositories',
+    enumeration_mode: EnumerationMode = _DEFAULT_MODE,
     dry_run: bool = False,
     jobs: int = 8,
     retained_outfile: str | None = None,
@@ -451,7 +468,7 @@ def prune(
                 fh.write(ref + '\n')
         print(f'Retain set written to {retained_outfile!r}')
 
-    if enumeration_mode == 'full-registry':
+    if not (enumeration_mode & EnumerationMode.KNOWN_REPOSITORIES):
         candidates = iter_candidates_full_registry(
             retain_set=retain_set,
             oci_client=oci_client,
@@ -487,6 +504,7 @@ def prune(
         oci_client=oci_client,
         retain_set=retain_set,
         jobs=jobs,
+        mode=enumeration_mode,
     )
 
     print(f'Pruned {len(candidates)} artefact(s)')

--- a/test/ocm/prune_test.py
+++ b/test/ocm/prune_test.py
@@ -7,6 +7,8 @@ iter_candidates_full_registry derived their repo sets from the entire retain
 set, which can contain source-registry refs (e.g. europe-docker.pkg.dev) that
 must never be touched by pruning.
 '''
+import types
+
 import ocm
 import ocm.prune as prune
 
@@ -126,3 +128,65 @@ def test_full_registry_repo_refs_include_account(monkeypatch):
         assert repo.startswith(TARGET_BASE + '/'), (
             f'repo {repo!r} is missing the account prefix {TARGET_BASE!r}'
         )
+
+
+# --- RESTRICT_TO_OCM_REPO flag ------------------------------------------------
+
+def _make_resource_node(image_ref):
+    access = ocm.OciAccess(imageReference=image_ref)
+    resource = types.SimpleNamespace(access=access)
+    return types.SimpleNamespace(resource=resource)
+
+
+def test_delete_skips_out_of_scope_oci_access(monkeypatch):
+    '''With RESTRICT_TO_OCM_REPO set, resources pointing to external registries
+    must not be submitted for deletion.'''
+    deleted = []
+    monkeypatch.setattr(prune, '_delete_one', lambda ref, client: deleted.append(ref))
+
+    node = _make_resource_node(f'{SOURCE_BASE}/some-image:v1')
+    ocm_repo = _ocm_repo()
+
+    # simulate _coordinate logic for a single resource node
+    mode = prune.EnumerationMode.RESTRICT_TO_OCM_REPO
+    for ref in prune._iter_resource_refs(node, ocm_repo):
+        base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
+            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
+                continue
+        deleted.append(ref)
+
+    assert deleted == [], f'expected no deletions, got {deleted}'
+
+
+def test_delete_includes_in_scope_oci_access(monkeypatch):
+    in_scope = f'{TARGET_BASE}/some-image:v1'
+    node = _make_resource_node(in_scope)
+    ocm_repo = _ocm_repo()
+
+    collected = []
+    mode = prune.EnumerationMode.RESTRICT_TO_OCM_REPO
+    for ref in prune._iter_resource_refs(node, ocm_repo):
+        base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
+            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
+                continue
+        collected.append(ref)
+
+    assert collected == [in_scope]
+
+
+def test_delete_without_restriction_includes_external_refs():
+    node = _make_resource_node(f'{SOURCE_BASE}/some-image:v1')
+    ocm_repo = _ocm_repo()
+
+    collected = []
+    mode = prune.EnumerationMode(0)  # no RESTRICT_TO_OCM_REPO
+    for ref in prune._iter_resource_refs(node, ocm_repo):
+        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
+            base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
+                continue
+        collected.append(ref)
+
+    assert len(collected) == 1


### PR DESCRIPTION
Replaces the `enumeration_mode: str` parameter on `prune()` with an
`EnumerationMode(IntFlag)` carrying two orthogonal bits:

- `KNOWN_REPOSITORIES` (1) — unset → full-registry enumeration via vendor API
- `RESTRICT_TO_OCM_REPO` (2) — unset → allow external OCI refs outside OCM repo prefix

Default is `KNOWN_REPOSITORIES | RESTRICT_TO_OCM_REPO` (conservative, same as before).

The scoping fix (previously applied unconditionally inside `_iter_resource_refs`)
is now a flag-controlled filter at the deletion call site in `_coordinate()`,
keeping `_iter_resource_refs` a pure helper that faithfully reflects the OCM spec.

CLI changes: `--enumeration-mode` replaced by `--[no-]full-registry` and
`--[no-]restrict-to-ocm-repo`.