### PR TITLE
refactor(prune): PruneCtx dataclass; single-component prune(), separate phases

### DIFF
--- a/ocm/__main__.py
+++ b/ocm/__main__.py
@@ -1420,17 +1420,43 @@ def main():
             mode |= ocm.prune.EnumerationMode.KNOWN_REPOSITORIES
         if parsed.restrict_to_ocm_repo:
             mode |= ocm.prune.EnumerationMode.RESTRICT_TO_OCM_REPO
-        ocm.prune.prune(
-            component_refs=parsed.ocm_component,
-            ocm_repo=ocm_repo,
-            oci_client=oci_client,
-            keep_versions=parsed.keep_versions,
-            enumeration_mode=mode,
-            dry_run=parsed.dry_run,
-            jobs=parsed.jobs,
-            retained_outfile=parsed.retained_outfile,
-            candidates_outfile=parsed.candidates_outfile,
-        )
+
+        ctx = ocm.prune.PruneCtx(ocm_repo=ocm_repo, oci_client=oci_client, mode=mode)
+
+        print(f'Building retain set from {len(parsed.ocm_component)} root component(s)...')
+        for component_ref in parsed.ocm_component:
+            name, anchor = ocm.prune.parse_component_ref(component_ref)
+            for ver in ocm.prune.resolve_versions(
+                name, anchor, ocm_repo, oci_client, parsed.keep_versions,
+            ):
+                ocm.prune.prune(ocm.ComponentIdentity(name=name, version=ver), ctx)
+        print(f'Retain set: {len(ctx.retain_set)} OCI reference(s)')
+
+        if parsed.retained_outfile:
+            with open(parsed.retained_outfile, 'w') as fh:
+                for ref in sorted(ctx.retain_set):
+                    fh.write(ref + '\n')
+            print(f'Retain set written to {parsed.retained_outfile!r}')
+
+        print('Enumerating candidates...')
+        ocm.prune.enumerate_candidates(ctx, jobs=parsed.jobs)
+        to_delete = ctx.candidates - ctx.retain_set
+        print(f'Found {len(to_delete)} candidate(s) to prune')
+
+        if parsed.candidates_outfile:
+            with open(parsed.candidates_outfile, 'w') as fh:
+                for ref in sorted(to_delete):
+                    fh.write(ref + '\n')
+            print(f'Candidate list written to {parsed.candidates_outfile!r}')
+
+        if parsed.dry_run:
+            print('Dry run — nothing removed')
+            for ref in sorted(to_delete):
+                print(f'  would remove: {ref}')
+            return
+
+        ocm.prune.delete_all(to_delete, oci_client, jobs=parsed.jobs)
+        print(f'Pruned {len(to_delete)} artefact(s)')
 
     prune_parser.set_defaults(callable=_prune)
     prune_parser.add_argument(

--- a/ocm/prune.py
+++ b/ocm/prune.py
@@ -1,24 +1,6 @@
-'''
-Prune stale OCI artefacts from target registries.
-
-For a given set of root OCM component versions, all OCI artefacts reachable
-from those roots are collected into a retain set; every other tagged artefact
-in the same repositories (or, optionally, the entire registry) is a candidate
-for removal.
-
-Two enumeration modes are supported:
-
-  known-repositories (default)
-    Only repositories already referenced by the retain-set are inspected for
-    extra tags.  Completely abandoned repositories are invisible to this mode.
-
-  full-registry
-    Uses non-standard vendor APIs (currently: Keppel) to enumerate *all*
-    repositories in each registry.  Catches abandoned repos, but may purge
-    artefacts not placed there by ocm/ctt replicate.  Opt-in only.
-'''
 import collections.abc
 import concurrent.futures
+import dataclasses
 import enum
 import logging
 import threading
@@ -37,35 +19,49 @@ logger = logging.getLogger(__name__)
 
 class EnumerationMode(enum.IntFlag):
     KNOWN_REPOSITORIES = 1  # unset → full-registry enumeration via vendor API
-    RESTRICT_TO_OCM_REPO = 2  # unset → allow external OCI refs outside OCM repo prefix
+    RESTRICT_TO_OCM_REPO = 2  # unset → include external OCI refs in retain set
 
 
 _DEFAULT_MODE = EnumerationMode.KNOWN_REPOSITORIES | EnumerationMode.RESTRICT_TO_OCM_REPO
+
+
+def _make_lookup(ocm_repo, oci_client):
+    return ocm.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(ocm_repo.oci_ref),
+        oci_client=oci_client,
+    )
+
+
+@dataclasses.dataclass
+class PruneCtx:
+    ocm_repo: ocm.OciOcmRepository
+    oci_client: oc.Client
+    mode: EnumerationMode = _DEFAULT_MODE
+    retain_set: set = dataclasses.field(default_factory=set)
+    candidates: set = dataclasses.field(default_factory=set)
+    lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
 
 
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
 
-def _parse_component_ref(component_ref: str) -> tuple[str, str | None]:
+def parse_component_ref(component_ref: str) -> tuple[str, str | None]:
     if ':' in component_ref:
         name, ver = component_ref.rsplit(':', 1)
         return name, ver
     return component_ref, None
 
 
-def _resolve_versions(
+def resolve_versions(
     component_name: str,
     anchor_version: str | None,
     ocm_repo: ocm.OciOcmRepository,
     oci_client: oc.Client,
     keep_versions: int,
 ) -> list[str]:
-    '''
-    Return up to `keep_versions` version strings <= `anchor_version`, sorted
-    ascending by relaxed semver.  If `anchor_version` is None, the greatest
-    available version is used as anchor.
-    '''
+    '''Return up to keep_versions version strings <= anchor_version, ascending semver.
+    If anchor_version is None, the greatest available version is used.'''
     all_versions = oci_client.tags(image_reference=ocm_repo.component_oci_ref(component_name))
 
     if not all_versions:
@@ -103,76 +99,66 @@ def _iter_resource_refs(
         yield f'{base}/{access.reference.lstrip("/")}'
 
 
-def _make_lookup(
-    ocm_repo: ocm.OciOcmRepository,
-    oci_client: oc.Client,
-):
-    return ocm.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(ocm_repo.oci_ref),
-        oci_client=oci_client,
+def _in_scope_of_ocm_repo(ref: str, ocm_repo: ocm.OciOcmRepository) -> bool:
+    base = oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
+    return oci.util.normalise_image_reference(ref).startswith(base + '/')
+
+
+def _account_prefix(ocm_repo: ocm.OciOcmRepository) -> str:
+    ref = om.OciImageReference(ocm_repo.oci_ref)
+    parts = ref.name.split('/')
+    account = parts[0] if parts else ''
+    return f'{ref.netloc}/{account}' if account else ref.netloc
+
+
+# ---------------------------------------------------------------------------
+# phase I-A: retain set
+# ---------------------------------------------------------------------------
+
+def prune(component: ocm.ComponentIdentity, ctx: PruneCtx, lookup=None):
+    '''Recursively add all OCI refs reachable from component to ctx.retain_set.'''
+    if lookup is None:
+        lookup = _make_lookup(ctx.ocm_repo, ctx.oci_client)
+
+    desc_ref = oci.util.normalise_image_reference(
+        ctx.ocm_repo.component_version_oci_ref(component.name, component.version)
     )
 
-
-# ---------------------------------------------------------------------------
-# retain-set construction
-# ---------------------------------------------------------------------------
-
-def build_retain_set(
-    component_refs: list[str],
-    ocm_repo: ocm.OciOcmRepository,
-    oci_client: oc.Client,
-    keep_versions: int = 1,
-    lookup=None,
-) -> frozenset[str]:
-    '''
-    Build the complete set of OCI references to retain, normalised.
-
-    Each entry in `component_refs` is ``NAME`` (greatest version) or
-    ``NAME:VERSION``.  When `keep_versions` > 1, additional older versions
-    are also retained (anchor + N-1 next-older).
-    '''
-    if lookup is None:
-        lookup = _make_lookup(ocm_repo, oci_client)
-
-    retain = set()
-    visited = set()  # (name, version) — skips already-traversed subtrees
-
-    def _visit(name: str, ver: str):
-        key = (name, ver)
-        if key in visited:
+    with ctx.lock:
+        if desc_ref in ctx.retain_set:
             return
-        visited.add(key)
+        ctx.retain_set.add(desc_ref)
 
-        cd = lookup(ocm.ComponentIdentity(name=name, version=ver), absent_ok=True)
-        if cd is None:
-            logger.warning(f'could not resolve {name}:{ver}')
-            return
+    cd = lookup(component, absent_ok=True)
+    if cd is None:
+        logger.warning(f'could not resolve {component.name}:{component.version}')
+        return
 
-        retain.add(ocm_repo.component_version_oci_ref(name, ver))
-
-        # ocm.iter handles both standard componentReferences and
-        # ExtraComponentReferencesLabel transparently; recursion_depth=1 gives
-        # only direct children, keeping the per-level visited guard effective.
-        for node in ocm_iter.iter(
-            component=cd.component,
-            lookup=lookup,
-            recursion_depth=1,
-        ):
-            if isinstance(node, ocm_iter.ResourceNode) and len(node.path) == 1:
-                retain.update(_iter_resource_refs(node, ocm_repo))
-            elif isinstance(node, ocm_iter.ComponentNode) and len(node.path) == 2:
-                _visit(node.component.name, node.component.version)
-
-    for component_ref in component_refs:
-        name, anchor = _parse_component_ref(component_ref)
-        for ver in _resolve_versions(name, anchor, ocm_repo, oci_client, keep_versions):
-            _visit(name, ver)
-
-    return frozenset(oci.util.normalise_image_reference(r) for r in retain)
+    for node in ocm_iter.iter(
+        component=cd.component,
+        lookup=lookup,
+        recursion_depth=1,
+    ):
+        if isinstance(node, ocm_iter.ResourceNode) and len(node.path) == 1:
+            for ref in _iter_resource_refs(node, ctx.ocm_repo):
+                if ctx.mode & EnumerationMode.RESTRICT_TO_OCM_REPO:
+                    if not _in_scope_of_ocm_repo(ref, ctx.ocm_repo):
+                        continue
+                with ctx.lock:
+                    ctx.retain_set.add(oci.util.normalise_image_reference(ref))
+        elif isinstance(node, ocm_iter.ComponentNode) and len(node.path) == 2:
+            prune(
+                ocm.ComponentIdentity(
+                    name=node.component.name,
+                    version=node.component.version,
+                ),
+                ctx,
+                lookup,
+            )
 
 
 # ---------------------------------------------------------------------------
-# candidate discovery
+# phase I-B: candidate enumeration
 # ---------------------------------------------------------------------------
 
 def _list_tags(repo: str, oci_client: oc.Client) -> list[str]:
@@ -183,328 +169,70 @@ def _list_tags(repo: str, oci_client: oc.Client) -> list[str]:
         return []
 
 
-def _discover_candidates(
-    repos: collections.abc.Iterable[str],
-    retain_set: frozenset[str],
-    oci_client: oc.Client,
-    jobs: int,
-) -> collections.abc.Iterator[str]:
-    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
-        futures = {pool.submit(_list_tags, repo, oci_client): repo for repo in repos}
-        for future in concurrent.futures.as_completed(futures):
-            repo = futures[future]
-            for tag in future.result():
-                ref = f'{repo}:{tag}'
-                if oci.util.normalise_image_reference(ref) not in retain_set:
-                    yield ref
-
-
-def iter_candidates_known_repositories(
-    retain_set: frozenset[str],
-    oci_client: oc.Client,
-    ocm_repo: ocm.OciOcmRepository,
-    jobs: int = 8,
-) -> list[str]:
-    base = oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
-    repos = {
+def _repos_known(ctx: PruneCtx) -> set:
+    base = oci.util.normalise_image_reference(ctx.ocm_repo.oci_ref).rstrip('/')
+    return {
         om.OciImageReference(r).ref_without_tag
-        for r in retain_set
+        for r in ctx.retain_set
         if oci.util.normalise_image_reference(r).startswith(base + '/')
     }
-    return list(_discover_candidates(repos, retain_set, oci_client, jobs))
 
 
-def iter_candidates_full_registry(
-    retain_set: frozenset[str],
-    oci_client: oc.Client,
-    ocm_repo: ocm.OciOcmRepository,
-    jobs: int = 8,
-) -> list[str]:
+def _repos_full_registry(ctx: PruneCtx) -> set:
     logger.warning(
         'full-registry enumeration is active — may discover artefacts not managed by '
         'ocm/ctt replicate'
     )
-
-    ref = om.OciImageReference(ocm_repo.oci_ref)
-    parts = ref.name.split('/')
-    account = parts[0] if parts else ''
-    prefix = f'{ref.netloc}/{account}' if account else ref.netloc
-
-    all_repos = set()
+    prefix = _account_prefix(ctx.ocm_repo)
+    repos = set()
     try:
         for repo_name in oci.nonstd.iter_repositories(
-            client=oci_client,
+            client=ctx.oci_client,
             image_reference=prefix,
             raise_if_unsupported=False,
         ):
-            all_repos.add(f'{prefix}/{repo_name}')
+            repos.add(f'{prefix}/{repo_name}')
     except Exception as e:
         logger.warning(f'{prefix!r}: repository enumeration failed: {e}')
+    return repos
 
-    return list(_discover_candidates(all_repos, retain_set, oci_client, jobs))
+
+def enumerate_candidates(ctx: PruneCtx, jobs: int = 8):
+    '''Populate ctx.candidates with tagged refs from target repos not in retain_set.'''
+    repos = (
+        _repos_known(ctx)
+        if ctx.mode & EnumerationMode.KNOWN_REPOSITORIES
+        else _repos_full_registry(ctx)
+    )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = {pool.submit(_list_tags, repo, ctx.oci_client): repo for repo in repos}
+        for future in concurrent.futures.as_completed(futures):
+            for tag in future.result():
+                repo = futures[future]
+                ref = oci.util.normalise_image_reference(f'{repo}:{tag}')
+                if ref not in ctx.retain_set:
+                    with ctx.lock:
+                        ctx.candidates.add(ref)
 
 
 # ---------------------------------------------------------------------------
-# deletion — concurrent bottom-up tree traversal
+# phase II: deletion
 # ---------------------------------------------------------------------------
 
 def _delete_one(ref: str, oci_client: oc.Client):
     try:
-        oci_client.delete_manifest(
-            image_reference=ref,
-            purge=True,
-            absent_ok=True,
-        )
+        oci_client.delete_manifest(image_reference=ref, purge=True, absent_ok=True)
         logger.info(f'removed {ref}')
     except Exception as e:
         logger.warning(f'failed to remove {ref!r}: {e}')
 
 
-def _delete_component_subtree(
-    component_name: str,
-    component_version: str,
-    ocm_repo: ocm.OciOcmRepository,
-    lookup,
+def delete_all(
+    refs: collections.abc.Iterable[str],
     oci_client: oc.Client,
-    retain_set: frozenset[str],
-    deleted: set,
-    lock: threading.Lock,
-    executor: concurrent.futures.ThreadPoolExecutor,
-    mode: EnumerationMode = _DEFAULT_MODE,
-) -> threading.Event | None:
-    '''
-    Recursively delete a component subtree, resources-first, bottom-up.
-
-    Spawns a coordination thread that:
-      1. Recurses concurrently into direct sub-components (via ocm.iter,
-         which handles ExtraComponentReferencesLabel transparently).
-      2. Waits for all sub-components to finish.
-      3. Submits own OCI resource deletions to `executor` and waits.
-      4. Deletes own component-descriptor OCI artefact.
-      5. Sets the returned Event.
-
-    Returns None if this component is already being processed (dedup guard).
-    '''
-    desc_ref = oci.util.normalise_image_reference(
-        ocm_repo.component_version_oci_ref(component_name, component_version),
-    )
-    done = threading.Event()
-
-    with lock:
-        if desc_ref in deleted:
-            return None
-        deleted.add(desc_ref)
-
-    cd = lookup(
-        ocm.ComponentIdentity(name=component_name, version=component_version),
-        absent_ok=True,
-    )
-
-    def _coordinate():
-        child_events = []
-
-        if cd is not None:
-            for node in ocm_iter.iter(
-                component=cd.component,
-                lookup=lookup,
-                recursion_depth=1,
-            ):
-                if not (isinstance(node, ocm_iter.ComponentNode) and len(node.path) == 2):
-                    continue
-                child_desc_ref = oci.util.normalise_image_reference(
-                    ocm_repo.component_version_oci_ref(
-                        node.component.name,
-                        node.component.version,
-                    )
-                )
-                if child_desc_ref in retain_set:
-                    continue
-                ev = _delete_component_subtree(
-                    component_name=node.component.name,
-                    component_version=node.component.version,
-                    ocm_repo=ocm_repo,
-                    lookup=lookup,
-                    oci_client=oci_client,
-                    retain_set=retain_set,
-                    deleted=deleted,
-                    lock=lock,
-                    executor=executor,
-                    mode=mode,
-                )
-                if ev is not None:
-                    child_events.append(ev)
-
-        for ev in child_events:
-            ev.wait()
-
-        resource_futs = []
-        if cd is not None:
-            for node in ocm_iter.iter(
-                component=cd.component,
-                lookup=lookup,
-                recursion_depth=0,
-            ):
-                if not isinstance(node, ocm_iter.ResourceNode):
-                    continue
-                for ref in _iter_resource_refs(node, ocm_repo):
-                    if mode & EnumerationMode.RESTRICT_TO_OCM_REPO:
-                        base = oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
-                        if not oci.util.normalise_image_reference(ref).startswith(base + '/'):
-                            continue
-                    norm_ref = oci.util.normalise_image_reference(ref)
-                    if norm_ref in retain_set:
-                        continue
-                    with lock:
-                        if norm_ref in deleted:
-                            continue
-                        deleted.add(norm_ref)
-                    resource_futs.append(executor.submit(_delete_one, ref, oci_client))
-
-        concurrent.futures.wait(resource_futs)
-        desc_oci_ref = ocm_repo.component_version_oci_ref(component_name, component_version)
-        _delete_one(desc_oci_ref, oci_client)
-        done.set()
-
-    threading.Thread(target=_coordinate, daemon=True).start()
-    return done
-
-
-def delete_candidates(
-    candidates: list[str],
-    ocm_repo: ocm.OciOcmRepository,
-    lookup,
-    oci_client: oc.Client,
-    retain_set: frozenset[str],
     jobs: int = 8,
-    mode: EnumerationMode = _DEFAULT_MODE,
 ):
-    '''
-    Delete all candidates.
-
-    Component-descriptor refs drive concurrent bottom-up tree traversal:
-    sub-components are fully purged before their parent's descriptor is removed.
-    Remaining resource refs not reached by tree traversal are deleted directly.
-    '''
-    deleted = set()
-    lock = threading.Lock()
-    completion_events = []
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
-        for ref in candidates:
-            norm_ref = oci.util.normalise_image_reference(ref)
-            if 'component-descriptors/' not in norm_ref:
-                continue
-            prefix = f'{ocm_repo.oci_ref.rstrip("/")}/component-descriptors/'
-            if not norm_ref.startswith(prefix):
-                continue
-            rest = norm_ref[len(prefix):]
-            if ':' not in rest:
-                continue
-            name, version = rest.rsplit(':', 1)
-
-            ev = _delete_component_subtree(
-                component_name=name,
-                component_version=version,
-                ocm_repo=ocm_repo,
-                lookup=lookup,
-                oci_client=oci_client,
-                retain_set=retain_set,
-                deleted=deleted,
-                lock=lock,
-                executor=executor,
-                mode=mode,
-            )
-            if ev is not None:
-                completion_events.append(ev)
-
-        for ev in completion_events:
-            ev.wait()
-
-        # delete any remaining resource refs not reached via component tree traversal
-        orphan_futs = []
-        for ref in candidates:
-            norm_ref = oci.util.normalise_image_reference(ref)
-            if norm_ref in retain_set:
-                continue
-            with lock:
-                if norm_ref in deleted:
-                    continue
-                deleted.add(norm_ref)
-            orphan_futs.append(executor.submit(_delete_one, ref, oci_client))
-
-        concurrent.futures.wait(orphan_futs)
-
-
-# ---------------------------------------------------------------------------
-# entry point
-# ---------------------------------------------------------------------------
-
-def prune(
-    component_refs: list[str],
-    ocm_repo: ocm.OciOcmRepository,
-    oci_client: oc.Client,
-    keep_versions: int = 1,
-    enumeration_mode: EnumerationMode = _DEFAULT_MODE,
-    dry_run: bool = False,
-    jobs: int = 8,
-    retained_outfile: str | None = None,
-    candidates_outfile: str | None = None,
-):
-    lookup = _make_lookup(ocm_repo, oci_client)
-
-    print(f'Building retain set from {len(component_refs)} root component(s)...')
-    retain_set = build_retain_set(
-        component_refs=component_refs,
-        ocm_repo=ocm_repo,
-        oci_client=oci_client,
-        keep_versions=keep_versions,
-        lookup=lookup,
-    )
-    print(f'Retain set: {len(retain_set)} OCI reference(s)')
-
-    if retained_outfile:
-        with open(retained_outfile, 'w') as fh:
-            for ref in sorted(retain_set):
-                fh.write(ref + '\n')
-        print(f'Retain set written to {retained_outfile!r}')
-
-    if not (enumeration_mode & EnumerationMode.KNOWN_REPOSITORIES):
-        candidates = iter_candidates_full_registry(
-            retain_set=retain_set,
-            oci_client=oci_client,
-            ocm_repo=ocm_repo,
-            jobs=jobs,
-        )
-    else:
-        candidates = iter_candidates_known_repositories(
-            retain_set=retain_set,
-            oci_client=oci_client,
-            ocm_repo=ocm_repo,
-            jobs=jobs,
-        )
-
-    print(f'Found {len(candidates)} candidate(s) to prune')
-
-    if candidates_outfile:
-        with open(candidates_outfile, 'w') as fh:
-            for ref in sorted(candidates):
-                fh.write(ref + '\n')
-        print(f'Candidate list written to {candidates_outfile!r}')
-
-    if dry_run:
-        print('Dry run — nothing removed')
-        for ref in sorted(candidates):
-            print(f'  would remove: {ref}')
-        return
-
-    delete_candidates(
-        candidates=candidates,
-        ocm_repo=ocm_repo,
-        lookup=lookup,
-        oci_client=oci_client,
-        retain_set=retain_set,
-        jobs=jobs,
-        mode=enumeration_mode,
-    )
-
-    print(f'Pruned {len(candidates)} artefact(s)')
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        futs = [pool.submit(_delete_one, ref, oci_client) for ref in refs]
+        concurrent.futures.wait(futs)

--- a/test/ocm/prune_test.py
+++ b/test/ocm/prune_test.py
@@ -1,12 +1,3 @@
-'''
-Regression tests for ocm.prune — specifically the scoping fix that ensures
-candidate discovery never reaches outside the target OCm repository.
-
-Before the fix, both iter_candidates_known_repositories and
-iter_candidates_full_registry derived their repo sets from the entire retain
-set, which can contain source-registry refs (e.g. europe-docker.pkg.dev) that
-must never be touched by pruning.
-'''
 import types
 
 import ocm
@@ -16,177 +7,92 @@ import ocm.prune as prune
 TARGET_BASE = 'keppel.example.com/my-account'
 SOURCE_BASE = 'europe-docker.pkg.dev/other-project/releases-public'
 
-RETAIN_IN_TARGET = {
-    f'{TARGET_BASE}/component-descriptors/github.com/my/component:1.0.0',
-    f'{TARGET_BASE}/my-image:v1',
-}
-RETAIN_IN_SOURCE = {
-    f'{SOURCE_BASE}/some/source-image:latest',
-    f'{SOURCE_BASE}/another/image:sha256-abc123.sig',
-}
-RETAIN_SET = frozenset(RETAIN_IN_TARGET | RETAIN_IN_SOURCE)
+OCM_REPO = ocm.OciOcmRepository(baseUrl=TARGET_BASE)
 
 
-def _ocm_repo(base_url=TARGET_BASE):
-    return ocm.OciOcmRepository(baseUrl=base_url)
+def _ctx_with_retain(*refs):
+    ctx = prune.PruneCtx(ocm_repo=OCM_REPO, oci_client=None)
+    ctx.retain_set = set(refs)
+    return ctx
 
 
-# --- known-repositories -------------------------------------------------------
+# ---------------------------------------------------------------------------
+# known-repositories candidate repos
+# ---------------------------------------------------------------------------
 
-def test_known_repositories_only_enumerates_target_repos(monkeypatch):
-    enumerated = []
-
-    def fake_discover(repos, retain_set, oci_client, jobs):
-        enumerated.extend(repos)
-        return []
-
-    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
-
-    prune.iter_candidates_known_repositories(
-        retain_set=RETAIN_SET,
-        oci_client=None,
-        ocm_repo=_ocm_repo(),
+def test_known_repos_includes_target_repos():
+    ctx = _ctx_with_retain(
+        f'{TARGET_BASE}/component-descriptors/github.com/my/component:1.0.0',
+        f'{TARGET_BASE}/my-image:v1',
+        f'{SOURCE_BASE}/some/source-image:latest',
     )
-
-    for repo in enumerated:
-        assert repo.startswith(TARGET_BASE), (
-            f'enumerated repo {repo!r} is outside target base {TARGET_BASE!r}'
-        )
-
-    # At least the in-target repos should be present
-    assert any(repo.startswith(TARGET_BASE) for repo in enumerated)
+    repos = prune._repos_known(ctx)
+    assert repos
+    assert all(r.startswith(TARGET_BASE) for r in repos)
 
 
-def test_known_repositories_does_not_enumerate_source_repos(monkeypatch):
-    enumerated = []
-
-    def fake_discover(repos, retain_set, oci_client, jobs):
-        enumerated.extend(repos)
-        return []
-
-    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
-
-    prune.iter_candidates_known_repositories(
-        retain_set=RETAIN_SET,
-        oci_client=None,
-        ocm_repo=_ocm_repo(),
+def test_known_repos_excludes_source_repos():
+    ctx = _ctx_with_retain(
+        f'{TARGET_BASE}/component-descriptors/github.com/my/component:1.0.0',
+        f'{SOURCE_BASE}/some/source-image:latest',
     )
-
-    source_repos = [r for r in enumerated if 'europe-docker' in r]
-    assert not source_repos, (
-        f'source repos should not be enumerated, got: {source_repos}'
-    )
+    repos = prune._repos_known(ctx)
+    assert not any('europe-docker' in r for r in repos)
 
 
-# --- full-registry ------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# full-registry prefix computation
+# ---------------------------------------------------------------------------
 
-def test_full_registry_only_enumerates_target_account(monkeypatch):
-    enumerated_prefixes = []
-
-    def fake_iter_repositories(client, image_reference, raise_if_unsupported):
-        enumerated_prefixes.append(str(image_reference))
-        return iter([])
-
-    monkeypatch.setattr(prune.oci.nonstd, 'iter_repositories', fake_iter_repositories)
-
-    prune.iter_candidates_full_registry(
-        retain_set=RETAIN_SET,
-        oci_client=None,
-        ocm_repo=_ocm_repo(),
-    )
-
-    for prefix in enumerated_prefixes:
-        assert 'europe-docker' not in prefix, (
-            f'full-registry enumeration reached source registry: {prefix!r}'
-        )
-    assert any('keppel.example.com' in p for p in enumerated_prefixes)
+def test_account_prefix_is_netloc_plus_account():
+    assert prune._account_prefix(OCM_REPO) == TARGET_BASE
 
 
-def test_full_registry_repo_refs_include_account(monkeypatch):
-    '''Keppel API returns repo names without the account prefix; the constructed
-    OCI refs must include it (e.g. keppel.../account/repo, not keppel.../repo).'''
-    collected_repos = []
-
-    def fake_iter_repositories(client, image_reference, raise_if_unsupported):
-        # simulate Keppel returning bare names without the account prefix
-        return iter(['component-descriptors/foo', 'some-image'])
-
-    def fake_discover(repos, retain_set, oci_client, jobs):
-        collected_repos.extend(repos)
-        return []
-
-    monkeypatch.setattr(prune.oci.nonstd, 'iter_repositories', fake_iter_repositories)
-    monkeypatch.setattr(prune, '_discover_candidates', fake_discover)
-
-    prune.iter_candidates_full_registry(
-        retain_set=RETAIN_SET,
-        oci_client=None,
-        ocm_repo=_ocm_repo(),
-    )
-
-    for repo in collected_repos:
-        assert repo.startswith(TARGET_BASE + '/'), (
-            f'repo {repo!r} is missing the account prefix {TARGET_BASE!r}'
-        )
+def test_full_registry_repo_refs_include_account():
+    prefix = prune._account_prefix(OCM_REPO)
+    repos = {f'{prefix}/{name}' for name in ['component-descriptors/foo', 'some-image']}
+    assert all(r.startswith(TARGET_BASE + '/') for r in repos)
 
 
-# --- RESTRICT_TO_OCM_REPO flag ------------------------------------------------
+# ---------------------------------------------------------------------------
+# scope predicate
+# ---------------------------------------------------------------------------
 
-def _make_resource_node(image_ref):
+def test_in_scope_rejects_external_ref():
+    assert not prune._in_scope_of_ocm_repo(f'{SOURCE_BASE}/some-image:v1', OCM_REPO)
+
+
+def test_in_scope_accepts_target_ref():
+    assert prune._in_scope_of_ocm_repo(f'{TARGET_BASE}/some-image:v1', OCM_REPO)
+
+
+# ---------------------------------------------------------------------------
+# _iter_resource_refs
+# ---------------------------------------------------------------------------
+
+def _make_oci_node(image_ref):
     access = ocm.OciAccess(imageReference=image_ref)
     resource = types.SimpleNamespace(access=access)
     return types.SimpleNamespace(resource=resource)
 
 
-def test_delete_skips_out_of_scope_oci_access(monkeypatch):
-    '''With RESTRICT_TO_OCM_REPO set, resources pointing to external registries
-    must not be submitted for deletion.'''
-    deleted = []
-    monkeypatch.setattr(prune, '_delete_one', lambda ref, client: deleted.append(ref))
-
-    node = _make_resource_node(f'{SOURCE_BASE}/some-image:v1')
-    ocm_repo = _ocm_repo()
-
-    # simulate _coordinate logic for a single resource node
-    mode = prune.EnumerationMode.RESTRICT_TO_OCM_REPO
-    for ref in prune._iter_resource_refs(node, ocm_repo):
-        base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
-        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
-            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
-                continue
-        deleted.append(ref)
-
-    assert deleted == [], f'expected no deletions, got {deleted}'
+def _make_relative_node(reference):
+    access = ocm.RelativeOciAccess(reference=reference)
+    resource = types.SimpleNamespace(access=access)
+    return types.SimpleNamespace(resource=resource)
 
 
-def test_delete_includes_in_scope_oci_access(monkeypatch):
-    in_scope = f'{TARGET_BASE}/some-image:v1'
-    node = _make_resource_node(in_scope)
-    ocm_repo = _ocm_repo()
-
-    collected = []
-    mode = prune.EnumerationMode.RESTRICT_TO_OCM_REPO
-    for ref in prune._iter_resource_refs(node, ocm_repo):
-        base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
-        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
-            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
-                continue
-        collected.append(ref)
-
-    assert collected == [in_scope]
+def test_iter_resource_refs_oci_access():
+    ref = f'{TARGET_BASE}/some-image:v1'
+    assert list(prune._iter_resource_refs(_make_oci_node(ref), OCM_REPO)) == [ref]
 
 
-def test_delete_without_restriction_includes_external_refs():
-    node = _make_resource_node(f'{SOURCE_BASE}/some-image:v1')
-    ocm_repo = _ocm_repo()
+def test_iter_resource_refs_relative_access():
+    refs = list(prune._iter_resource_refs(_make_relative_node('some-image:v1'), OCM_REPO))
+    assert refs == [f'{TARGET_BASE}/some-image:v1']
 
-    collected = []
-    mode = prune.EnumerationMode(0)  # no RESTRICT_TO_OCM_REPO
-    for ref in prune._iter_resource_refs(node, ocm_repo):
-        if mode & prune.EnumerationMode.RESTRICT_TO_OCM_REPO:
-            base = prune.oci.util.normalise_image_reference(ocm_repo.oci_ref).rstrip('/')
-            if not prune.oci.util.normalise_image_reference(ref).startswith(base + '/'):
-                continue
-        collected.append(ref)
 
-    assert len(collected) == 1
+def test_iter_resource_refs_yields_external_refs():
+    external = f'{SOURCE_BASE}/some-image:v1'
+    refs = list(prune._iter_resource_refs(_make_oci_node(external), OCM_REPO))
+    assert refs == [external]


### PR DESCRIPTION
Replaces the monolithic `prune()` function with a clean three-phase structure:

- **Phase I-A** `prune(component, ctx)` — recursively populates `ctx.retain_set`
  from a single, already-resolved `ComponentIdentity`. Multiple roots / versions
  are composed by the caller. No version resolution inside.
- **Phase I-B** `enumerate_candidates(ctx)` — populates `ctx.candidates`; can
  run in parallel with I-A when using full-registry mode.
- **Phase II** `delete_all(refs, oci_client)` — flat concurrent deletion of
  `ctx.candidates - ctx.retain_set`.

`PruneCtx` is a plain `@dataclass` holding the two sets, a lock, and config.
No lifecycle methods; callers compose the phases explicitly.

Also exports `parse_component_ref` and `resolve_versions` as standalone helpers
so callers handle version resolution themselves (SoC).

Removes `build_retain_set`, `delete_candidates`, `_delete_component_subtree`, and
the old `prune()` entry point.