### PR TITLE
fix(oci): separate read/write throttles; increase retries + cap backoff

### DIFF
--- a/oci/client.py
+++ b/oci/client.py
@@ -853,12 +853,12 @@ class Client:
 
         if not res.ok and warn_if_not_ok:
             logger.warning(
-                f'rq against {url=} failed {res.status_code=} {res.reason=} {method=} {res.content}'
+                f'rq against {method=} {url=} failed {res.status_code=} {res.reason=} {res.content}'
             )
 
         if res.status_code == 429 and remaining_retries > 0:
             retry_after_seconds = _retry_after_seconds(res=res, fallback=sleep_before_retry_seconds)
-            jitter = random.uniform(0, max(1.0, retry_after_seconds * 0.1))
+            jitter = random.uniform(0, retry_after_seconds * 0.1)
 
             throttle.on_429(retry_after=retry_after_seconds)
 

--- a/oci/client.py
+++ b/oci/client.py
@@ -429,9 +429,11 @@ class Client:
         session: requests.Session=None,
         tag_preprocessing_callback: collections.abc.Callable[[str], str]=None,
         tag_postprocessing_callback: collections.abc.Callable[[str], str]=None,
-        max_retries: int=5,
+        max_retries: int=12,
         default_backoff_base_seconds: float=1.0,
+        max_backoff_seconds: float=60.0,
         max_concurrency_per_host: int=8,
+        max_write_concurrency_per_host: int=4,
     ):
         '''
         :param Callable credentials_lookup:
@@ -449,12 +451,18 @@ class Client:
         :param int max_retries:
             how many times to retry a failed request (connection errors, 429, 5xx)
         :param float default_backoff_base_seconds:
-            initial sleep before first retry; doubles on each subsequent attempt
+            initial sleep before first retry; doubles on each subsequent attempt, capped at
+            `max_backoff_seconds`
+        :param float max_backoff_seconds:
+            ceiling for the exponential backoff sleep between retries
         :param int max_concurrency_per_host:
-            initial maximum number of simultaneous in-flight requests to any single registry host.
-            The limit is adaptive (AIMD): halved on each 429 response (minimum 1), incremented by
-            one on each successful non-429/non-5xx response, up to this initial value.  Prevents
-            burst concurrency from triggering per-client rate limits on registries such as Keppel.
+            initial maximum number of simultaneous in-flight read requests to any single registry
+            host.  The limit is adaptive (AIMD): halved on each 429 (minimum 1), incremented by one
+            on each success, up to this value.
+        :param int max_write_concurrency_per_host:
+            same as `max_concurrency_per_host` but applies only to mutating requests (PUT, POST,
+            PATCH, DELETE).  A separate throttle is kept per host so that write-429s do not reduce
+            read concurrency.
         '''
         self.credentials_lookup = credentials_lookup
         self.token_cache = OauthTokenCache()
@@ -468,9 +476,12 @@ class Client:
         self.tag_postprocessing_callback = tag_postprocessing_callback
         self.max_retries = max_retries
         self.default_backoff_base_seconds = default_backoff_base_seconds
+        self.max_backoff_seconds = max_backoff_seconds
         self._max_concurrency_per_host = max_concurrency_per_host
+        self._max_write_concurrency_per_host = max_write_concurrency_per_host
         self._per_host_initial_limits: dict[str, int] = {}
         self._host_throttles: dict[str, '_PerHostThrottle'] = {}
+        self._host_write_throttles: dict[str, '_PerHostThrottle'] = {}
         self._host_throttles_lock = threading.Lock()
 
         if timeout_seconds:
@@ -492,6 +503,19 @@ class Client:
                     ),
                 )
             return self._host_throttles[host]
+
+    def _write_throttle_for(self, host: str) -> '_PerHostThrottle':
+        try:
+            return self._host_write_throttles[host]
+        except KeyError:
+            pass
+        with self._host_throttles_lock:
+            if host not in self._host_write_throttles:
+                self._host_write_throttles[host] = _PerHostThrottle(
+                    host=host,
+                    initial_limit=self._max_write_concurrency_per_host,
+                )
+            return self._host_write_throttles[host]
 
     def set_host_initial_limit(self, host: str, limit: int):
         '''Set the initial (max) per-host concurrency limit for `host`.
@@ -719,7 +743,10 @@ class Client:
                 raise_for_status=raise_for_status,
                 warn_if_not_ok=warn_if_not_ok,
                 remaining_retries=remaining_retries - 1,
-                sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
+                sleep_before_retry_seconds=min(
+                    sleep_before_retry_seconds * 2,
+                    self.max_backoff_seconds,
+                ),
                 **kwargs,
             )
 
@@ -778,7 +805,11 @@ class Client:
         except KeyError:
             timeout = (31, 121)
 
-        throttle = self._throttle_for(urllib.parse.urlparse(url).netloc)
+        throttle = (
+            self._write_throttle_for(urllib.parse.urlparse(url).netloc)
+            if method.upper() in ('PUT', 'POST', 'PATCH', 'DELETE')
+            else self._throttle_for(urllib.parse.urlparse(url).netloc)
+        )
         conn_exc = None
         with throttle:
             try:
@@ -813,7 +844,10 @@ class Client:
                 raise_for_status=raise_for_status,
                 warn_if_not_ok=warn_if_not_ok,
                 remaining_retries=remaining_retries - 1,
-                sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
+                sleep_before_retry_seconds=min(
+                    sleep_before_retry_seconds * 2,
+                    self.max_backoff_seconds,
+                ),
                 **kwargs,
             )
 
@@ -844,7 +878,10 @@ class Client:
                 raise_for_status=raise_for_status,
                 warn_if_not_ok=warn_if_not_ok,
                 remaining_retries=remaining_retries - 1,
-                sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
+                sleep_before_retry_seconds=min(
+                    sleep_before_retry_seconds * 2,
+                    self.max_backoff_seconds,
+                ),
                 **kwargs,
             )
 
@@ -867,7 +904,10 @@ class Client:
                 raise_for_status=raise_for_status,
                 warn_if_not_ok=warn_if_not_ok,
                 remaining_retries=remaining_retries - 1,
-                sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
+                sleep_before_retry_seconds=min(
+                    sleep_before_retry_seconds * 2,
+                    self.max_backoff_seconds,
+                ),
                 **kwargs,
             )
 

--- a/test/oci/client_test.py
+++ b/test/oci/client_test.py
@@ -103,7 +103,7 @@ def _mock_response(status_code, headers=None):
 
 def test_client_calls_throttle_on_429():
     '''on_429() halves the limit on 429; on_success() recovers it after the retry succeeds.'''
-    client = co.Client(max_concurrency_per_host=4)
+    client = co.Client(max_write_concurrency_per_host=4)
 
     # pre-populate auth cache so _authenticate() exits early without network I/O
     client.token_cache.set_auth_method(
@@ -120,18 +120,15 @@ def test_client_calls_throttle_on_429():
             return _mock_response(429, headers={'Retry-After': '0'})
         return _mock_response(200)
 
-    throttle = co._PerHostThrottle(host='registry.example.com', initial_limit=4)
-    client._throttle_for = lambda host: throttle
-
     with unittest.mock.patch.object(client.session, 'request', side_effect=fake_request):
-        with unittest.mock.patch('oci.client.time.sleep'):
-            client._request(
-                url='https://registry.example.com/v2/repo/blobs/uploads/',
-                image_reference='registry.example.com/repo:tag',
-                scope='repository:repo:push',
-                method='POST',
-            )
+        client._request(
+            url='https://registry.example.com/v2/repo/blobs/uploads/',
+            image_reference='registry.example.com/repo:tag',
+            scope='repository:repo:push',
+            method='POST',
+        )
 
+    throttle = client._host_write_throttles['registry.example.com']
     # 4 → 2 from on_429, then 2 → 3 from on_success on the successful retry
     assert throttle._limit == 3
     assert call_count == 2


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Keppel rate-limits write requests (PUT/POST) far more aggressively than
reads.  Previously a write-429 halved the *shared* per-host concurrency
limit, which also starved concurrent reads and caused the retry budget to
exhaust before Keppel recovered.

**Changes**

- `_request` now routes `PUT`/`POST`/`PATCH`/`DELETE` through a dedicated
  per-host write throttle (new `_write_throttle_for`), leaving the read
  throttle untouched when a write gets 429'd.
- New `max_write_concurrency_per_host` parameter (default **4**, vs 8 for
  reads) so writes start more conservatively.
- `max_retries` default raised **5 → 12**.
- New `max_backoff_seconds` parameter (default **60 s**) caps the
  exponential backoff; worst-case retry budget is now ~11 min vs the
  previous 31 s.

**Release note**:
```bugfix operator
oci.Client: separate read/write per-host throttles so write-429s no longer
reduce read concurrency; retry budget raised to 12 attempts, backoff capped
at 60 s (~11 min total vs previous 31 s).
```