### PR TITLE
SBOM enrichment: BoringCrypto, APK key fallback, ELF guard, OS purl for EOL images

### DIFF
--- a/sbom/boringcrypto.py
+++ b/sbom/boringcrypto.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+BoringCrypto binary scan for Go executables.
+
+Identifies Go binaries by the build-ID magic header and checks for
+crypto/internal/boring import-path markers to determine whether the binary
+was compiled with -tags boringcrypto.
+
+Public interface
+----------------
+  TOOL_NAME                                    str
+  ANALYSIS_METHOD_ANNOTATION                   str
+  ANALYSIS_METHOD_VALUE                        str
+
+  scan_binaries(entries)                       -> dict | None
+  build_inferred_cbom(image_reference, result) -> bytes
+'''
+import datetime
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = 'boringcrypto-scan'
+ANALYSIS_METHOD_ANNOTATION = 'gardener.cloud/cbom/analysis-method'
+ANALYSIS_METHOD_VALUE = 'boringcrypto-scan'
+
+# Go build-info magic header; survives stripping.
+_GO_BUILD_ID_MAGIC = b'\xff Go build ID:'
+
+# BoringCrypto markers: import path always present when linked; GOEXPERIMENT belt-and-suspenders.
+_BORING_MARKERS = (
+    b'crypto/internal/boring',
+    b'GOEXPERIMENT=boringcrypto',
+)
+
+# Binary dirs to scan (matches elfcrypto.py).
+_SEARCH_DIRS = frozenset({
+    '/usr/local/bin', '/usr/bin', '/usr/sbin',
+    '/bin', '/sbin', '/usr/local/sbin',
+})
+
+_MAX_BINARY_BYTES = 256 * 1024 * 1024  # 256 MiB
+
+_SCAN_CHUNK = 65536
+# Overlap ensures patterns that span a chunk boundary are still found.
+_SCAN_OVERLAP = max(len(p) for p in (_GO_BUILD_ID_MAGIC,) + _BORING_MARKERS) - 1
+
+
+def _scan_file(fobj, patterns):
+    '''
+    Stream-scan fobj for byte patterns using a sliding window.
+
+    Reads in 64 KiB chunks with a tail buffer of max(len(p))-1 bytes.
+    Never holds more than ~128 KiB in memory regardless of file size.
+    Returns frozenset of the patterns found.
+    '''
+    remaining = set(patterns)
+    found = set()
+    tail = b''
+    while remaining:
+        chunk = fobj.read(_SCAN_CHUNK)
+        if not chunk:
+            break
+        window = tail + chunk
+        for p in list(remaining):
+            if p in window:
+                found.add(p)
+                remaining.discard(p)
+        tail = window[-_SCAN_OVERLAP:] if _SCAN_OVERLAP else b''
+    return frozenset(found)
+
+
+def scan_binaries(entries):
+    '''
+    Scan an iterable of (path, fobj) pairs for BoringCrypto markers.
+
+    Each fobj must support sequential read(). I/O failures for individual
+    entries are skipped with a debug log; iterator-level failures propagate
+    to the caller.
+
+    Returns {"boring_fips_module": bool, "go_binaries_scanned": int}
+    or None if no Go binaries were found.
+    '''
+    all_patterns = (_GO_BUILD_ID_MAGIC,) + _BORING_MARKERS
+    seen_paths = set()
+    go_count = 0
+    boring_found = False
+
+    for path, fobj in entries:
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        try:
+            found = _scan_file(fobj, all_patterns)
+        except Exception as exc:
+            logger.debug('boringcrypto: read failed %s: %s', path, exc)
+            continue
+        if _GO_BUILD_ID_MAGIC not in found:
+            continue
+        go_count += 1
+        if any(m in found for m in _BORING_MARKERS):
+            boring_found = True
+
+    if go_count == 0:
+        return None
+
+    return {
+        'boring_fips_module': boring_found,
+        'go_binaries_scanned': go_count,
+    }
+
+
+def build_inferred_cbom(image_reference, scan_result: dict) -> bytes:
+    '''Build a CycloneDX 1.6 CBOM from a boringcrypto scan result dict.'''
+    now = datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    boring = scan_result.get('boring_fips_module', False)
+    scanned = scan_result.get('go_binaries_scanned', 0)
+    doc = {
+        'bomFormat':   'CycloneDX',
+        'specVersion': '1.6',
+        'version':     1,
+        'metadata': {
+            'timestamp': now,
+            'tools': [{'name': TOOL_NAME, 'version': '0.1.0'}],
+            'component': {
+                'type': 'container',
+                'name': str(image_reference),
+                'properties': [
+                    {'name': ANALYSIS_METHOD_ANNOTATION, 'value': ANALYSIS_METHOD_VALUE},
+                ],
+            },
+            'properties': [
+                {
+                    'name': 'boring_fips_module',
+                    'value': 'true' if boring else 'false',
+                },
+                {
+                    'name': 'go_binaries_scanned',
+                    'value': str(scanned),
+                },
+                {
+                    'name': 'gardener.cloud/cbom/source-image',
+                    'value': str(image_reference),
+                },
+            ],
+        },
+        'components': [],
+    }
+    return json.dumps(doc, indent=2).encode()

--- a/sbom/boringcrypto.py
+++ b/sbom/boringcrypto.py
@@ -20,7 +20,6 @@ Public interface
 import datetime
 import json
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +41,6 @@ _SEARCH_DIRS = frozenset({
     '/usr/local/bin', '/usr/bin', '/usr/sbin',
     '/bin', '/sbin', '/usr/local/sbin',
 })
-
-_MAX_BINARY_BYTES = 256 * 1024 * 1024  # 256 MiB
 
 _SCAN_CHUNK = 65536
 # Overlap ensures patterns that span a chunk boundary are still found.

--- a/sbom/cbomenrich.py
+++ b/sbom/cbomenrich.py
@@ -370,6 +370,42 @@ def _enrich_apk_keys(components, file_reader):
     return new_comps
 
 
+_CA_BUNDLE_PATHS = (
+    '/etc/ssl/',
+    '/etc/pki/tls/',
+    '/usr/share/ca-certificates/',
+    '/usr/local/share/ca-certificates/',
+)
+
+
+def _tag_trust_store_components(components):
+    '''
+    Tag cryptographic-asset components whose every occurrence location is under a
+    well-known OS CA-bundle path with gardener.cloud/cbom/source: os-trust-store.
+
+    Returns the number of components tagged.
+    '''
+    tagged = 0
+    for comp in components:
+        if comp.get('type') != 'cryptographic-asset':
+            continue
+        occs = (comp.get('evidence') or {}).get('occurrences') or []
+        locs = [occ.get('location', '') for occ in occs if occ.get('location')]
+        if not locs:
+            continue
+        if not all(
+            any(loc.startswith(prefix) for prefix in _CA_BUNDLE_PATHS)
+            for loc in locs
+        ):
+            continue
+        props = comp.setdefault('properties', [])
+        if any(p.get('name') == 'gardener.cloud/cbom/source' for p in props):
+            continue
+        props.append({'name': 'gardener.cloud/cbom/source', 'value': 'os-trust-store'})
+        tagged += 1
+    return tagged
+
+
 def enrich(cbom_bytes, image_reference=None, file_reader=None, oci_client=None):
     '''
     Return enriched CBOM bytes.
@@ -402,6 +438,13 @@ def enrich(cbom_bytes, image_reference=None, file_reader=None, oci_client=None):
         logger.info(
             'CBOM enrichment: resolved %d orphan algorithm component(s) from siblings',
             orphaned,
+        )
+
+    trust_store_tagged = _tag_trust_store_components(components)
+    if trust_store_tagged:
+        logger.info(
+            'CBOM enrichment: tagged %d component(s) as os-trust-store source',
+            trust_store_tagged,
         )
 
     if image_reference:

--- a/sbom/cbomenrich.py
+++ b/sbom/cbomenrich.py
@@ -406,6 +406,94 @@ def _tag_trust_store_components(components):
     return tagged
 
 
+def _parse_os_release(data):
+    '''Parse /etc/os-release bytes into a dict of key→value (quotes stripped).'''
+    result = {}
+    for line in data.decode('utf-8', errors='replace').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if '=' not in line:
+            continue
+        key, _, val = line.partition('=')
+        result[key.strip()] = val.strip().strip('"\'')
+    return result
+
+
+_OS_PURL_PREFIXES = (
+    'pkg:apk/alpine/',
+    'pkg:deb/debian/',
+    'pkg:deb/ubuntu/',
+    'pkg:rpm/rhel/',
+)
+
+
+def _has_os_purl(components):
+    '''Return True if any component already carries an OS purl.'''
+    for comp in components:
+        purl = comp.get('purl', '')
+        if any(purl.startswith(p) for p in _OS_PURL_PREFIXES):
+            return True
+    return False
+
+
+def _synthesise_os_purl(fields):
+    '''
+    Derive (purl, name, version) from /etc/os-release fields, or None.
+
+    Returns None when VERSION_ID is absent, empty, non-numeric, or the distro
+    ID is not in the recognised set.
+    '''
+    distro_id = fields.get('ID', '').lower()
+    version_id = fields.get('VERSION_ID', '')
+    if not version_id or not version_id[0].isdigit():
+        return None
+    if distro_id == 'alpine':
+        return f'pkg:apk/alpine/alpine@{version_id}', 'alpine', version_id
+    if distro_id in ('debian', 'ubuntu'):
+        return f'pkg:deb/{distro_id}/base-files@{version_id}', 'base-files', version_id
+    if distro_id in ('rhel', 'centos') or distro_id.startswith('ubi'):
+        return f'pkg:rpm/rhel/redhat-release@{version_id}', 'redhat-release', version_id
+    return None
+
+
+def enrich_sbom(cdx_bytes, file_reader):
+    '''
+    Inject a synthetic OS purl component into cdx_bytes if one is missing.
+
+    Reads /etc/os-release via file_reader, parses ID and VERSION_ID, and appends
+    a single "library" component tagged with gardener.cloud/sbom/source:
+    os-release-injection.  Returns unchanged bytes when the purl already exists,
+    /etc/os-release is unreadable, or the distro/version is unrecognised.
+    '''
+    doc = json.loads(cdx_bytes)
+    components = doc.setdefault('components', [])
+
+    if _has_os_purl(components):
+        return cdx_bytes
+
+    data = file_reader('/etc/os-release')
+    if not data:
+        return cdx_bytes
+
+    result = _synthesise_os_purl(_parse_os_release(data))
+    if not result:
+        return cdx_bytes
+
+    purl, name, version = result
+    components.append({
+        'type': 'library',
+        'name': name,
+        'version': version,
+        'purl': purl,
+        'properties': [
+            {'name': 'gardener.cloud/sbom/source', 'value': 'os-release-injection'},
+        ],
+    })
+    logger.info('SBOM enrichment: injected OS purl %s from /etc/os-release', purl)
+    return json.dumps(doc, ensure_ascii=False).encode()
+
+
 def enrich(cbom_bytes, image_reference=None, file_reader=None, oci_client=None):
     '''
     Return enriched CBOM bytes.

--- a/sbom/cbomenrich.py
+++ b/sbom/cbomenrich.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 '''Enrich cbomkit-theia CBOMs with key-size information not extracted during scanning.'''
+import gzip
 import io
 import json
 import logging
 import shutil
 import subprocess
 import tarfile
+import tempfile
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -46,22 +48,19 @@ def _docker_file_reader(image_reference):
         return None, lambda: None
 
     def read_file(path):
-        try:
-            result = subprocess.run(
-                ['docker', 'cp', f'{container_id}:{path}', '-'],
-                capture_output=True,
-                check=False,
-            )
-            if result.returncode != 0:
-                return None
-            # docker cp to stdout produces a single-file tar archive
-            with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tf:
-                for member in tf.getmembers():
-                    if member.isfile():
-                        fobj = tf.extractfile(member)
-                        return fobj.read() if fobj else None
-        except Exception:  # nosec B110
-            pass
+        result = subprocess.run(
+            ['docker', 'cp', f'{container_id}:{path}', '-'],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        # docker cp to stdout produces a single-file tar archive
+        with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tf:
+            for member in tf.getmembers():
+                if member.isfile():
+                    fobj = tf.extractfile(member)
+                    return fobj.read() if fobj else None
         return None
 
     def cleanup():
@@ -72,6 +71,87 @@ def _docker_file_reader(image_reference):
         )
 
     return read_file, cleanup
+
+
+def _oci_file_reader(image_reference, oci_client):
+    '''Return a read_file callable backed by OCI layer downloads, or None on failure.'''
+    try:
+        import oci.model as om
+        ref = om.OciImageReference.to_image_ref(image_reference)
+        repo_ref = ref.ref_without_tag
+        manifest = oci_client.manifest(image_reference)
+        if isinstance(manifest, om.OciImageManifestList):
+            entries = [
+                e for e in manifest.manifests
+                if e.platform and e.platform.os == 'linux'
+                and e.platform.architecture == 'amd64'
+            ]
+            entry = entries[0] if entries else (
+                manifest.manifests[0] if manifest.manifests else None
+            )
+            if entry is None:
+                return None
+            manifest = oci_client.manifest(f'{repo_ref}@{entry.digest}')
+        if manifest is None:
+            return None
+    except Exception as exc:
+        logger.debug('CBOM enrichment: OCI manifest fetch failed for %s: %s', image_reference, exc)
+        raise
+
+    # newest layer first — read_file returns the topmost (container-visible) version of a file
+    layers = list(reversed(manifest.layers))
+    layer_cache = {}  # digest -> TemporaryFile (seekable, decompressed)
+
+    def _load_layer(layer):
+        digest = layer.digest
+        if digest in layer_cache:
+            return layer_cache[digest]
+        resp = oci_client.blob(
+            image_reference=repo_ref,
+            digest=digest,
+            stream=True,
+        )
+        if resp is None:
+            layer_cache[digest] = None
+            return None
+        tmp = tempfile.TemporaryFile()
+        first_bytes = b''
+        for chunk in resp.iter_content(chunk_size=65536):
+            if not first_bytes:
+                first_bytes = chunk[:2]
+            tmp.write(chunk)
+        tmp.seek(0)
+        if first_bytes[:2] == b'\x1f\x8b':
+            # gzip: decompress into a second tempfile so tarfile can seek
+            decompressed = tempfile.TemporaryFile()
+            with gzip.open(tmp) as gz:
+                while True:
+                    block = gz.read(65536)
+                    if not block:
+                        break
+                    decompressed.write(block)
+            tmp.close()
+            decompressed.seek(0)
+            layer_cache[digest] = decompressed
+        else:
+            layer_cache[digest] = tmp
+        return layer_cache[digest]
+
+    def read_file(path):
+        norm = path.lstrip('/')
+        for layer in layers:
+            tmp = _load_layer(layer)
+            if tmp is None:
+                continue
+            tmp.seek(0)
+            with tarfile.open(fileobj=tmp) as tf:
+                for member in tf.getmembers():
+                    if member.name.lstrip('./') == norm and member.isfile():
+                        fobj = tf.extractfile(member)
+                        return fobj.read() if fobj else None
+        return None
+
+    return read_file
 
 
 def _compute_sizes_from_values(components):
@@ -290,7 +370,7 @@ def _enrich_apk_keys(components, file_reader):
     return new_comps
 
 
-def enrich(cbom_bytes, image_reference=None, file_reader=None):
+def enrich(cbom_bytes, image_reference=None, file_reader=None, oci_client=None):
     '''
     Return enriched CBOM bytes.
 
@@ -298,11 +378,11 @@ def enrich(cbom_bytes, image_reference=None, file_reader=None):
     1. Propagate key sizes from related-crypto-material components to their referenced
        algorithm components' parameterSetIdentifier (works without image access).
     2. If image_reference is given, inject RSA algorithm and key-material components for
-       APK signing keys (.rsa.pub files) — using file_reader if provided, otherwise Docker
-       if available.
+       APK signing keys (.rsa.pub files) — using file_reader if provided, then Docker
+       if available, then OCI layer download if oci_client is provided.
 
     file_reader, if given, must be a callable: path: str -> bytes | None.
-    When provided, Docker is not attempted.
+    When provided, Docker and OCI paths are not attempted.
     '''
     doc = json.loads(cbom_bytes)
     components = doc.get('components') or []
@@ -330,6 +410,9 @@ def enrich(cbom_bytes, image_reference=None, file_reader=None):
             cleanup = lambda: None
         else:
             active_reader, cleanup = _docker_file_reader(image_reference)
+            if active_reader is None and oci_client is not None:
+                active_reader = _oci_file_reader(image_reference, oci_client)
+                cleanup = lambda: None
         try:
             if active_reader:
                 new_comps = _enrich_apk_keys(components, active_reader)

--- a/sbom/elfcrypto.py
+++ b/sbom/elfcrypto.py
@@ -725,6 +725,17 @@ def infer_from_elf(
         return _infer_via_docker(image_reference, binary_paths, tmpdir)
 
 
+def _deployment_context(inference: dict) -> str | None:
+    '''Map ELF inference output to a deployment-context string.'''
+    protocols = inference.get('protocols', [])
+    has_tls = any(p.startswith('TLS') or p.startswith('DTLS') for p in protocols)
+    if has_tls:
+        return 'tls-termination'
+    if inference.get('algorithms'):
+        return 'data-encryption'
+    return None
+
+
 def build_inferred_cbom(image_ref: str, inference: dict) -> bytes:
     '''
     Build a CycloneDX 1.6 CBOM from an ELF inference result dict.
@@ -775,6 +786,9 @@ def build_inferred_cbom(image_ref: str, inference: dict) -> bytes:
         properties.append({'name': 'gardener.cloud/cbom/boringssl-detected', 'value': 'true'})
     if inference.get('boringssl_fips'):
         properties.append({'name': 'gardener.cloud/cbom/boringssl-fips-detected', 'value': 'true'})
+    ctx = _deployment_context(inference)
+    if ctx is not None:
+        properties.append({'name': 'gardener.cloud/cbom/deployment-context', 'value': ctx})
 
     doc = {
         'bomFormat':   'CycloneDX',

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -506,6 +506,10 @@ def scan_image(
         with open(cdx_path, 'rb') as f:
             cdx_bytes = f.read()
 
+        _fr, _ = _oci_file_reader(image_ref, oci_client)
+        if _fr is not None:
+            cdx_bytes = scbe.enrich_sbom(cdx_bytes, _fr)
+
         _run_cbomkit_theia(
             image_ref=str(image_ref),
             cdx_bom_path=cdx_path,

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -23,13 +23,16 @@ import io
 import json
 import logging
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
+import zlib
 
 import oci.client as oc
 import oci.model as om
 import ocm
+import sbom.boringcrypto as sboring
 import sbom.cbom as scbom
 import sbom.cbomenrich as scbe
 import sbom.elfcrypto as selfc
@@ -353,6 +356,124 @@ def _oci_file_reader(image_ref, oci_client):
     return read_file, lambda: None
 
 
+class _ChainReader:
+    '''Prepends `head` bytes before delegating reads to `tail`.'''
+    __slots__ = ('_head', '_tail')
+
+    def __init__(self, head, tail):
+        self._head = head
+        self._tail = tail
+
+    def read(self, n=-1):
+        if self._head:
+            if n < 0:
+                data = self._head + self._tail.read()
+                self._head = b''
+                return data
+            chunk = self._head[:n]
+            self._head = self._head[n:]
+            return chunk
+        return self._tail.read(n) if n >= 0 else self._tail.read()
+
+    def close(self):
+        pass
+
+
+def _decompress_layer(resp, dst):
+    '''
+    Stream-decompress an OCI layer blob into dst (writable file-like).
+
+    Detects gzip (magic 1f 8b), zstd (magic 28 b5 2f fd), or plain tar
+    from the first four bytes; requires neither resp.content nor a
+    second full-size buffer.
+    '''
+    header = resp.raw.read(4)
+    if not header:
+        return
+    if header[:4] == b'\x28\xb5\x2f\xfd':
+        import zstandard
+        with zstandard.ZstdDecompressor().stream_reader(_ChainReader(header, resp.raw)) as r:
+            shutil.copyfileobj(r, dst, 65536)
+    elif header[:2] == b'\x1f\x8b':
+        d = zlib.decompressobj(wbits=47)  # 47 = auto-detect gzip
+        dst.write(d.decompress(header))
+        while True:
+            chunk = resp.raw.read(65536)
+            if not chunk:
+                break
+            dst.write(d.decompress(chunk))
+        dst.write(d.flush())
+    else:
+        dst.write(header)
+        shutil.copyfileobj(resp.raw, dst, 65536)
+
+
+def _iter_boring_candidates(image_ref, oci_client):
+    '''
+    Yield (path, fobj) pairs for executable candidates in Go binary search dirs.
+
+    Streams each layer to a TemporaryFile to avoid double-buffering the full
+    decompressed content in memory.  Yields in overlay order (topmost layer first)
+    so the caller sees the correct file for each path without needing to understand
+    the overlay structure.  Raises on manifest fetch or layer I/O failure.
+    '''
+    import oci.model as om
+    ref = om.OciImageReference.to_image_ref(image_ref)
+    repo_ref = ref.ref_without_tag
+    manifest = oci_client.manifest(image_ref)
+    if isinstance(manifest, om.OciImageManifestList):
+        entries = [
+            e for e in manifest.manifests
+            if e.platform and e.platform.os == 'linux'
+            and e.platform.architecture == 'amd64'
+        ]
+        entry = entries[0] if entries else (
+            manifest.manifests[0] if manifest.manifests else None
+        )
+        if entry is None:
+            return
+        manifest = oci_client.manifest(f'{repo_ref}@{entry.digest}')
+
+    seen_paths = set()
+
+    for layer in reversed(manifest.layers):
+        with tempfile.TemporaryFile() as tmp_f:
+            resp = oci_client.blob(
+                image_reference=repo_ref,
+                digest=layer.digest,
+                stream=True,
+            )
+            try:
+                _decompress_layer(resp, tmp_f)
+            finally:
+                resp.close()
+            tmp_f.seek(0)
+            with tarfile.open(fileobj=tmp_f) as tf:
+                for member in tf:
+                    if not member.isfile():
+                        continue
+                    path = '/' + member.name.lstrip('./')
+                    if path in seen_paths:
+                        continue
+                    dir_part = os.path.dirname(path)
+                    if dir_part not in sboring._SEARCH_DIRS:
+                        continue
+                    if not (member.mode & 0o111):
+                        continue
+                    if member.size > sboring._MAX_BINARY_BYTES:
+                        logger.debug(
+                            'boringcrypto: skipping oversized binary %s (%d bytes)',
+                            path, member.size,
+                        )
+                        seen_paths.add(path)
+                        continue
+                    fobj = tf.extractfile(member)
+                    if fobj is None:
+                        continue
+                    seen_paths.add(path)
+                    yield path, fobj
+
+
 def scan_image(
     image_ref: str | om.OciImageReference,
     oci_client: oc.Client,
@@ -499,6 +620,35 @@ def scan_image(
             len(node_inference['algorithms']),
             len(node_inference['protocols']),
         )
+
+    # BoringCrypto scan — detects whether Go binaries were built with -tags boringcrypto.
+    try:
+        boring_result = sboring.scan_binaries(
+            _iter_boring_candidates(str(image_ref), oci_client)
+        )
+    except Exception as exc:
+        logger.warning('%s: boringcrypto scan failed: %s', image_ref, exc)
+        boring_result = None
+    if boring_result is not None:
+        boring_cbom = sboring.build_inferred_cbom(str(image_ref), boring_result)
+        try:
+            scbom.push_cbom_referrer(
+                cbom_bytes=boring_cbom,
+                image_reference=image_ref,
+                oci_client=oci_client,
+                tool_version=sboring.TOOL_NAME,
+                extra_annotations={
+                    sboring.ANALYSIS_METHOD_ANNOTATION: sboring.ANALYSIS_METHOD_VALUE,
+                },
+            )
+            logger.info(
+                '%s: pushed boringcrypto CBOM (%d Go binaries, boring_fips_module=%s)',
+                image_ref,
+                boring_result['go_binaries_scanned'],
+                boring_result['boring_fips_module'],
+            )
+        except Exception as exc:
+            logger.error('%s: failed to push boringcrypto CBOM: %s', image_ref, exc)
 
     return (
         spdx_bytes, cdx_bytes, cbom_bytes,

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -460,13 +460,6 @@ def _iter_boring_candidates(image_ref, oci_client):
                         continue
                     if not (member.mode & 0o111):
                         continue
-                    if member.size > sboring._MAX_BINARY_BYTES:
-                        logger.debug(
-                            'boringcrypto: skipping oversized binary %s (%d bytes)',
-                            path, member.size,
-                        )
-                        seen_paths.add(path)
-                        continue
                     fobj = tf.extractfile(member)
                     if fobj is None:
                         continue
@@ -622,33 +615,26 @@ def scan_image(
         )
 
     # BoringCrypto scan — detects whether Go binaries were built with -tags boringcrypto.
-    try:
-        boring_result = sboring.scan_binaries(
-            _iter_boring_candidates(str(image_ref), oci_client)
-        )
-    except Exception as exc:
-        logger.warning('%s: boringcrypto scan failed: %s', image_ref, exc)
-        boring_result = None
+    boring_result = sboring.scan_binaries(
+        _iter_boring_candidates(str(image_ref), oci_client)
+    )
     if boring_result is not None:
         boring_cbom = sboring.build_inferred_cbom(str(image_ref), boring_result)
-        try:
-            scbom.push_cbom_referrer(
-                cbom_bytes=boring_cbom,
-                image_reference=image_ref,
-                oci_client=oci_client,
-                tool_version=sboring.TOOL_NAME,
-                extra_annotations={
-                    sboring.ANALYSIS_METHOD_ANNOTATION: sboring.ANALYSIS_METHOD_VALUE,
-                },
-            )
-            logger.info(
-                '%s: pushed boringcrypto CBOM (%d Go binaries, boring_fips_module=%s)',
-                image_ref,
-                boring_result['go_binaries_scanned'],
-                boring_result['boring_fips_module'],
-            )
-        except Exception as exc:
-            logger.error('%s: failed to push boringcrypto CBOM: %s', image_ref, exc)
+        scbom.push_cbom_referrer(
+            cbom_bytes=boring_cbom,
+            image_reference=image_ref,
+            oci_client=oci_client,
+            tool_version=sboring.TOOL_NAME,
+            extra_annotations={
+                sboring.ANALYSIS_METHOD_ANNOTATION: sboring.ANALYSIS_METHOD_VALUE,
+            },
+        )
+        logger.info(
+            '%s: pushed boringcrypto CBOM (%d Go binaries, boring_fips_module=%s)',
+            image_ref,
+            boring_result['go_binaries_scanned'],
+            boring_result['boring_fips_module'],
+        )
 
     return (
         spdx_bytes, cdx_bytes, cbom_bytes,

--- a/sbom/inject.py
+++ b/sbom/inject.py
@@ -564,10 +564,16 @@ def scan_image(
 
     # ELF symbol inference — detects crypto in C/C++ images (envoy, fluent-bit, etc.)
     # that cbomkit-theia only covers as CA-bundle noise.
-    elf_inference = selfc.infer_from_elf(
-        image_reference=str(image_ref),
-        oci_client=oci_client,
-    )
+    # Skipped for Go images (inference is non-None when pkg:golang/ purls are present);
+    # dynamic imports carry no useful signal for pure Go binaries.
+    # Known limitation: mixed Go+C/C++ images (CGo + OpenSSL) are also skipped.
+    if not inference:
+        elf_inference = selfc.infer_from_elf(
+            image_reference=str(image_ref),
+            oci_client=oci_client,
+        )
+    else:
+        elf_inference = None
     if elf_inference:
         elf_cbom_bytes = selfc.build_inferred_cbom(
             image_ref=image_ref,

--- a/test/sbom/cbomenrich_os_test.py
+++ b/test/sbom/cbomenrich_os_test.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''Unit tests for OS purl injection helpers in cbomenrich.py.'''
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+import sbom.cbomenrich as scbe
+
+
+# ---------------------------------------------------------------------------
+# _parse_os_release
+# ---------------------------------------------------------------------------
+
+def test_parse_os_release_basic():
+    data = b'ID=alpine\nVERSION_ID=3.18\n'
+    assert scbe._parse_os_release(data) == {'ID': 'alpine', 'VERSION_ID': '3.18'}
+
+
+def test_parse_os_release_quoted_double():
+    data = b'ID="debian"\nVERSION_ID="11"\n'
+    result = scbe._parse_os_release(data)
+    assert result['ID'] == 'debian'
+    assert result['VERSION_ID'] == '11'
+
+
+def test_parse_os_release_quoted_single():
+    data = b"ID='ubuntu'\nVERSION_ID='22.04'\n"
+    result = scbe._parse_os_release(data)
+    assert result['ID'] == 'ubuntu'
+    assert result['VERSION_ID'] == '22.04'
+
+
+def test_parse_os_release_ignores_comments():
+    data = b'# comment\nID=alpine\n# another\nVERSION_ID=3.18\n'
+    result = scbe._parse_os_release(data)
+    assert result == {'ID': 'alpine', 'VERSION_ID': '3.18'}
+
+
+def test_parse_os_release_crlf():
+    data = b'ID=alpine\r\nVERSION_ID=3.18\r\n'
+    result = scbe._parse_os_release(data)
+    assert result['ID'] == 'alpine'
+    assert result['VERSION_ID'] == '3.18'
+
+
+def test_parse_os_release_empty_lines():
+    data = b'\nID=alpine\n\nVERSION_ID=3.18\n\n'
+    result = scbe._parse_os_release(data)
+    assert result['ID'] == 'alpine'
+    assert result['VERSION_ID'] == '3.18'
+
+
+def test_parse_os_release_non_utf8():
+    data = b'ID=alpine\nVERSION_ID=3.18\xff\n'
+    result = scbe._parse_os_release(data)
+    assert result['ID'] == 'alpine'
+
+
+# ---------------------------------------------------------------------------
+# _synthesise_os_purl
+# ---------------------------------------------------------------------------
+
+def test_synthesise_alpine():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'alpine', 'VERSION_ID': '3.18'})
+    assert purl == 'pkg:apk/alpine/alpine@3.18'
+    assert name == 'alpine'
+    assert ver == '3.18'
+
+
+def test_synthesise_alpine_mixed_case():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'Alpine', 'VERSION_ID': '3.18'})
+    assert purl == 'pkg:apk/alpine/alpine@3.18'
+
+
+def test_synthesise_debian():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'debian', 'VERSION_ID': '11'})
+    assert purl == 'pkg:deb/debian/base-files@11'
+    assert name == 'base-files'
+
+
+def test_synthesise_ubuntu():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'ubuntu', 'VERSION_ID': '22.04'})
+    assert purl == 'pkg:deb/ubuntu/base-files@22.04'
+    assert name == 'base-files'
+
+
+def test_synthesise_rhel():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'rhel', 'VERSION_ID': '8.7'})
+    assert purl == 'pkg:rpm/rhel/redhat-release@8.7'
+    assert name == 'redhat-release'
+
+
+def test_synthesise_centos():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'centos', 'VERSION_ID': '7'})
+    assert purl == 'pkg:rpm/rhel/redhat-release@7'
+
+
+def test_synthesise_ubi():
+    purl, name, ver = scbe._synthesise_os_purl({'ID': 'ubi8', 'VERSION_ID': '8.7'})
+    assert purl == 'pkg:rpm/rhel/redhat-release@8.7'
+
+
+def test_synthesise_missing_version_id():
+    assert scbe._synthesise_os_purl({'ID': 'alpine'}) is None
+
+
+def test_synthesise_empty_version_id():
+    assert scbe._synthesise_os_purl({'ID': 'alpine', 'VERSION_ID': ''}) is None
+
+
+def test_synthesise_non_numeric_version_id():
+    assert scbe._synthesise_os_purl({'ID': 'debian', 'VERSION_ID': 'bullseye'}) is None
+
+
+def test_synthesise_unknown_distro():
+    assert scbe._synthesise_os_purl({'ID': 'wolfi', 'VERSION_ID': '1.0'}) is None
+
+
+# ---------------------------------------------------------------------------
+# _has_os_purl
+# ---------------------------------------------------------------------------
+
+def test_has_os_purl_apk():
+    comps = [{'purl': 'pkg:apk/alpine/alpine@3.18'}]
+    assert scbe._has_os_purl(comps) is True
+
+
+def test_has_os_purl_deb():
+    comps = [{'purl': 'pkg:deb/debian/base-files@11'}]
+    assert scbe._has_os_purl(comps) is True
+
+
+def test_has_os_purl_rpm():
+    comps = [{'purl': 'pkg:rpm/rhel/redhat-release@8.7'}]
+    assert scbe._has_os_purl(comps) is True
+
+
+def test_has_os_purl_false():
+    comps = [{'purl': 'pkg:golang/somelib@1.0'}]
+    assert scbe._has_os_purl(comps) is False
+
+
+def test_has_os_purl_empty():
+    assert scbe._has_os_purl([]) is False
+
+
+# ---------------------------------------------------------------------------
+# enrich_sbom
+# ---------------------------------------------------------------------------
+
+def _minimal_cdx(components=None):
+    doc = {'bomFormat': 'CycloneDX', 'specVersion': '1.6', 'components': components or []}
+    return json.dumps(doc).encode()
+
+
+def _make_reader(data):
+    def reader(path):
+        if path == '/etc/os-release':
+            return data
+        return None
+    return reader
+
+
+_ALPINE_OS_RELEASE = b'ID=alpine\nVERSION_ID=3.18\n'
+
+
+def test_enrich_sbom_injects_alpine():
+    result = scbe.enrich_sbom(_minimal_cdx(), _make_reader(_ALPINE_OS_RELEASE))
+    doc = json.loads(result)
+    comps = doc['components']
+    assert len(comps) == 1
+    c = comps[0]
+    assert c['purl'] == 'pkg:apk/alpine/alpine@3.18'
+    assert c['name'] == 'alpine'
+    assert c['version'] == '3.18'
+    assert c['type'] == 'library'
+    assert c['properties'] == [
+        {'name': 'gardener.cloud/sbom/source', 'value': 'os-release-injection'}
+    ]
+
+
+def test_enrich_sbom_idempotent():
+    once = scbe.enrich_sbom(_minimal_cdx(), _make_reader(_ALPINE_OS_RELEASE))
+    twice = scbe.enrich_sbom(once, _make_reader(_ALPINE_OS_RELEASE))
+    assert json.loads(once)['components'] == json.loads(twice)['components']
+
+
+def test_enrich_sbom_no_os_release():
+    result = scbe.enrich_sbom(_minimal_cdx(), lambda p: None)
+    assert json.loads(result)['components'] == []
+
+
+def test_enrich_sbom_unrecognised_distro():
+    data = b'ID=wolfi\nVERSION_ID=1.0\n'
+    result = scbe.enrich_sbom(_minimal_cdx(), _make_reader(data))
+    assert json.loads(result)['components'] == []
+
+
+def test_enrich_sbom_existing_os_purl_unchanged():
+    existing = [{'purl': 'pkg:apk/alpine/alpine@3.17', 'type': 'library', 'name': 'alpine'}]
+    cdx = _minimal_cdx(existing)
+    result = scbe.enrich_sbom(cdx, _make_reader(_ALPINE_OS_RELEASE))
+    assert json.loads(result)['components'] == existing
+
+
+def test_enrich_sbom_debian():
+    data = b'ID=debian\nVERSION_ID=11\nVERSION_CODENAME=bullseye\n'
+    result = scbe.enrich_sbom(_minimal_cdx(), _make_reader(data))
+    comps = json.loads(result)['components']
+    assert comps[0]['purl'] == 'pkg:deb/debian/base-files@11'

--- a/test/sbom/cbomenrich_test.py
+++ b/test/sbom/cbomenrich_test.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+'''Unit tests for error-propagation in cbomenrich reader functions.'''
+import gzip
+import io
+import sys
+import os
+import tarfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+import sbom.cbomenrich as scbe
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tar(filename, content):
+    '''Return bytes of a tar archive containing one file.'''
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w') as tf:
+        info = tarfile.TarInfo(name=filename)
+        info.size = len(content)
+        tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _make_gzip_tar(filename, content):
+    return gzip.compress(_make_tar(filename, content))
+
+
+# ---------------------------------------------------------------------------
+# _docker_file_reader
+# ---------------------------------------------------------------------------
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode, stdout=b''):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_docker_read_file_not_found(monkeypatch):
+    '''returncode != 0 → None (not-found path preserved).'''
+    def fake_run(*args, **kwargs):
+        return _FakeCompletedProcess(returncode=1)
+
+    monkeypatch.setattr('shutil.which', lambda _: '/usr/bin/docker')
+    monkeypatch.setattr(
+        'subprocess.check_output',
+        lambda *a, **kw: 'fake-container-id\n',
+    )
+    monkeypatch.setattr('subprocess.run', fake_run)
+
+    reader, cleanup = scbe._docker_file_reader('example.com/img:tag')
+    assert reader('/etc/passwd') is None
+    cleanup()
+
+
+def test_docker_read_file_corrupt_tar_raises(monkeypatch):
+    '''Corrupt tar data must raise, not return None.'''
+    def fake_run(*args, **kwargs):
+        return _FakeCompletedProcess(returncode=0, stdout=b'this is not a tar archive')
+
+    monkeypatch.setattr('shutil.which', lambda _: '/usr/bin/docker')
+    monkeypatch.setattr(
+        'subprocess.check_output',
+        lambda *a, **kw: 'fake-container-id\n',
+    )
+    monkeypatch.setattr('subprocess.run', fake_run)
+
+    reader, cleanup = scbe._docker_file_reader('example.com/img:tag')
+    with pytest.raises(Exception):
+        reader('/etc/passwd')
+    cleanup()
+
+
+# ---------------------------------------------------------------------------
+# _oci_file_reader  (lightweight mock OCI client — no unittest.mock)
+# ---------------------------------------------------------------------------
+
+class _FakeManifest:
+    def __init__(self, layers):
+        self.layers = layers
+
+
+class _FakeLayer:
+    def __init__(self, digest, data):
+        self.digest = digest
+        self._data = data
+
+    mediaType = 'application/vnd.oci.image.layer.v1.tar+gzip'
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.content = content
+
+    def iter_content(self, chunk_size=65536):
+        yield self.content
+
+
+class _OciClientManifestFails:
+    def manifest(self, *a, **kw):
+        raise RuntimeError('network error')
+
+    def blob(self, *a, **kw):
+        raise AssertionError('should not be reached')
+
+
+class _OciClientBlobFails:
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def manifest(self, *a, **kw):
+        return self._manifest
+
+    def blob(self, *a, **kw):
+        raise RuntimeError('blob download failed')
+
+
+class _OciClientCorruptLayer:
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def manifest(self, *a, **kw):
+        return self._manifest
+
+    def blob(self, *a, **kw):
+        return _FakeResponse(b'not valid gzip or tar data')
+
+
+class _OciClientGoodLayer:
+    def __init__(self, manifest, layer_data):
+        self._manifest = manifest
+        self._layer_data = layer_data
+
+    def manifest(self, *a, **kw):
+        return self._manifest
+
+    def blob(self, *a, **kw):
+        return _FakeResponse(self._layer_data)
+
+
+def _patch_oci_model(monkeypatch, manifest):
+    '''Patch oci.model so _oci_file_reader can import it.'''
+    import types
+
+    fake_ref = types.SimpleNamespace(ref_without_tag='example.com/repo')
+    fake_om = types.ModuleType('oci.model')
+    fake_om.OciImageReference = types.SimpleNamespace(
+        to_image_ref=lambda _ref: fake_ref,
+    )
+    fake_om.OciImageManifestList = type('OciImageManifestList', (), {})
+
+    import sys
+    # Ensure oci package exists
+    if 'oci' not in sys.modules:
+        oci_pkg = types.ModuleType('oci')
+        sys.modules['oci'] = oci_pkg
+    sys.modules['oci.model'] = fake_om
+    return fake_om
+
+
+def test_oci_manifest_fetch_raises(monkeypatch):
+    '''manifest() throwing must propagate out of _oci_file_reader.'''
+    _patch_oci_model(monkeypatch, None)
+    client = _OciClientManifestFails()
+    with pytest.raises(RuntimeError, match='network error'):
+        scbe._oci_file_reader('example.com/img:tag', client)
+
+
+def test_oci_load_layer_raises(monkeypatch):
+    '''blob() throwing must propagate when read_file is called.'''
+    layer = _FakeLayer('sha256:abc123', b'')
+    manifest = _FakeManifest([layer])
+    _patch_oci_model(monkeypatch, manifest)
+    client = _OciClientBlobFails(manifest)
+    reader = scbe._oci_file_reader('example.com/img:tag', client)
+    assert reader is not None
+    with pytest.raises(RuntimeError, match='blob download failed'):
+        reader('/etc/passwd')
+
+
+def test_oci_read_file_corrupt_tar_raises(monkeypatch):
+    '''Corrupt layer data (not valid tar) must raise.'''
+    layer = _FakeLayer('sha256:def456', b'')
+    manifest = _FakeManifest([layer])
+    _patch_oci_model(monkeypatch, manifest)
+    # Return raw (non-gzip) bytes that are not a valid tar
+    client = _OciClientCorruptLayer(manifest)
+    reader = scbe._oci_file_reader('example.com/img:tag', client)
+    assert reader is not None
+    with pytest.raises(Exception):
+        reader('/etc/passwd')
+
+
+def test_oci_read_file_not_found_returns_none(monkeypatch):
+    '''File absent from all layers returns None (not-found path preserved).'''
+    tar_data = _make_tar('./other/file.txt', b'hello')
+    layer = _FakeLayer('sha256:fff000', tar_data)
+    manifest = _FakeManifest([layer])
+    _patch_oci_model(monkeypatch, manifest)
+    client = _OciClientGoodLayer(manifest, tar_data)
+    reader = scbe._oci_file_reader('example.com/img:tag', client)
+    assert reader is not None
+    assert reader('/etc/passwd') is None
+
+
+def test_oci_read_file_found_returns_bytes(monkeypatch):
+    '''File present in a layer is returned correctly.'''
+    content = b'root:x:0:0:root:/root:/bin/sh\n'
+    tar_data = _make_tar('./etc/passwd', content)
+    layer = _FakeLayer('sha256:aaa111', tar_data)
+    manifest = _FakeManifest([layer])
+    _patch_oci_model(monkeypatch, manifest)
+    client = _OciClientGoodLayer(manifest, tar_data)
+    reader = scbe._oci_file_reader('example.com/img:tag', client)
+    assert reader is not None
+    assert reader('/etc/passwd') == content


### PR DESCRIPTION
## Summary

- Add BoringCrypto binary scan module (`sbom/boringcrypto.py`): detects FIPS mode in Go binaries via build-ID header, wired into `inject.py`
- Add OCI layer fallback for APK key enrichment in `cbomenrich`
- Add ELF guard, `deployment_context`, and CA-bundle tagging (addressing gaps 3+5)
- Inject OS purl into CycloneDX SBOM for images with manual EOL entries
- Refactor `sbom/boringcrypto.py`: decouple OCI layer-fetching from scan logic, harden error handling (raise instead of swallowing), reduce memory usage via streaming decompression and sliding-window binary scan
- `sbom/cbomenrich.py`: propagate I/O errors (layer download, manifest fetch, tar read) instead of swallowing them silently