### PR TITLE
ctt: wire inject_sboms from processing.cfg into ProcessingPipeline

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -109,12 +109,14 @@ class ProcessingPipeline:
         filters: list[filters.FilterBase],
         processor: processors.ProcessorBase,
         uploaders: list[uploaders.UploaderBase],
+        inject_sboms: bool=False,
     ):
         self._name = name
         self._targets = targets
         self._filters = filters
         self._processor = processor
         self._uploaders = uploaders
+        self._inject_sboms = inject_sboms
 
     def matches_filter(
         self,
@@ -181,6 +183,9 @@ class ProcessingPipeline:
                 target_as_source=not first,
             )
             first = False
+
+        if self._inject_sboms:
+            replication_resource_element.inject_sboms = True
 
         ctt_label = create_ctt_label(
             processing_rules=[
@@ -313,12 +318,15 @@ def processing_pipeline(
 
     uploaders = [instantiate_uploader(upload_cfg) for upload_cfg in upload_cfgs]
 
+    inject_sboms = bool(processing_cfg.get('inject_sboms', False))
+
     pipeline = ProcessingPipeline(
         name=name,
         targets=targets,
         filters=filters,
         processor=proc,
         uploaders=uploaders,
+        inject_sboms=inject_sboms,
     )
     return pipeline
 
@@ -1176,7 +1184,15 @@ def process_replication_plan_step(
         ]
 
         # append any SBOM resources injected for this component
-        for sbom_resource in sbom_extra_resources.get(component.identity(), ()):
+        fresh = sbom_extra_resources.get(component.identity(), ())
+        if fresh:
+            # strip stale SBOM/CBOM resources so fresh ones are the only source of truth
+            component.resources = [
+                r for r in component.resources
+                if 'cbom-format' not in (r.extraIdentity or {})
+                and 'sbom-format' not in (r.extraIdentity or {})
+            ]
+        for sbom_resource in fresh:
             component.resources.append(sbom_resource)
 
         # Validate the patched component-descriptor and exit on fail

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -203,3 +203,40 @@ def test_identity_version_fallback_with_version_in_extra_identity():
     assert len(set(map(str, identities))) == 3, (
         f'expected 3 distinct identities, got: {[str(i) for i in identities]}'
     )
+
+
+def test_inject_sboms_flag_propagates_to_rre(tmpdir):
+    '''
+    inject_sboms: true in processing_cfg must cause ProcessingPipeline.process to set
+    inject_sboms=True on the returned ReplicationResourceElement.
+    '''
+    filter_file = tmpdir.join('no_files.remove')
+    filter_file.write('')
+
+    cfg = {
+        'target': {
+            'type': 'RegistriesTarget',
+            'kwargs': {
+                'registries': ['registry.example.com'],
+            },
+        },
+        'filter': {
+            'type': 'ImageFilter',
+            'kwargs': {
+                'include_image_refs': ['^.*'],
+            },
+        },
+        'processor': {
+            'type': 'FileFilter',
+            'kwargs': {
+                'filter_files': [str(filter_file)],
+            },
+        },
+        'upload': {
+            'type': 'PrependTargetUploader',
+        },
+        'inject_sboms': True,
+    }
+
+    pipeline = process_dependencies.processing_pipeline(cfg)
+    assert pipeline._inject_sboms is True


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Wire `inject_sboms: true` from `processing.cfg` into `ProcessingPipeline`.
The flag was silently ignored because `processing_pipeline()` never read it.
Also strips stale SBOM/CBOM resources from the target component descriptor
before appending freshly injected ones (handles re-processing scenarios).

**Release note**:
```bugfix operator
ctt: fix silently ignored `inject_sboms: true` in processing.cfg — wire the
flag into ProcessingPipeline and strip stale SBOM/CBOM resources before
re-injection.
```