### PR TITLE
ctt: fix duplicate resources for diamond component-reference graphs

### DIFF
--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -356,8 +356,20 @@ def determine_changed_components(
     component_filter: collections.abc.Callable[[ocm.Component], bool]=None,
     reftype_filter: collections.abc.Callable[[ocm.iter.NodeReferenceType], bool]=None,
     pruning_mode: PruningMode=PruningMode.PRUNE_SUBTREES,
+    _visited: set[ocm.ComponentIdentity] | None=None,
 ) -> collections.abc.Generator[ocm.ComponentDescriptor, None, None]:
     component = component_descriptor.component
+
+    # the component-reference graph is not necessarily a tree (diamond dependencies, where the
+    # same component is referenced via more than one path, are common) - without this guard, a
+    # shared component would be yielded once per path leading to it, which in turn causes its
+    # resources (e.g. injected SBOM/CBOM resources) to be processed - and appended - more than
+    # once downstream, resulting in duplicate OCM resource identities.
+    if _visited is None:
+        _visited = set()
+    if component.identity() in _visited:
+        return
+    _visited.add(component.identity())
 
     if component_filter and component_filter(component):
         return
@@ -389,6 +401,7 @@ def determine_changed_components(
             component_filter=component_filter,
             reftype_filter=reftype_filter,
             pruning_mode=pruning_mode,
+            _visited=_visited,
         )
 
     if not (
@@ -412,6 +425,7 @@ def determine_changed_components(
                 component_filter=component_filter,
                 reftype_filter=reftype_filter,
                 pruning_mode=pruning_mode,
+                _visited=_visited,
             )
 
     yield component_descriptor

--- a/ctt/test/process_deps_test.py
+++ b/ctt/test/process_deps_test.py
@@ -205,6 +205,80 @@ def test_identity_version_fallback_with_version_in_extra_identity():
     )
 
 
+def _fake_component_descriptor(name, version, component_references=None):
+    return ocm.ComponentDescriptor(
+        meta=ocm.Metadata(),
+        component=ocm.Component(
+            name=name,
+            version=version,
+            repositoryContexts=[],
+            provider='sap',
+            sources=[],
+            componentReferences=component_references or [],
+            resources=[],
+        ),
+    )
+
+
+def test_determine_changed_components_diamond_dependency_visited_once():
+    '''
+    root -> a, b; a -> c; b -> c. Without de-duplication, "c" would be yielded twice
+    (once via "a", once via "b"), causing its resources (e.g. injected SBOM/CBOM
+    resources) to be processed - and appended - more than once downstream. This is the
+    scenario that caused the "Dev Release" testmachinery failure with duplicate
+    "etcdbrctl" SBOM/CBOM resources (github.com/gardener/etcd-backup-restore:v0.44.1).
+    '''
+    component_c = _fake_component_descriptor('example.org/c', '1.0')
+    component_a = _fake_component_descriptor(
+        'example.org/a',
+        '1.0',
+        component_references=[
+            ocm.ComponentReference(name='c', componentName='example.org/c', version='1.0'),
+        ],
+    )
+    component_b = _fake_component_descriptor(
+        'example.org/b',
+        '1.0',
+        component_references=[
+            ocm.ComponentReference(name='c', componentName='example.org/c', version='1.0'),
+        ],
+    )
+    component_root = _fake_component_descriptor(
+        'example.org/root',
+        '1.0',
+        component_references=[
+            ocm.ComponentReference(name='a', componentName='example.org/a', version='1.0'),
+            ocm.ComponentReference(name='b', componentName='example.org/b', version='1.0'),
+        ],
+    )
+
+    component_descriptors_by_id = {
+        component_a.component.identity(): component_a,
+        component_b.component.identity(): component_b,
+        component_c.component.identity(): component_c,
+    }
+
+    def component_descriptor_lookup(component_id):
+        return component_descriptors_by_id[component_id]
+
+    def tgt_component_descriptor_lookup(component_id, absent_ok=False):
+        return None
+
+    changed_components = list(process_dependencies.determine_changed_components(
+        component_descriptor=component_root,
+        tgt_ocm_repo_url='registry.example.com',
+        component_descriptor_lookup=component_descriptor_lookup,
+        tgt_component_descriptor_lookup=tgt_component_descriptor_lookup,
+        pruning_mode=process_dependencies.PruningMode.REPLICATE_ALL,
+    ))
+
+    identities = [cd.component.identity() for cd in changed_components]
+    assert len(identities) == len(set(identities)), (
+        f'expected each component to be yielded once, got: {identities}'
+    )
+    assert component_c.component.identity() in identities
+
+
 def test_inject_sboms_flag_propagates_to_rre(tmpdir):
     '''
     inject_sboms: true in processing_cfg must cause ProcessingPipeline.process to set


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

`determine_changed_components()` did not de-duplicate visited components. In a
diamond dependency graph (a component reachable via more than one path), the
same shared component was yielded once per path, causing its resources (e.g.
injected SBOM/CBOM resources) to be processed and appended more than once,
resulting in duplicate OCM resource identities in the replicated component
descriptor.

Fixes this by tracking visited component identities and skipping components
already yielded during the recursive traversal.

**Release note**:
```other operator
fix(ctt): avoid duplicate resources when replicating diamond component-reference graphs
```