### PR TITLE
Transparent OIDC token refresh for long-running OCI workflows

### DIFF
--- a/.github/actions/oci-auth/oidc.py
+++ b/.github/actions/oci-auth/oidc.py
@@ -9,6 +9,7 @@ import dacite
 import requests
 import yaml
 
+import oci.auth
 import oci.model
 
 own_dir = os.path.dirname(__file__)
@@ -322,54 +323,14 @@ def authenticate_against_gar(
     '''
     See https://github.com/google-github-actions/auth for reference.
     '''
-    session = requests.Session()
-
-    res = _fetch_with_retries(
-        url=f'{gh_token_url}&audience={oidc_cfg.audience}',
-        session=session,
-        headers={
-            'Authorization': f'Bearer {gh_token}',
-        },
+    access_token = oci.auth.exchange_gar_token(
+        oidc_cfg=oidc_cfg,
+        gh_token=gh_token,
+        gh_token_url=gh_token_url,
+        lifetime_seconds=lifetime_seconds,
     )
-    gh_oidc_token = res.json()['value']
-
-    body = {
-        'audience': oidc_cfg.audience,
-        'grantType': 'urn:ietf:params:oauth:grant-type:token-exchange',
-        'requestedTokenType': 'urn:ietf:params:oauth:token-type:access_token',
-        'scope': 'https://www.googleapis.com/auth/cloud-platform',
-        'subjectTokenType': 'urn:ietf:params:oauth:token-type:jwt',
-        'subjectToken': gh_oidc_token,
-    }
-    res = _fetch_with_retries(
-        url='https://sts.googleapis.com/v1/token',
-        session=session,
-        method='POST',
-        json=body,
-    )
-    auth_token = res.json()['access_token']
-
-    gar_access_token_url = (
-        'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/'
-        f'{oidc_cfg.service_account}:generateAccessToken'
-    )
-    body = {
-        'scope': 'https://www.googleapis.com/auth/cloud-platform',
-        'lifetime': f'{lifetime_seconds}s',
-    }
-    res = _fetch_with_retries(
-        url=gar_access_token_url,
-        session=session,
-        method='POST',
-        json=body,
-        headers={
-            'Authorization': f'Bearer {auth_token}',
-        },
-    )
-    access_token = res.json()['accessToken']
 
     username = 'oauth2accesstoken'
-
     token = base64.b64encode(f'{username}:{access_token}'.encode()).decode()
 
     return {

--- a/oci/auth.py
+++ b/oci/auth.py
@@ -8,6 +8,10 @@ import operator
 import os
 import shutil
 import subprocess
+import threading
+import time
+
+import requests
 
 import oci.util
 
@@ -379,3 +383,126 @@ def docker_credentials_lookup(
         return None
 
     return docker_auth_lookup
+
+
+def exchange_gar_token(
+    oidc_cfg,
+    gh_token: str,
+    gh_token_url: str,
+    lifetime_seconds: int=3600,
+) -> str:
+    '''
+    Exchange a GitHub OIDC token for a GAR/GCR access token via GCP STS and IAM.
+
+    oidc_cfg must have .audience and .service_account attributes
+    (compatible with GarOidcConfiguration from .github/actions/oci-auth/oidc.py).
+
+    Returns the raw GAR access token string.
+    '''
+    session = requests.Session()
+
+    def _fetch(url, method='GET', json_body=None, headers=None, remaining=3):
+        res = session.request(
+            method=method,
+            url=url,
+            json=json_body,
+            headers=headers,
+        )
+        if not res.ok and remaining > 0:
+            return _fetch(url, method, json_body, headers, remaining - 1)
+        res.raise_for_status()
+        return res
+
+    res = _fetch(
+        url=f'{gh_token_url}&audience={oidc_cfg.audience}',
+        headers={'Authorization': f'Bearer {gh_token}'},
+    )
+    gh_oidc_token = res.json()['value']
+
+    res = _fetch(
+        url='https://sts.googleapis.com/v1/token',
+        method='POST',
+        json_body={
+            'audience': oidc_cfg.audience,
+            'grantType': 'urn:ietf:params:oauth:grant-type:token-exchange',
+            'requestedTokenType': 'urn:ietf:params:oauth:token-type:access_token',
+            'scope': 'https://www.googleapis.com/auth/cloud-platform',
+            'subjectTokenType': 'urn:ietf:params:oauth:token-type:jwt',
+            'subjectToken': gh_oidc_token,
+        },
+    )
+    sts_token = res.json()['access_token']
+
+    res = _fetch(
+        url=(
+            'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/'
+            f'{oidc_cfg.service_account}:generateAccessToken'
+        ),
+        method='POST',
+        json_body={
+            'scope': 'https://www.googleapis.com/auth/cloud-platform',
+            'lifetime': f'{lifetime_seconds}s',
+        },
+        headers={'Authorization': f'Bearer {sts_token}'},
+    )
+    return res.json()['accessToken']
+
+
+class _RefreshableGarCredentialsLookup:
+    def __init__(self, oidc_cfg, prefetch_margin_seconds: int=300):
+        self._oidc_cfg = oidc_cfg
+        self._prefetch_margin_seconds = prefetch_margin_seconds
+        self._token: str | None = None
+        self._expires_at: float = 0.0  # time.monotonic() timestamp
+        self._lock = threading.Lock()
+
+    def _needs_refresh(self) -> bool:
+        return (
+            self._token is None
+            or time.monotonic() >= self._expires_at - self._prefetch_margin_seconds
+        )
+
+    def _refresh(self):
+        # caller must hold _lock
+        gh_token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+        gh_token_url = os.environ['ACTIONS_ID_TOKEN_REQUEST_URL']
+        self._token = exchange_gar_token(
+            oidc_cfg=self._oidc_cfg,
+            gh_token=gh_token,
+            gh_token_url=gh_token_url,
+        )
+        # exchange_gar_token requests a 3600 s token by default
+        self._expires_at = time.monotonic() + 3600
+
+    def invalidate_cache(self):
+        with self._lock:
+            self._token = None
+            self._expires_at = 0.0
+
+    def __call__(
+        self,
+        image_reference: str,
+        privileges: 'Privileges'=None,
+        absent_ok: bool=False,
+    ) -> OciBasicAuthCredentials | None:
+        import oci.model as om
+        ref = om.OciImageReference(image_reference)
+        if ref.registry_type not in (om.OciRegistryType.GAR, om.OciRegistryType.GCR):
+            return None
+
+        with self._lock:
+            if self._needs_refresh():
+                self._refresh()
+            token = self._token
+
+        return OciBasicAuthCredentials(username='oauth2accesstoken', password=token)
+
+
+def make_refreshable_gar_credentials_lookup(
+    oidc_cfg,
+    prefetch_margin_seconds: int=300,
+) -> _RefreshableGarCredentialsLookup:
+    return _RefreshableGarCredentialsLookup(
+        oidc_cfg=oidc_cfg,
+        prefetch_margin_seconds=prefetch_margin_seconds,
+    )

--- a/oci/client.py
+++ b/oci/client.py
@@ -358,6 +358,32 @@ def client_with_dockerauth(
     )
 
 
+def client_with_gar_oidc_auth(
+    oidc_cfg,
+    http_connection_pool_size: int=10,
+) -> 'Client':
+    '''
+    Creates an oci.client.Client that authenticates against GAR/GCR using a refreshable
+    OIDC-based credentials lookup.  On each credentials call the lookup checks whether
+    the cached GAR access token is within prefetch_margin_seconds of expiry and, if so,
+    transparently re-runs the OIDC exchange before returning credentials.
+
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL must be set in the
+    environment at the time credentials are first needed (and at each subsequent refresh).
+    '''
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(
+        pool_connections=http_connection_pool_size,
+        pool_maxsize=http_connection_pool_size,
+    )
+    session.mount('https://', adapter)
+
+    return Client(
+        credentials_lookup=oa.make_refreshable_gar_credentials_lookup(oidc_cfg=oidc_cfg),
+        session=session,
+    )
+
+
 class _PerHostThrottle:
     '''
     Adaptive per-host concurrency gate (AIMD) with rate-limit awareness.
@@ -535,6 +561,7 @@ class Client:
         scope: str,
         remaining_retries: int=None,
         sleep_before_retry_seconds: float=None,
+        _gar_refreshed: bool=False,
     ):
         if remaining_retries is None:
             remaining_retries = self.max_retries
@@ -675,6 +702,21 @@ class Client:
                     scope=scope,
                     remaining_retries=remaining_retries - 1,
                     sleep_before_retry_seconds=sleep_before_retry_seconds * 2,
+                )
+
+            if (
+                res.status_code == 401
+                and not _gar_refreshed
+                and hasattr(self.credentials_lookup, 'invalidate_cache')
+            ):
+                logger.warning('bearer realm 401 - invalidating cached GAR token and retrying')
+                self.credentials_lookup.invalidate_cache()
+                return self._authenticate(
+                    image_reference=image_reference,
+                    scope=scope,
+                    remaining_retries=remaining_retries,
+                    sleep_before_retry_seconds=sleep_before_retry_seconds,
+                    _gar_refreshed=True,
                 )
 
         res.raise_for_status()

--- a/test/oci/gar_refresh_test.py
+++ b/test/oci/gar_refresh_test.py
@@ -1,0 +1,225 @@
+import datetime
+import threading
+import time
+import unittest.mock
+
+import oci.auth as oa
+import oci.client as oc
+
+
+class _FakeOidcCfg:
+    audience = '//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/p'
+    service_account = 'sa@project.iam.gserviceaccount.com'
+
+
+_GAR_REF = 'europe-docker.pkg.dev/project/repo/image:tag'
+_OTHER_REF = 'docker.io/library/alpine:3'
+
+
+# --- make_refreshable_gar_credentials_lookup ---------------------------------
+
+def test_refreshable_lookup_returns_creds_for_gar(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    monkeypatch.setattr(oa, 'exchange_gar_token', lambda **_: 'token-A')
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    creds = lookup(image_reference=_GAR_REF, absent_ok=True)
+
+    assert isinstance(creds, oa.OciBasicAuthCredentials)
+    assert creds.username == 'oauth2accesstoken'
+    assert creds.password == 'token-A'
+
+
+def test_refreshable_lookup_returns_none_for_non_gar(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    monkeypatch.setattr(oa, 'exchange_gar_token', lambda **_: 'token-A')
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    creds = lookup(image_reference=_OTHER_REF, absent_ok=True)
+
+    assert creds is None
+
+
+def test_refreshable_lookup_no_refetch_while_valid(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    call_count = {'n': 0}
+
+    def fake_exchange(**_):
+        call_count['n'] += 1
+        return 'token-A'
+
+    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    lookup(image_reference=_GAR_REF)
+    lookup(image_reference=_GAR_REF)
+
+    assert call_count['n'] == 1
+
+
+def test_refreshable_lookup_refetches_after_margin(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    call_count = {'n': 0}
+    tokens = ['token-A', 'token-B']
+
+    def fake_exchange(**_):
+        t = tokens[call_count['n']]
+        call_count['n'] += 1
+        return t
+
+    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
+
+    # use a large margin so the token is always "near-expiry" after first fetch
+    lookup = oa.make_refreshable_gar_credentials_lookup(
+        oidc_cfg=_FakeOidcCfg(),
+        prefetch_margin_seconds=7200,  # > 3600 s token lifetime → always needs refresh
+    )
+
+    c1 = lookup(image_reference=_GAR_REF)
+    c2 = lookup(image_reference=_GAR_REF)
+
+    assert call_count['n'] == 2
+    assert c1.password == 'token-A'
+    assert c2.password == 'token-B'
+
+
+def test_refreshable_lookup_invalidate_cache(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    call_count = {'n': 0}
+
+    def fake_exchange(**_):
+        call_count['n'] += 1
+        return f'token-{call_count["n"]}'
+
+    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    c1 = lookup(image_reference=_GAR_REF)
+    lookup.invalidate_cache()
+    c2 = lookup(image_reference=_GAR_REF)
+
+    assert call_count['n'] == 2
+    assert c1.password == 'token-1'
+    assert c2.password == 'token-2'
+
+
+def test_refreshable_lookup_concurrent_single_fetch(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    call_count = {'n': 0}
+
+    def slow_exchange(**_):
+        time.sleep(0.05)
+        call_count['n'] += 1
+        return 'token-shared'
+
+    monkeypatch.setattr(oa, 'exchange_gar_token', slow_exchange)
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            creds = lookup(image_reference=_GAR_REF)
+            results.append(creds.password)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert all(r == 'token-shared' for r in results)
+    assert call_count['n'] == 1
+
+
+# --- _authenticate 401 retry -------------------------------------------------
+
+def _make_mock_session(responses):
+    '''responses: list of (status_code, json_dict) applied in order'''
+    session = unittest.mock.MagicMock()
+    side_effects = []
+    for status, body in responses:
+        r = unittest.mock.MagicMock()
+        r.ok = status < 400
+        r.status_code = status
+        r.reason = 'OK' if status < 400 else 'Unauthorized'
+        r.content = b''
+        r.headers = {
+            'www-authenticate': (
+                'Bearer realm="https://auth.example.com/token",'
+                'service="registry.example.com",'
+                'scope="repository:foo:pull"'
+            ),
+        }
+        r.json.return_value = body
+        side_effects.append(r)
+    session.get.side_effect = side_effects
+    return session
+
+
+def test_authenticate_401_triggers_invalidate_and_retry(monkeypatch):
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+
+    exchange_calls = {'n': 0}
+    tokens = ['token-stale', 'token-fresh']
+
+    def fake_exchange(**_):
+        t = tokens[exchange_calls['n']]
+        exchange_calls['n'] += 1
+        return t
+
+    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
+
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+
+    # /v2/ probe → bearer challenge
+    probe_resp = unittest.mock.MagicMock()
+    probe_resp.ok = True
+    probe_resp.headers = {
+        'www-authenticate': (
+            'Bearer realm="https://auth.example.com/token",'
+            'service="registry.example.com"'
+        ),
+    }
+
+    # first bearer-realm call → 401 (stale token)
+    auth_401 = unittest.mock.MagicMock()
+    auth_401.ok = False
+    auth_401.status_code = 401
+    auth_401.reason = 'Unauthorized'
+    auth_401.content = b'unauthorized'
+
+    # second bearer-realm call → 200 (fresh token)
+    valid_token_resp = unittest.mock.MagicMock()
+    valid_token_resp.ok = True
+    valid_token_resp.status_code = 200
+    valid_token_resp.json.return_value = {
+        'token': 'oci-bearer-token',
+        'expires_in': 3600,
+        'issued_at': datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+        'scope': 'repository:project/repo/image:pull',
+    }
+
+    session = unittest.mock.MagicMock()
+    # sequence: probe, auth-with-stale, probe-again, auth-with-fresh
+    session.get.side_effect = [probe_resp, auth_401, probe_resp, valid_token_resp]
+
+    client = oc.Client(credentials_lookup=lookup, session=session)
+
+    client._authenticate(
+        image_reference=_GAR_REF,
+        scope='repository:project/repo/image:pull',
+    )
+
+    assert exchange_calls['n'] == 2


### PR DESCRIPTION
## Summary

- Adds a 3-step OIDC exchange (GitHub OIDC -> GCP STS -> IAM generateAccessToken) in
  `oci/auth.py::exchange_gar_token()` with retry.
- Adds `_RefreshableGarCredentialsLookup` (lock-protected, expiry-aware token cache) and
  `make_refreshable_gar_credentials_lookup()`.
- `oci.client.Client._authenticate` now retries once on 401 when the credentials lookup
  supports `invalidate_cache()`, and a `client_with_gar_oidc_auth()` factory is added.
- `.github/actions/oci-auth/oidc.py::authenticate_against_gar` delegates to the new
  `oci.auth.exchange_gar_token()` (signature unchanged).

Fixes token expiry failures in long-running OCI workflows that previously required
re-authenticating from scratch.

## Test plan

- [x] `test/oci/gar_refresh_test.py` (7 new tests, 15/15 OCI tests pass)