### PR TITLE
Decouple GAR-OIDC auth from GitHub-Actions specifics

### DIFF
--- a/.github/actions/oci-auth/action.yaml
+++ b/.github/actions/oci-auth/action.yaml
@@ -52,6 +52,13 @@ outputs:
     description: |
       the path to which docker-cfg was written. Defaults to $HOME/.docker/config.json
     value: ${{ steps.oci-auth.outputs.docker-cfg-path }}
+  oidc-cfgs:
+    description: |
+      JSON mapping of GAR/GCR registry-host -> resolved GAR OIDC configuration
+      (`{"audience": ..., "service_account": ...}`, matching oci.auth.GarOidcConfiguration).
+      Allows subsequent steps to build a refreshable GAR credentials-lookup (e.g. via
+      oci.auth.refreshable_gar_credentials_lookup) without re-resolving the config.
+    value: ${{ steps.oci-auth.outputs.oidc-cfgs }}
 
 runs:
   using: composite
@@ -100,6 +107,11 @@ runs:
           extra_auths=extra_auths,
         )
 
+        oidc_cfgs = oidc.export_gar_oidc_cfgs(
+          image_references=image_references,
+        )
+
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
           f.write(f'docker-cfg={json.dumps(docker_cfg)}\n')
           f.write(f'docker-cfg-path={docker_cfg_path}\n')
+          f.write(f'oidc-cfgs={json.dumps(oidc_cfgs)}\n')

--- a/.github/actions/oci-auth/oidc.py
+++ b/.github/actions/oci-auth/oidc.py
@@ -314,6 +314,28 @@ def authenticate_against_azure(
     }
 
 
+def fetch_github_oidc_token(
+    gh_token: str,
+    gh_token_url: str,
+    audience: str,
+    session: requests.Session | None=None,
+) -> str:
+    '''
+    Fetch a GitHub Actions OIDC token (JWT) for the given audience from GitHub's
+    id-token endpoint (ACTIONS_ID_TOKEN_REQUEST_URL / _TOKEN).
+    '''
+    session = session or requests.Session()
+
+    res = _fetch_with_retries(
+        url=f'{gh_token_url}&audience={audience}',
+        session=session,
+        headers={
+            'Authorization': f'Bearer {gh_token}',
+        },
+    )
+    return res.json()['value']
+
+
 def authenticate_against_gar(
     oidc_cfg: GarOidcConfiguration,
     gh_token: str,
@@ -323,10 +345,15 @@ def authenticate_against_gar(
     '''
     See https://github.com/google-github-actions/auth for reference.
     '''
-    access_token = oci.auth.exchange_gar_token(
-        oidc_cfg=oidc_cfg,
+    subject_token = fetch_github_oidc_token(
         gh_token=gh_token,
         gh_token_url=gh_token_url,
+        audience=oidc_cfg.audience,
+    )
+
+    access_token = oci.auth.exchange_gar_token(
+        oidc_cfg=oidc_cfg,
+        subject_token=subject_token,
         lifetime_seconds=lifetime_seconds,
     )
 
@@ -443,3 +470,70 @@ def write_docker_config(
         json.dump(docker_cfg, file)
 
     return docker_cfg
+
+
+def exportable_gar_oidc_cfg(
+    oidc_cfg: GarOidcConfiguration,
+) -> oci.auth.GarOidcConfiguration:
+    '''
+    Project the action's GarOidcConfiguration (which derives `audience` from its project /
+    identity-pool attributes) onto oci.auth.GarOidcConfiguration, i.e. the portable, JSON-
+    serialisable form consumable by oci.auth.refreshable_gar_credentials_lookup.
+    '''
+    return oci.auth.GarOidcConfiguration(
+        audience=oidc_cfg.audience,
+        service_account=oidc_cfg.service_account,
+    )
+
+
+def export_gar_oidc_cfgs(
+    image_references: collections.abc.Iterable[str],
+) -> dict[str, dict]:
+    '''
+    Resolve the matching GAR OIDC cfg for each passed-in GAR/GCR image-reference and return a
+    mapping of registry-host -> oci.auth.GarOidcConfiguration (as dict), suitable for exporting
+    as an action output. Non-GAR/GCR image-references, and hosts without a match, are omitted.
+    '''
+    cfgs: dict[str, dict] = {}
+
+    for image_reference in image_references:
+        image_reference = oci.model.OciImageReference(image_reference)
+
+        if image_reference.registry_type not in (
+            oci.model.OciRegistryType.GAR,
+            oci.model.OciRegistryType.GCR,
+        ):
+            continue
+
+        oidc_cfg = find_oidc_cfg(image_reference=image_reference)
+        cfgs[image_reference.netloc] = dataclasses.asdict(
+            exportable_gar_oidc_cfg(oidc_cfg=oidc_cfg),
+        )
+
+    return cfgs
+
+
+def refreshable_gar_credentials_lookup(
+    oidc_cfg: GarOidcConfiguration,
+    prefetch_margin_seconds: int=300,
+):
+    '''
+    Build an oci.auth.refreshable_gar_credentials_lookup for GitHub Actions: the OIDC
+    subject-token is re-fetched from GitHub's id-token endpoint (ACTIONS_ID_TOKEN_REQUEST_URL /
+    _TOKEN) on each refresh.
+
+    The lookup exposes `invalidate_cache`, to be passed as oci.client.Client's
+    `credentials_invalidate`.
+    '''
+    def subject_token_supplier() -> str:
+        return fetch_github_oidc_token(
+            gh_token=os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN'],
+            gh_token_url=os.environ['ACTIONS_ID_TOKEN_REQUEST_URL'],
+            audience=oidc_cfg.audience,
+        )
+
+    return oci.auth.refreshable_gar_credentials_lookup(
+        oidc_cfg=exportable_gar_oidc_cfg(oidc_cfg=oidc_cfg),
+        subject_token_supplier=subject_token_supplier,
+        prefetch_margin_seconds=prefetch_margin_seconds,
+    )

--- a/oci/auth.py
+++ b/oci/auth.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import threading
 import time
+import warnings
 
 import requests
 
@@ -385,21 +386,57 @@ def docker_credentials_lookup(
     return docker_auth_lookup
 
 
+@dataclasses.dataclass(frozen=True)
+class GarOidcConfiguration:
+    '''
+    Configuration for OIDC-based authentication against Google Artifact Registry (GAR) / GCR.
+
+    Registry- and identity-provider-specific, but free of any CI-/GitHub-Actions specifics.
+    `audience` identifies the workload-identity-provider, `service_account` the GCP service
+    account to impersonate.
+    '''
+    audience: str
+    service_account: str
+
+
 def exchange_gar_token(
-    oidc_cfg,
-    gh_token: str,
-    gh_token_url: str,
+    oidc_cfg: GarOidcConfiguration,
+    subject_token: str | None=None,
     lifetime_seconds: int=3600,
+    gh_token: str | None=None,
+    gh_token_url: str | None=None,
 ) -> str:
     '''
-    Exchange a GitHub OIDC token for a GAR/GCR access token via GCP STS and IAM.
+    Exchange an OIDC subject-token for a GAR/GCR access token via GCP STS token-exchange followed
+    by service-account impersonation (IAM `generateAccessToken`).
 
-    oidc_cfg must have .audience and .service_account attributes
-    (compatible with GarOidcConfiguration from .github/actions/oci-auth/oidc.py).
+    `subject_token` is the already-acquired OIDC JWT of the calling workload; how it is obtained
+    is the caller's concern (no CI-environment specifics are read here). Returns the raw GAR
+    access token string.
 
-    Returns the raw GAR access token string.
+    DEPRECATED compatibility: `gh_token`/`gh_token_url` (GitHub Actions id-token credentials) may
+    be passed instead of `subject_token`, in which case the subject-token is fetched from GitHub's
+    id-token endpoint. This path exists only to tolerate action/library version skew during
+    rollout (composite actions are resolved `@master`); it will be removed once consumers pin the
+    oci-auth action to a released ref.
     '''
     session = requests.Session()
+
+    if subject_token is None:
+        if not (gh_token and gh_token_url):
+            raise ValueError('either subject_token or gh_token/gh_token_url must be passed')
+        warnings.warn(
+            'exchange_gar_token(gh_token=..., gh_token_url=...) is deprecated - pass an '
+            'explicitly obtained OIDC subject_token instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        res = session.get(
+            url=f'{gh_token_url}&audience={oidc_cfg.audience}',
+            headers={'Authorization': f'Bearer {gh_token}'},
+        )
+        res.raise_for_status()
+        subject_token = res.json()['value']
 
     def _fetch(url, method='GET', json_body=None, headers=None, remaining=3):
         res = session.request(
@@ -414,12 +451,6 @@ def exchange_gar_token(
         return res
 
     res = _fetch(
-        url=f'{gh_token_url}&audience={oidc_cfg.audience}',
-        headers={'Authorization': f'Bearer {gh_token}'},
-    )
-    gh_oidc_token = res.json()['value']
-
-    res = _fetch(
         url='https://sts.googleapis.com/v1/token',
         method='POST',
         json_body={
@@ -428,7 +459,7 @@ def exchange_gar_token(
             'requestedTokenType': 'urn:ietf:params:oauth:token-type:access_token',
             'scope': 'https://www.googleapis.com/auth/cloud-platform',
             'subjectTokenType': 'urn:ietf:params:oauth:token-type:jwt',
-            'subjectToken': gh_oidc_token,
+            'subjectToken': subject_token,
         },
     )
     sts_token = res.json()['access_token']
@@ -449,8 +480,24 @@ def exchange_gar_token(
 
 
 class _RefreshableGarCredentialsLookup:
-    def __init__(self, oidc_cfg, prefetch_margin_seconds: int=300):
+    '''
+    Credentials-lookup that yields a GAR/GCR access token, transparently re-running the
+    OIDC exchange shortly before the cached token expires.
+
+    `subject_token_supplier` is a zero-arg callable returning a fresh OIDC subject-token; all
+    environment-/CI-specifics live behind it. `invalidate_cache` force-expires the cached token
+    (used by oci.client on 401 to retry once with a fresh token).
+    '''
+    def __init__(
+        self,
+        oidc_cfg: GarOidcConfiguration,
+        subject_token_supplier: collections.abc.Callable[[], str],
+        lifetime_seconds: int=3600,
+        prefetch_margin_seconds: int=300,
+    ):
         self._oidc_cfg = oidc_cfg
+        self._subject_token_supplier = subject_token_supplier
+        self._lifetime_seconds = lifetime_seconds
         self._prefetch_margin_seconds = prefetch_margin_seconds
         self._token: str | None = None
         self._expires_at: float = 0.0  # time.monotonic() timestamp
@@ -464,15 +511,12 @@ class _RefreshableGarCredentialsLookup:
 
     def _refresh(self):
         # caller must hold _lock
-        gh_token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
-        gh_token_url = os.environ['ACTIONS_ID_TOKEN_REQUEST_URL']
         self._token = exchange_gar_token(
             oidc_cfg=self._oidc_cfg,
-            gh_token=gh_token,
-            gh_token_url=gh_token_url,
+            subject_token=self._subject_token_supplier(),
+            lifetime_seconds=self._lifetime_seconds,
         )
-        # exchange_gar_token requests a 3600 s token by default
-        self._expires_at = time.monotonic() + 3600
+        self._expires_at = time.monotonic() + self._lifetime_seconds
 
     def invalidate_cache(self):
         with self._lock:
@@ -498,11 +542,52 @@ class _RefreshableGarCredentialsLookup:
         return OciBasicAuthCredentials(username='oauth2accesstoken', password=token)
 
 
-def make_refreshable_gar_credentials_lookup(
-    oidc_cfg,
+def refreshable_gar_credentials_lookup(
+    oidc_cfg: GarOidcConfiguration,
+    subject_token_supplier: collections.abc.Callable[[], str],
+    lifetime_seconds: int=3600,
     prefetch_margin_seconds: int=300,
 ) -> _RefreshableGarCredentialsLookup:
     return _RefreshableGarCredentialsLookup(
         oidc_cfg=oidc_cfg,
+        subject_token_supplier=subject_token_supplier,
+        lifetime_seconds=lifetime_seconds,
+        prefetch_margin_seconds=prefetch_margin_seconds,
+    )
+
+
+def make_refreshable_gar_credentials_lookup(
+    oidc_cfg: GarOidcConfiguration,
+    prefetch_margin_seconds: int=300,
+) -> _RefreshableGarCredentialsLookup:
+    '''
+    DEPRECATED — kept for backwards-compatibility. Reads GitHub Actions'
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN / ACTIONS_ID_TOKEN_REQUEST_URL from the environment.
+    Use `refreshable_gar_credentials_lookup` with an explicit `subject_token_supplier` instead.
+    '''
+    warnings.warn(
+        'oci.auth.make_refreshable_gar_credentials_lookup is deprecated - use '
+        'oci.auth.refreshable_gar_credentials_lookup with an explicit subject_token_supplier',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    def _subject_token_supplier() -> str:
+        session = requests.Session()
+        res = session.get(
+            url=(
+                f'{os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"]}'
+                f'&audience={oidc_cfg.audience}'
+            ),
+            headers={
+                'Authorization': f'Bearer {os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]}',
+            },
+        )
+        res.raise_for_status()
+        return res.json()['value']
+
+    return _RefreshableGarCredentialsLookup(
+        oidc_cfg=oidc_cfg,
+        subject_token_supplier=_subject_token_supplier,
         prefetch_margin_seconds=prefetch_margin_seconds,
     )

--- a/oci/client.py
+++ b/oci/client.py
@@ -363,13 +363,16 @@ def client_with_gar_oidc_auth(
     http_connection_pool_size: int=10,
 ) -> 'Client':
     '''
-    Creates an oci.client.Client that authenticates against GAR/GCR using a refreshable
-    OIDC-based credentials lookup.  On each credentials call the lookup checks whether
-    the cached GAR access token is within prefetch_margin_seconds of expiry and, if so,
-    transparently re-runs the OIDC exchange before returning credentials.
+    DEPRECATED — kept for backwards-compatibility. Reads GitHub Actions'
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN / ACTIONS_ID_TOKEN_REQUEST_URL from the environment (via
+    oci.auth.make_refreshable_gar_credentials_lookup). Prefer constructing the Client directly
+    with a credentials_lookup obtained from oci.auth.refreshable_gar_credentials_lookup and an
+    explicit subject-token-supplier, passing its `invalidate_cache` as credentials_invalidate.
 
-    ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL must be set in the
-    environment at the time credentials are first needed (and at each subsequent refresh).
+    Creates an oci.client.Client that authenticates against GAR/GCR using a refreshable
+    OIDC-based credentials lookup. On each credentials call the lookup checks whether the cached
+    GAR access token is within prefetch_margin_seconds of expiry and, if so, transparently
+    re-runs the OIDC exchange before returning credentials.
     '''
     session = requests.Session()
     adapter = requests.adapters.HTTPAdapter(
@@ -378,8 +381,11 @@ def client_with_gar_oidc_auth(
     )
     session.mount('https://', adapter)
 
+    credentials_lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=oidc_cfg)
+
     return Client(
-        credentials_lookup=oa.make_refreshable_gar_credentials_lookup(oidc_cfg=oidc_cfg),
+        credentials_lookup=credentials_lookup,
+        credentials_invalidate=credentials_lookup.invalidate_cache,
         session=session,
     )
 
@@ -449,6 +455,7 @@ class Client:
     def __init__(
         self,
         credentials_lookup: collections.abc.Callable=no_credentials_lookup,
+        credentials_invalidate: collections.abc.Callable[[], None]=None,
         routes: OciRoutes=OciRoutes(),
         disable_tls_validation: bool=False,
         timeout_seconds: int=None,
@@ -464,6 +471,9 @@ class Client:
         '''
         :param Callable credentials_lookup:
             defaults to no credentials, leading to anonymous-auth attempt
+        :param Callable credentials_invalidate:
+            optional, invoked to drop any cached credentials before one retry upon a 401 from the
+            bearer-realm (e.g. for refreshable credentials whose cached token expired prematurely)
         :param OciRoutes routes:
         :param bool disable_tls_validation:
         :param int timeout_seconds:
@@ -491,6 +501,7 @@ class Client:
             read concurrency.
         '''
         self.credentials_lookup = credentials_lookup
+        self.credentials_invalidate = credentials_invalidate
         self.token_cache = OauthTokenCache()
         if not session:
             self.session = requests.Session()
@@ -561,7 +572,7 @@ class Client:
         scope: str,
         remaining_retries: int=None,
         sleep_before_retry_seconds: float=None,
-        _gar_refreshed: bool=False,
+        _credentials_refreshed: bool=False,
     ):
         if remaining_retries is None:
             remaining_retries = self.max_retries
@@ -706,17 +717,17 @@ class Client:
 
             if (
                 res.status_code == 401
-                and not _gar_refreshed
-                and hasattr(self.credentials_lookup, 'invalidate_cache')
+                and not _credentials_refreshed
+                and self.credentials_invalidate
             ):
-                logger.warning('bearer realm 401 - invalidating cached GAR token and retrying')
-                self.credentials_lookup.invalidate_cache()
+                logger.warning('bearer realm 401 - invalidating cached credentials and retrying')
+                self.credentials_invalidate()
                 return self._authenticate(
                     image_reference=image_reference,
                     scope=scope,
                     remaining_retries=remaining_retries,
                     sleep_before_retry_seconds=sleep_before_retry_seconds,
-                    _gar_refreshed=True,
+                    _credentials_refreshed=True,
                 )
 
         res.raise_for_status()

--- a/test/oci/gar_refresh_test.py
+++ b/test/oci/gar_refresh_test.py
@@ -6,24 +6,42 @@ import unittest.mock
 import oci.auth as oa
 import oci.client as oc
 
-
-class _FakeOidcCfg:
-    audience = '//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/p'
-    service_account = 'sa@project.iam.gserviceaccount.com'
-
+_GAR_OID_CFG = oa.GarOidcConfiguration(
+    audience='//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/p',
+    service_account='sa@project.iam.gserviceaccount.com',
+)
 
 _GAR_REF = 'europe-docker.pkg.dev/project/repo/image:tag'
 _OTHER_REF = 'docker.io/library/alpine:3'
 
 
-# --- make_refreshable_gar_credentials_lookup ---------------------------------
+def _lookup_stubbing_exchange(
+    monkeypatch,
+    exchange_impl,
+    prefetch_margin_seconds: int=300,
+) -> oa._RefreshableGarCredentialsLookup:
+    '''
+    Build a refreshable_gar_credentials_lookup whose subject-token is static and whose
+    exchange_gar_token is replaced by `exchange_impl(subject-token-invariant)`.
+    '''
+    monkeypatch.setattr(
+        oa,
+        'exchange_gar_token',
+        lambda oidc_cfg, subject_token, lifetime_seconds=3600: exchange_impl(),
+    )
+
+    return oa.refreshable_gar_credentials_lookup(
+        oidc_cfg=_GAR_OID_CFG,
+        subject_token_supplier=lambda: 'subject-token',
+        prefetch_margin_seconds=prefetch_margin_seconds,
+    )
+
+
+# --- refreshable_gar_credentials_lookup ---------------------------------------
 
 def test_refreshable_lookup_returns_creds_for_gar(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
-    monkeypatch.setattr(oa, 'exchange_gar_token', lambda **_: 'token-A')
+    lookup = _lookup_stubbing_exchange(monkeypatch, lambda: 'token-A')
 
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
     creds = lookup(image_reference=_GAR_REF, absent_ok=True)
 
     assert isinstance(creds, oa.OciBasicAuthCredentials)
@@ -32,28 +50,21 @@ def test_refreshable_lookup_returns_creds_for_gar(monkeypatch):
 
 
 def test_refreshable_lookup_returns_none_for_non_gar(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
-    monkeypatch.setattr(oa, 'exchange_gar_token', lambda **_: 'token-A')
+    lookup = _lookup_stubbing_exchange(monkeypatch, lambda: 'token-A')
 
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
     creds = lookup(image_reference=_OTHER_REF, absent_ok=True)
 
     assert creds is None
 
 
 def test_refreshable_lookup_no_refetch_while_valid(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
     call_count = {'n': 0}
 
-    def fake_exchange(**_):
+    def fake_exchange():
         call_count['n'] += 1
         return 'token-A'
 
-    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
-
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    lookup = _lookup_stubbing_exchange(monkeypatch, fake_exchange)
     lookup(image_reference=_GAR_REF)
     lookup(image_reference=_GAR_REF)
 
@@ -61,21 +72,18 @@ def test_refreshable_lookup_no_refetch_while_valid(monkeypatch):
 
 
 def test_refreshable_lookup_refetches_after_margin(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
     call_count = {'n': 0}
     tokens = ['token-A', 'token-B']
 
-    def fake_exchange(**_):
-        t = tokens[call_count['n']]
+    def fake_exchange():
+        token = tokens[call_count['n']]
         call_count['n'] += 1
-        return t
-
-    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
+        return token
 
     # use a large margin so the token is always "near-expiry" after first fetch
-    lookup = oa.make_refreshable_gar_credentials_lookup(
-        oidc_cfg=_FakeOidcCfg(),
+    lookup = _lookup_stubbing_exchange(
+        monkeypatch,
+        fake_exchange,
         prefetch_margin_seconds=7200,  # > 3600 s token lifetime → always needs refresh
     )
 
@@ -88,17 +96,13 @@ def test_refreshable_lookup_refetches_after_margin(monkeypatch):
 
 
 def test_refreshable_lookup_invalidate_cache(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
     call_count = {'n': 0}
 
-    def fake_exchange(**_):
+    def fake_exchange():
         call_count['n'] += 1
         return f'token-{call_count["n"]}'
 
-    monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
-
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    lookup = _lookup_stubbing_exchange(monkeypatch, fake_exchange)
     c1 = lookup(image_reference=_GAR_REF)
     lookup.invalidate_cache()
     c2 = lookup(image_reference=_GAR_REF)
@@ -109,18 +113,14 @@ def test_refreshable_lookup_invalidate_cache(monkeypatch):
 
 
 def test_refreshable_lookup_concurrent_single_fetch(monkeypatch):
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
     call_count = {'n': 0}
 
-    def slow_exchange(**_):
+    def slow_exchange():
         time.sleep(0.05)
         call_count['n'] += 1
         return 'token-shared'
 
-    monkeypatch.setattr(oa, 'exchange_gar_token', slow_exchange)
-
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    lookup = _lookup_stubbing_exchange(monkeypatch, slow_exchange)
     results = []
     errors = []
 
@@ -142,46 +142,86 @@ def test_refreshable_lookup_concurrent_single_fetch(monkeypatch):
     assert call_count['n'] == 1
 
 
-# --- _authenticate 401 retry -------------------------------------------------
+# --- deprecated env-reading shim ----------------------------------------------
 
-def _make_mock_session(responses):
-    '''responses: list of (status_code, json_dict) applied in order'''
-    session = unittest.mock.MagicMock()
-    side_effects = []
-    for status, body in responses:
-        r = unittest.mock.MagicMock()
-        r.ok = status < 400
-        r.status_code = status
-        r.reason = 'OK' if status < 400 else 'Unauthorized'
-        r.content = b''
-        r.headers = {
-            'www-authenticate': (
-                'Bearer realm="https://auth.example.com/token",'
-                'service="registry.example.com",'
-                'scope="repository:foo:pull"'
-            ),
-        }
-        r.json.return_value = body
-        side_effects.append(r)
-    session.get.side_effect = side_effects
-    return session
-
-
-def test_authenticate_401_triggers_invalidate_and_retry(monkeypatch):
+def test_make_refreshable_gar_credentials_lookup_reads_gh_oidc_from_env(monkeypatch):
+    '''The deprecated compat-shim must resolve the GitHub OIDC token from the environment.'''
     monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-tok')
-    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com')
+    monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', 'https://tok.example.com?x=1')
 
-    exchange_calls = {'n': 0}
-    tokens = ['token-stale', 'token-fresh']
+    captured = {}
+    session = unittest.mock.MagicMock()
+    res = unittest.mock.MagicMock()
+    res.ok = True
+    res.json.return_value = {'value': 'gh-oidc-token'}
+    session.get.return_value = res
+    monkeypatch.setattr(oa.requests, 'Session', lambda: session)
 
-    def fake_exchange(**_):
-        t = tokens[exchange_calls['n']]
-        exchange_calls['n'] += 1
-        return t
+    def fake_exchange(oidc_cfg, subject_token, lifetime_seconds=3600):
+        captured['subject_token'] = subject_token
+        return 'gar-token'
 
     monkeypatch.setattr(oa, 'exchange_gar_token', fake_exchange)
 
-    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_FakeOidcCfg())
+    lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_GAR_OID_CFG)
+    creds = lookup(image_reference=_GAR_REF)
+
+    called_url = session.get.call_args.kwargs['url']
+    assert called_url.startswith('https://tok.example.com')
+    assert f'audience={_GAR_OID_CFG.audience}' in called_url
+    assert captured['subject_token'] == 'gh-oidc-token'
+    assert creds.password == 'gar-token'
+
+
+def test_exchange_gar_token_legacy_gh_kwargs(monkeypatch):
+    '''Deprecated gh_token/gh_token_url path: the subject-token is fetched from the GitHub
+    id-token endpoint before running the STS exchange (tolerates action/library version skew).'''
+    session = unittest.mock.MagicMock()
+    gh_res = unittest.mock.MagicMock()
+    gh_res.ok = True
+    gh_res.json.return_value = {'value': 'gh-oidc-token'}
+    session.get.return_value = gh_res
+    monkeypatch.setattr(oa.requests, 'Session', lambda: session)
+
+    captured = {}
+
+    # intercept the internal requests at session-level; subject-token fetch uses session.get,
+    # STS/IAM exchanges route through session.request via the internal _fetch
+    def request(method, url, json=None, headers=None):
+        response = unittest.mock.MagicMock()
+        response.ok = True
+        if url == 'https://sts.googleapis.com/v1/token':
+            captured['sts_body'] = json
+            response.json.return_value = {'access_token': 'sts-token'}
+        else:
+            response.json.return_value = {'accessToken': 'gar-token'}
+        return response
+
+    session.request = request
+
+    token = oa.exchange_gar_token(
+        oidc_cfg=_GAR_OID_CFG,
+        gh_token='gh-tok',
+        gh_token_url='https://tok.example.com?x=1',
+    )
+
+    assert token == 'gar-token'
+    # the fetched gh-oidc-token must have been used as subjectToken in the STS exchange
+    assert captured['sts_body']['subjectToken'] == 'gh-oidc-token'
+
+
+# --- _authenticate 401 retry --------------------------------------------------
+
+def test_authenticate_401_triggers_invalidate_and_retry(monkeypatch):
+    exchange_calls = {'n': 0}
+    tokens = ['token-stale', 'token-fresh']
+
+    def fake_exchange():
+        token = tokens[exchange_calls['n']]
+        exchange_calls['n'] += 1
+        return token
+
+    lookup = _lookup_stubbing_exchange(monkeypatch, fake_exchange)
 
     # /v2/ probe → bearer challenge
     probe_resp = unittest.mock.MagicMock()
@@ -215,7 +255,11 @@ def test_authenticate_401_triggers_invalidate_and_retry(monkeypatch):
     # sequence: probe, auth-with-stale, probe-again, auth-with-fresh
     session.get.side_effect = [probe_resp, auth_401, probe_resp, valid_token_resp]
 
-    client = oc.Client(credentials_lookup=lookup, session=session)
+    client = oc.Client(
+        credentials_lookup=lookup,
+        credentials_invalidate=lookup.invalidate_cache,
+        session=session,
+    )
 
     client._authenticate(
         image_reference=_GAR_REF,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

The transparent OIDC token-refresh added recently entangled GitHub-Actions specifics into the generic `oci` modules (`exchange_gar_token` consumed GHA id-token env-vars; the refreshable lookup read `ACTIONS_ID_TOKEN_REQUEST_*`; the 401-retry in `Client._authenticate` hasattr-probed the credentials-lookup). This change decouples them:

- `oci.auth.exchange_gar_token` now takes an already-acquired OIDC subject-token
- new `oci.auth.refreshable_gar_credentials_lookup(oidc_cfg, subject_token_supplier)` — caller injects how the subject-token is obtained; no env reads
- `oci.auth.GarOidcConfiguration` (`audience`, `service_account`) as portable, JSON-serialisable config
- `Client` gains explicit `credentials_invalidate` callback used by the 401-retry (replaces hasattr-probing)
- `oci-auth` action exports resolved GAR OIDC cfgs via new `oidc-cfgs` output so consumers can build refreshable clients without re-resolving/inlining the config

Backwards-compatible: `oci.auth.make_refreshable_gar_credentials_lookup` and `oci.client.client_with_gar_oidc_auth` are kept (now deprecated with `DeprecationWarning`) so existing consumers keep working until migrated.

**Release note**:
```breaking developer
oci.auth GAR-OIDC helpers were decoupled from GitHub-Actions specifics: exchange_gar_token now accepts an OIDC subject-token, and refreshable credentials are built via refreshable_gar_credentials_lookup(oidc_cfg, subject_token_supplier). oci.client.Client gained a credentials_invalidate callback for one-shot 401 retry. The previous entrypoints (make_refreshable_gar_credentials_lookup, client_with_gar_oidc_auth) remain but are deprecated.
```
