### PR TITLE
GAR OIDC: retry id-token fetch; warn on deprecated client factory

### DIFF
--- a/oci/auth.py
+++ b/oci/auth.py
@@ -2,6 +2,7 @@ import base64
 import collections.abc
 import dataclasses
 import enum
+import functools
 import json
 import logging
 import operator
@@ -399,6 +400,26 @@ class GarOidcConfiguration:
     service_account: str
 
 
+def _fetch_with_retries(
+    session: requests.Session,
+    url: str,
+    method: str='GET',
+    json_body: dict | None=None,
+    headers: dict | None=None,
+    remaining: int=3,
+) -> requests.Response:
+    res = session.request(
+        method=method,
+        url=url,
+        json=json_body,
+        headers=headers,
+    )
+    if not res.ok and remaining > 0:
+        return _fetch_with_retries(session, url, method, json_body, headers, remaining - 1)
+    res.raise_for_status()
+    return res
+
+
 def exchange_gar_token(
     oidc_cfg: GarOidcConfiguration,
     subject_token: str | None=None,
@@ -431,24 +452,15 @@ def exchange_gar_token(
             DeprecationWarning,
             stacklevel=2,
         )
-        res = session.get(
+        # note: gh_token_url already carries query params, hence '&audience=' concatenation
+        res = _fetch_with_retries(
+            session=session,
             url=f'{gh_token_url}&audience={oidc_cfg.audience}',
             headers={'Authorization': f'Bearer {gh_token}'},
         )
-        res.raise_for_status()
         subject_token = res.json()['value']
 
-    def _fetch(url, method='GET', json_body=None, headers=None, remaining=3):
-        res = session.request(
-            method=method,
-            url=url,
-            json=json_body,
-            headers=headers,
-        )
-        if not res.ok and remaining > 0:
-            return _fetch(url, method, json_body, headers, remaining - 1)
-        res.raise_for_status()
-        return res
+    _fetch = functools.partial(_fetch_with_retries, session)
 
     res = _fetch(
         url='https://sts.googleapis.com/v1/token',
@@ -573,8 +585,9 @@ def make_refreshable_gar_credentials_lookup(
     )
 
     def _subject_token_supplier() -> str:
-        session = requests.Session()
-        res = session.get(
+        # note: token-request-url already carries query params, hence '&audience=' concatenation
+        res = _fetch_with_retries(
+            session=requests.Session(),
             url=(
                 f'{os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"]}'
                 f'&audience={oidc_cfg.audience}'
@@ -583,7 +596,6 @@ def make_refreshable_gar_credentials_lookup(
                 'Authorization': f'Bearer {os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]}',
             },
         )
-        res.raise_for_status()
         return res.json()['value']
 
     return _RefreshableGarCredentialsLookup(

--- a/oci/client.py
+++ b/oci/client.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
+import warnings
 
 import dacite
 import dateutil.parser
@@ -374,6 +375,13 @@ def client_with_gar_oidc_auth(
     GAR access token is within prefetch_margin_seconds of expiry and, if so, transparently
     re-runs the OIDC exchange before returning credentials.
     '''
+    warnings.warn(
+        'oci.client.client_with_gar_oidc_auth is deprecated - construct the Client directly with '
+        'oci.auth.refreshable_gar_credentials_lookup (explicit subject_token_supplier) and pass '
+        'its invalidate_cache as credentials_invalidate',
+        DeprecationWarning,
+        stacklevel=2,
+    )
     session = requests.Session()
     adapter = requests.adapters.HTTPAdapter(
         pool_connections=http_connection_pool_size,

--- a/test/oci/gar_refresh_test.py
+++ b/test/oci/gar_refresh_test.py
@@ -151,10 +151,16 @@ def test_make_refreshable_gar_credentials_lookup_reads_gh_oidc_from_env(monkeypa
 
     captured = {}
     session = unittest.mock.MagicMock()
-    res = unittest.mock.MagicMock()
-    res.ok = True
-    res.json.return_value = {'value': 'gh-oidc-token'}
-    session.get.return_value = res
+
+    # subject-token fetch routes through the retrying helper -> session.request
+    def request(method, url, json=None, headers=None):
+        captured['url'] = url
+        response = unittest.mock.MagicMock()
+        response.ok = True
+        response.json.return_value = {'value': 'gh-oidc-token'}
+        return response
+
+    session.request = request
     monkeypatch.setattr(oa.requests, 'Session', lambda: session)
 
     def fake_exchange(oidc_cfg, subject_token, lifetime_seconds=3600):
@@ -166,9 +172,8 @@ def test_make_refreshable_gar_credentials_lookup_reads_gh_oidc_from_env(monkeypa
     lookup = oa.make_refreshable_gar_credentials_lookup(oidc_cfg=_GAR_OID_CFG)
     creds = lookup(image_reference=_GAR_REF)
 
-    called_url = session.get.call_args.kwargs['url']
-    assert called_url.startswith('https://tok.example.com')
-    assert f'audience={_GAR_OID_CFG.audience}' in called_url
+    assert captured['url'].startswith('https://tok.example.com')
+    assert f'audience={_GAR_OID_CFG.audience}' in captured['url']
     assert captured['subject_token'] == 'gh-oidc-token'
     assert creds.password == 'gar-token'
 
@@ -177,20 +182,17 @@ def test_exchange_gar_token_legacy_gh_kwargs(monkeypatch):
     '''Deprecated gh_token/gh_token_url path: the subject-token is fetched from the GitHub
     id-token endpoint before running the STS exchange (tolerates action/library version skew).'''
     session = unittest.mock.MagicMock()
-    gh_res = unittest.mock.MagicMock()
-    gh_res.ok = True
-    gh_res.json.return_value = {'value': 'gh-oidc-token'}
-    session.get.return_value = gh_res
     monkeypatch.setattr(oa.requests, 'Session', lambda: session)
 
     captured = {}
 
-    # intercept the internal requests at session-level; subject-token fetch uses session.get,
-    # STS/IAM exchanges route through session.request via the internal _fetch
+    # all fetches (subject-token + STS/IAM) route through session.request via the retry helper
     def request(method, url, json=None, headers=None):
         response = unittest.mock.MagicMock()
         response.ok = True
-        if url == 'https://sts.googleapis.com/v1/token':
+        if 'tok.example.com' in url:
+            response.json.return_value = {'value': 'gh-oidc-token'}
+        elif url == 'https://sts.googleapis.com/v1/token':
             captured['sts_body'] = json
             response.json.return_value = {'access_token': 'sts-token'}
         else:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Small follow-up to #1738 addressing review nits:

- route the GitHub OIDC id-token fetch (both the deprecated `gh_token`/`gh_token_url` path in `exchange_gar_token` and the deprecated `make_refreshable_gar_credentials_lookup` env-shim) through the retrying `_fetch_with_retries` helper, for parity with the STS/IAM exchanges (a single transient 5xx previously failed the call)
- emit `DeprecationWarning` from `oci.client.client_with_gar_oidc_auth` (previously documented-only)

**Release note**:
```bugfix developer
GAR OIDC id-token fetch retries like the STS/IAM exchanges; client_with_gar_oidc_auth now raises a DeprecationWarning as documented.
```
