### PR TITLE
migrate cnudie.util usages to ocm

### DIFF
--- a/.github/actions/component-diff/action.yaml
+++ b/.github/actions/component-diff/action.yaml
@@ -2,7 +2,7 @@ name: component-diff
 description: |
   An action to determine the component-diff between the current version (read from passed-in
   component-descriptor) and the greatest published release-version. The diff is structured according
-  to `cnudie.util.ComponentDiff`.
+  to `ocm.diff.ComponentDiff`.
 
 inputs:
   component-descriptor:

--- a/.github/actions/component-diff/action.yaml
+++ b/.github/actions/component-diff/action.yaml
@@ -67,7 +67,7 @@ runs:
 
         import yaml
 
-        import cnudie.retrieve
+        import ocm.retrieve
         import oci.client
         import ocm
         import version
@@ -85,16 +85,16 @@ runs:
         component_version = current_component_descriptor.component.version
 
         ocm_repositories = '${{ inputs.ocm-repositories }}'.split(',')
-        ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
+        ocm_repository_lookup = ocm.retrieve.ocm_repository_lookup(*ocm_repositories)
 
         oci_client = oci.client.client_with_dockerauth()
 
-        component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
           ocm_repository_lookup=ocm_repository_lookup,
           oci_client=oci_client,
         )
 
-        version_lookup = cnudie.retrieve.version_lookup(
+        version_lookup = ocm.retrieve.version_lookup(
           ocm_repository_lookup=ocm_repository_lookup,
           oci_client=oci_client,
         )
@@ -111,7 +111,7 @@ runs:
           ),
         )
 
-        component_diff = cnudie.retrieve.component_diff(
+        component_diff = ocm.retrieve.component_diff(
           left_component=latest_component_descriptor,
           right_component=current_component_descriptor,
           ignore_component_names=(component_name,),

--- a/.github/actions/helmchart/action.yaml
+++ b/.github/actions/helmchart/action.yaml
@@ -158,7 +158,7 @@ runs:
         import dacite
         import yaml
 
-        import cnudie.retrieve
+        import ocm.retrieve
         import oci.client
         import ocm
 
@@ -184,8 +184,8 @@ runs:
         oci_client = oci.client.client_with_dockerauth()
 
         if ocm_repository := '${{ inputs.ocm-repository }}':
-          component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-            ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repository),
+          component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
+            ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(ocm_repository),
             oci_client=oci_client,
           )
         else:

--- a/.github/actions/ocm-upgrade/ocm_upgrade.py
+++ b/.github/actions/ocm-upgrade/ocm_upgrade.py
@@ -24,7 +24,7 @@ import dacite
 import github3.repos
 import yaml
 
-import cnudie.retrieve
+import ocm.retrieve
 import github.pullrequest
 import gitutil
 import oci.auth
@@ -138,17 +138,17 @@ def create_ocm_lookups(
     oci_client = oci.client.Client(
         credentials_lookup=oci.auth.docker_credentials_lookup(),
     )
-    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(
+    ocm_repository_lookup = ocm.retrieve.ocm_repository_lookup(
         *ocm_repositories,
     )
 
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client,
         cache_dir=None,
     )
 
-    version_lookup = cnudie.retrieve.version_lookup(
+    version_lookup = ocm.retrieve.version_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client,
     )

--- a/.github/actions/ocm-validate/validate.py
+++ b/.github/actions/ocm-validate/validate.py
@@ -1,6 +1,6 @@
 import yaml
 
-import cnudie.retrieve
+import ocm.retrieve
 import ocm
 import ocm.iter
 import ocm.validate
@@ -21,8 +21,8 @@ def validate(
 
     if recursion_depth != 0 and ocm_repositories:
         repos = [r.strip() for r in ocm_repositories.split(',') if r.strip()]
-        ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*repos)
-        lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(*repos)
+        lookup = ocm.retrieve.create_default_component_descriptor_lookup(
             ocm_repository_lookup=ocm_repo_lookup,
             oci_client=oci.client.client_with_dockerauth(),
         )

--- a/.github/actions/release-notes/release_notes_cli.py
+++ b/.github/actions/release-notes/release_notes_cli.py
@@ -24,7 +24,7 @@ except ImportError:
     print(f'note: added {repo_root} to python-path (sys.path)', file=sys.stderr)
     import ocm
 
-import cnudie.retrieve
+import ocm.retrieve
 import github
 import gitutil
 import oci.auth
@@ -195,17 +195,17 @@ def main():
             absent_ok=True,
         ),
     )
-    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(
+    ocm_repository_lookup = ocm.retrieve.ocm_repository_lookup(
         *parsed.ocm_repositories,
         component.current_ocm_repo,
     )
 
-    ocm_version_lookup = cnudie.retrieve.version_lookup(
+    ocm_version_lookup = ocm.retrieve.version_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client,
     )
 
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client,
     )

--- a/.github/actions/sbom-upload/scan.py
+++ b/.github/actions/sbom-upload/scan.py
@@ -25,7 +25,7 @@ _cc_utils_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath
 sys.path.insert(0, _cc_utils_root)
 
 
-import cnudie.retrieve
+import ocm.retrieve
 import oci.auth
 import oci.client
 import oci.model as om
@@ -123,13 +123,13 @@ def main() -> None:
         credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
     )
 
-    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
-    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+    ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(*ocm_repositories)
+    lookup = ocm.retrieve.composite_component_descriptor_lookup(
         lookups=(
-            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+            ocm.retrieve.in_memory_cache_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
             ),
-            cnudie.retrieve.oci_component_descriptor_lookup(
+            ocm.retrieve.oci_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
                 oci_client=oci_client,
             ),

--- a/.github/actions/sbom-upload/scan_gobinary.py
+++ b/.github/actions/sbom-upload/scan_gobinary.py
@@ -36,7 +36,7 @@ import urllib.request
 _cc_utils_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, _cc_utils_root)
 
-import cnudie.retrieve
+import ocm.retrieve
 import oci.auth
 import oci.client
 import oci.model as om
@@ -173,13 +173,13 @@ def main() -> None:
         credentials_lookup=credentials_lookup,
     )
 
-    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
-    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+    ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(*ocm_repositories)
+    lookup = ocm.retrieve.composite_component_descriptor_lookup(
         lookups=(
-            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+            ocm.retrieve.in_memory_cache_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
             ),
-            cnudie.retrieve.oci_component_descriptor_lookup(
+            ocm.retrieve.oci_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
                 oci_client=oci_client,
             ),

--- a/.github/actions/sbom-upload/upload.py
+++ b/.github/actions/sbom-upload/upload.py
@@ -16,7 +16,7 @@ import time
 import urllib.parse
 import urllib.request
 
-import cnudie.retrieve
+import ocm.retrieve
 import oci.auth
 import oci.client
 import ocm
@@ -378,13 +378,13 @@ def main() -> None:
         credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
     )
 
-    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*ocm_repositories)
-    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+    ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(*ocm_repositories)
+    lookup = ocm.retrieve.composite_component_descriptor_lookup(
         lookups=(
-            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+            ocm.retrieve.in_memory_cache_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
             ),
-            cnudie.retrieve.oci_component_descriptor_lookup(
+            ocm.retrieve.oci_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
                 oci_client=oci_client,
             ),

--- a/.github/actions/setup-testrunner/install_testrunner.py
+++ b/.github/actions/setup-testrunner/install_testrunner.py
@@ -12,14 +12,14 @@ logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logging.getLogger('oci.client').setLevel(logging.WARN)
 
 try:
-    import cnudie.retrieve
+    import ocm.retrieve
 except ImportError:
     # patch pythonpath for local development
     sys.path.insert(
         1,
         os.path.join(own_dir, '../../..'),
     )
-    import cnudie.retrieve
+    import ocm.retrieve
 
 import ocm
 import oci.auth
@@ -43,12 +43,12 @@ def main():
         credentials_lookup=oci.auth.docker_credentials_lookup(absent_ok=True),
     )
 
-    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(parsed.ocm_repo)
-    version_lookup = cnudie.retrieve.version_lookup(
+    ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(parsed.ocm_repo)
+    version_lookup = ocm.retrieve.version_lookup(
         ocm_repository_lookup=ocm_repo_lookup,
         oci_client=oci_client,
     )
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repo_lookup,
         oci_client=oci_client,
     )

--- a/.github/actions/update-extension-provider-images/update-images.py
+++ b/.github/actions/update-extension-provider-images/update-images.py
@@ -66,7 +66,7 @@ import semver
 from ruamel.yaml import YAML
 from ruamel.yaml import YAMLError
 
-import cnudie.retrieve
+import ocm.retrieve
 import ocm
 import requests.exceptions
 
@@ -1213,13 +1213,13 @@ def write_ocm_release_notes(
     repo_dir: str = '.',
     ocm_repository: str = GARDENER_OCM_REPOSITORY,
 ) -> None:
-    ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(ocm_repository)
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+    ocm_repository_lookup = ocm.retrieve.ocm_repository_lookup(ocm_repository)
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client_,
         cache_dir=None,
     )
-    version_lookup = cnudie.retrieve.version_lookup(
+    version_lookup = ocm.retrieve.version_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         oci_client=oci_client_,
     )

--- a/cli/gardener_ci/compliance.py
+++ b/cli/gardener_ci/compliance.py
@@ -25,7 +25,7 @@ import yaml
 
 import ccc.oci
 import ci.util
-import cnudie.retrieve
+import ocm.retrieve
 import ocm
 import ocm.iter
 import ocm.util
@@ -104,8 +104,8 @@ def diff(
 
     print('retrieving component-descriptors (might take a few seconds)')
 
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(
             *parsed.ocm_repo_urls,
         ),
         oci_client=ccc.oci.oci_client(),

--- a/cnudie/util.py
+++ b/cnudie/util.py
@@ -1,732 +1,106 @@
-import collections.abc
-import dataclasses
-import graphlib
-import textwrap
+import warnings
 
 import ocm
-import oci.model as om
-
-ComponentId = (
-    ocm.Component
-    | ocm.ComponentDescriptor
-    | ocm.ComponentIdentity
-    | ocm.ComponentReference
-    | str
-    | tuple[str, str]
-)
-ComponentName = (
-    ocm.Component
-    | ocm.ComponentReference
-    | ocm.ComponentDescriptor
-    | ocm.ComponentIdentity
-    | str
-)
-
-META_SEPARATOR = '.build-'
-
-
-def to_component_id(
-    component: ComponentId, /
-) -> ocm.ComponentIdentity:
-    if isinstance(component, ocm.ComponentIdentity):
-        return component
-
-    if isinstance(component, ocm.ComponentDescriptor) or hasattr(component, 'component'):
-        component = component.component
-        # fall through to next case
-    if isinstance(component, ocm.Component) or hasattr(component, 'name') \
-        and not hasattr(component, 'componentName'):
-        name = component.name
-        version = component.version
-    if isinstance(component, ocm.ComponentReference) or hasattr(component, 'componentName'):
-        name = component.componentName
-        version = component.version
-    if isinstance(component, str):
-        try:
-            name, version = component.split(':', 1)
-        except ValueError as ve:
-            ve.add_note(f'{component=}')
-            raise
-    if isinstance(component, tuple):
-        name, version = component
-
-    return ocm.ComponentIdentity(
-        name=name,
-        version=version,
-    )
-
-
-def to_component_name(
-    component: ComponentName,
-) -> str:
-    if isinstance(component, ocm.ComponentDescriptor):
-        component = component.component
-    if isinstance(component, ocm.Component):
-        component = component.name
-    elif isinstance(component, ocm.ComponentIdentity):
-        component = component.name
-    elif isinstance(component, ocm.ComponentReference):
-        component = component.componentName
-    elif isinstance(component, tuple):
-        if not len(component) == 2:
-            raise ValueError('expected two-tuple with two elements')
-        component = component[0]
-    if not isinstance(component, str):
-        raise ValueError(component)
-
-    if ':' in component:
-        # assumption: has form <name>:<version>
-        # let exception raise in other cases
-        component, _ = component.split(':')
-
-    return component
-
-
-def to_component_id_and_repository_url(
-    component: ocm.Component | ocm.ComponentDescriptor | ocm.ComponentIdentity | str,
-    repository: ocm.OciOcmRepository|str=None,
-):
-    if isinstance(component, str):
-        name, version = component.rsplit(':', 1)
-        component = ocm.ComponentIdentity(
-            name=name,
-            version=version,
-        )
-
-    if isinstance(component, ocm.ComponentDescriptor):
-        component = component.component
-    elif isinstance(component, ocm.ComponentIdentity) and not repository:
-        raise ValueError('repository must be passed if calling w/ component-identity')
-
-    if not repository: # component is sure to be of type ocm.Component by now (checked above)
-        component: ocm.Component
-        repository = component.current_ocm_repo
-
-    if isinstance(repository, ocm.OciOcmRepository):
-        repo_base_url = repository.baseUrl
-    elif isinstance(repository, str):
-        repo_base_url = repository
-    else:
-        raise ValueError(f'only OciOcmRepository is supported - got: {repository=}')
-
-    return component, repo_base_url
-
-
-def oci_ref(
-    component: ocm.Component | ocm.ComponentDescriptor | ocm.ComponentIdentity | str,
-    repository: ocm.OciOcmRepository|str=None,
-) -> om.OciImageReference:
-    component, repo_base_url = to_component_id_and_repository_url(
-        component=component,
-        repository=repository,
-    )
-
-    return om.OciImageReference(
-        '/'.join((
-            repo_base_url.rstrip('/'),
-            'component-descriptors',
-            f'{component.name.lower()}:{component.version}',
-        ))
-    )
-
-
-def iter_sorted(
-    components: collections.abc.Iterable[ocm.Component], /
-) -> collections.abc.Generator[ocm.Component, None, None]:
-    '''
-    returns a generator yielding the given components, honouring their dependencies, starting
-    with "leaf" components (i.e. components w/o dependencies), also known as topologically sorted.
-    '''
-    components = (to_component(c) for c in components)
-    components_by_id = {c.identity(): c for c in components}
-
-    toposorter = graphlib.TopologicalSorter()
-
-    def ref_to_comp_id(component_ref: ocm.ComponentReference) -> ocm.ComponentIdentity:
-        return ocm.ComponentIdentity(
-            name=component_ref.componentName,
-            version=component_ref.version,
-        )
-
-    for component_id, component in components_by_id.items():
-        depended_on_comp_ids = (
-            ref_to_comp_id(cref)
-            for cref in component.componentReferences
-        )
-        toposorter.add(component_id, *depended_on_comp_ids)
-
-    for component_id in toposorter.static_order():
-        if not component_id in components_by_id:
-            # XXX: ignore component-references not contained in passed components for now
-            continue
-
-        yield components_by_id[component_id]
-
-
-def to_component(*args, **kwargs) -> ocm.Component:
-    if not kwargs and len(args) == 1:
-        component = args[0]
-        if isinstance(component, ocm.Component):
-            return component
-        elif isinstance(component, ocm.ComponentDescriptor):
-            return component.component
-        else:
-            raise ValueError(args)
-    raise NotImplementedError
-
-
-def determine_component_name(
-    repository_hostname: str,
-    repository_path: str,
-) -> str:
-    component_name = '/'.join((
-        repository_hostname,
-        repository_path,
-    ))
-    return component_name.lower() # OCI demands lowercase
-
-
-def normalise_component_name(component_name: str) -> str:
-    return component_name.lower() # oci-spec demands lowercase
-
-
-def oci_artefact_reference(
-        component: (
-            ocm.Component
-            | ocm.ComponentIdentity
-            | ocm.ComponentReference
-            | str # 'name:version'
-            | tuple[str, str] # (name, version)
-        ),
-        ocm_repository: str | ocm.OciOcmRepository = None
-) -> str:
-    if isinstance(component, ocm.Component):
-        if not ocm_repository:
-            ocm_repository = component.current_ocm_repo
-        component_name = component.name
-        component_version = component.version
-
-    elif isinstance(component, ocm.ComponentIdentity):
-        component_name = component.name
-        component_version = component.version
-
-    elif isinstance(component, ocm.ComponentReference):
-        component_name = component.componentName
-        component_version = component.version
-
-    elif isinstance(component, str):
-        component_name, component_version = component.split(':')
-
-    elif isinstance(component, tuple):
-        if not len(component) == 2 or not (
-            isinstance(component[0], str) and isinstance(component[1], str)
-        ):
-            raise TypeError("If a tuple is given as component, it must contain two strings.")
-        component_name, component_version = component
-    else:
-        raise ValueError(component)
-
-    if not ocm_repository:
-        raise ValueError('ocm_repository must be given unless a Component is passed.')
-    elif isinstance(ocm_repository, str):
-        ocm_repository = ocm.OciOcmRepository(baseUrl=ocm_repository)
-    elif isinstance(ocm_repository, ocm.OciOcmRepository):
-        ocm_repository = ocm_repository
-    else:
-        raise TypeError(type(ocm_repository))
-
-    return ocm_repository.component_version_oci_ref(
-        name=component_name,
-        version=component_version,
-    )
-
-
-def target_oci_ref(
-    component: ocm.Component,
-    component_ref: ocm.ComponentReference=None,
-    component_version: str=None,
-):
-    if not component_ref:
-        component_ref = component
-        component_name = component_ref.name
-    else:
-        component_name = component_ref.componentName
-
-    component_name = normalise_component_name(component_name)
-    component_version = component_ref.version
-
-    last_ocm_repo = component.current_ocm_repo
-
-    return last_ocm_repo.component_version_oci_ref(
-        name=component_name,
-        version=component_version,
-    )
-
-
-def main_source(
-    component: ocm.Component,
-    absent_ok: bool=True,
-) -> ocm.Source:
-    print('warning: cnudie.util is deprecated - use ocm.util instead')
-    component = to_component(component)
-    for source in component.sources:
-        if label := source.find_label('cloud.gardener/cicd/source'):
-            if label.value.get('repository-classification') == 'main':
-                return source
-
-    if not component.sources:
-        if absent_ok:
-            return None
-        raise ValueError(f'no sources defined by {component=}')
-
-    # if no label was found use heuristic approach
-    # heuristic: use first source
-    return component.sources[0]
-
-
-determine_main_source_for_component = main_source
-
-
-@dataclasses.dataclass(frozen=True)
-class ComponentResource:
-    component: ocm.Component
-    resource: ocm.Resource
-
-
-@dataclasses.dataclass(frozen=True)
-class LabelDiff:
-    labels_only_left: list[ocm.Label] = dataclasses.field(default_factory=list)
-    labels_only_right: list[ocm.Label] = dataclasses.field(default_factory=list)
-    label_pairs_changed: list[tuple[ocm.Label, ocm.Label]] = dataclasses.field(default_factory=list)
-
-
-empty_list = lambda: dataclasses.field(default_factory=list) # noqa:E3701
-
-
-@dataclasses.dataclass
-class ComponentDiff:
-    cidentities_only_left: set = empty_list()
-    cidentities_only_right: set = empty_list()
-    cpairs_version_changed: list[tuple[ocm.Component, ocm.Component]] = empty_list
-    # only set when new component is added/removed
-    names_only_left: set = dataclasses.field(default_factory=set)
-    names_only_right: set = dataclasses.field(default_factory=set)
-    # only set on update
-    names_version_changed: set = dataclasses.field(default_factory=set)
-
-
-def diff_labels(
-    left_labels: list[ocm.Label],
-    right_labels: list[ocm.Label],
-) -> LabelDiff:
-
-    left_label_name_to_label = {l.name: l for l in left_labels}
-    right_label_name_to_label = {l.name: l for l in right_labels}
-
-    labels_only_left = [
-        l for l in left_labels if l.name not in right_label_name_to_label.keys()
-    ]
-    labels_only_right = [
-        l for l in right_labels if l.name not in left_label_name_to_label.keys()
-    ]
-    label_pairs_changed = []
-    for left_label, right_label in _enumerate_group_pairs(
-        left_elements=left_labels,
-        right_elements=right_labels,
-        unique_name=True,
-    ):
-        if left_label.value == right_label.value:
-            continue
-        else:
-            label_pairs_changed.append((left_label, right_label))
-
-    return LabelDiff(
-        labels_only_left=labels_only_left,
-        labels_only_right=labels_only_right,
-        label_pairs_changed=label_pairs_changed,
-    )
-
-
-def diff_components(
-    left_components: collections.abc.Iterable[ocm.Component],
-    right_components: collections.abc.Iterable[ocm.Component],
-    ignore_component_names=(),
-) -> ComponentDiff:
-    left_component_identities = {
-        c.identity() for c in left_components if c.name not in ignore_component_names
-    }
-    right_component_identities = {
-        c.identity() for c in right_components if c.name not in ignore_component_names
-    }
-
-    left_only_component_identities = left_component_identities - right_component_identities
-    right_only_component_identities = right_component_identities - left_component_identities
-
-    if left_only_component_identities == right_only_component_identities:
-        return None # no diff
-
-    left_components = tuple((
-        c for c in left_components if c.identity() in left_only_component_identities
-    ))
-    right_components = tuple((
-        c for c in right_components if c.identity() in right_only_component_identities
-    ))
-
-    def find_changed_component(
-        changed_component: ocm.Component,
-        components: list[ocm.Component],
-    ):
-        for c in components:
-            if c.name == changed_component.name:
-                return (changed_component, c)
-        return (changed_component, None) # no pair component found
-
-    components_with_changed_versions = []
-    for component in left_components:
-        changed_component = find_changed_component(component, right_components)
-        if changed_component[1] is not None:
-            components_with_changed_versions.append(changed_component)
-
-    left_component_names = {i.name for i in left_component_identities}
-    right_component_names = {i.name for i in right_component_identities}
-    names_version_changed = {c[0].name for c in components_with_changed_versions}
-
-    both_names = left_component_names & right_component_names
-    left_component_names -= both_names
-    right_component_names -= both_names
-
-    return ComponentDiff(
-        cidentities_only_left=left_only_component_identities,
-        cidentities_only_right=right_only_component_identities,
-        cpairs_version_changed=components_with_changed_versions,
-        names_only_left=left_component_names,
-        names_only_right=right_component_names,
-        names_version_changed=names_version_changed,
-    )
-
-
-def format_component_diff(
-    component_diff: ComponentDiff,
-    delivery_dashboard_url_view_diff: str | None=None,
-    delivery_dashboard_url: str | None=None
-):
-    if delivery_dashboard_url_view_diff:
-        bom_diff_header = f'## <a href="{delivery_dashboard_url_view_diff}">BoM Diff</a>\n'
-    else:
-        bom_diff_header = '## BoM Diff\n'
-
-    added_components = [
-        f'\U00002795 {component.name} {component.version}'
-        for component in component_diff.cidentities_only_right
-        if component.name not in component_diff.names_version_changed
-    ]
-
-    removed_components = [
-        f'\U00002796 {component.name} {component.version}'
-        for component in component_diff.cidentities_only_left
-        if component.name not in component_diff.names_version_changed
-    ]
-
-    changed_components = [
-        f'\U00002699 {new_component.name}: {old_component.version} → {new_component.version}'
-        for old_component, new_component in component_diff.cpairs_version_changed
-    ]
-
-    summary_counts = textwrap.dedent(f'''\
-        Added components: {len(added_components)}
-        Changed components: {len(changed_components)}
-        Removed components: {len(removed_components)}\n
-    ''')
-
-    summary_details = []
-    if added_components:
-        summary_details.append('### Added Components:\n' + '\n'.join(added_components) + '\n')
-
-    if removed_components:
-        summary_details.append('### Removed Components:\n' + '\n'.join(removed_components) + '\n')
-
-    if changed_components:
-        summary_details.append('### Changed Components:\n' + '\n'.join(changed_components) + '\n')
-
-    component_details = []
-    for old_component, new_component in component_diff.cpairs_version_changed:
-        if delivery_dashboard_url:
-            component_link = (
-                f"<a href='{delivery_dashboard_url}/#/component?name={new_component.name}'>"
-                f'{new_component.name}</a>'
-            )
-        else:
-            component_link = new_component.name
-
-        component_header = (
-            f'<details><summary>\U00002699 {component_link}:'
-            f'{old_component.version} → {new_component.version}</summary>\n'
-        )
-
-        added_resources = []
-        removed_resources = []
-        changed_resources = []
-
-        # Group resources by name
-        old_resources_grouped = {}
-        new_resources_grouped = {}
-
-        for res in old_component.resources:
-            old_resources_grouped.setdefault(res.name, []).append(res)
-
-        for res in new_component.resources:
-            new_resources_grouped.setdefault(res.name, []).append(res)
-
-        # Process each resource in the new component
-        for res_name, new_res_list in new_resources_grouped.items():
-            old_res_list = old_resources_grouped.get(res_name, [])
-
-            if (
-                old_res_list
-                and sorted([res.version for res in old_res_list])
-                == sorted([res.version for res in new_res_list])
-            ):
-                # Skip resource as all versions are identical in both the old and new components
-                continue
-
-            if len(new_res_list) == 1 and len(old_res_list) == 1:
-                # Single occurrence in both -> Compare versions
-                new_res = new_res_list[0]
-                old_res = old_res_list[0]
-                if new_res.version != old_res.version:
-                    changed_resources.append(
-                        [f'\U0001F504 {res_name}', f'{old_res.version} → {new_res.version}']
-                    )
-            else:
-                # Multiple occurrences -> Display all versions for each resource name
-                if old_res_list:
-                    removed_resources.extend(
-                        [[f'\U00002796 {res_name}', res.version] for res in old_res_list]
-                    )
-                if new_res_list:
-                    added_resources.extend(
-                        [[f'\U00002795 {res_name}', res.version] for res in new_res_list]
-                    )
-
-        # Process resources that only exist in the old component
-        for res_name, old_res_list in old_resources_grouped.items():
-            if res_name not in new_resources_grouped:
-                removed_resources.extend(
-                    [[f'\U00002796 {res_name}', res.version] for res in old_res_list]
-                )
-
-        # Aggregate results for resources into `resources_data`
-        if not (added_resources or removed_resources or changed_resources):
-            resources_data = [['No resources added, removed, or changed', '']]
-        else:
-            resources_data = added_resources + removed_resources + changed_resources
-
-        #Import `tabulate` only when the function is called to avoid loading it during module import
-        import tabulate
-        # Generate HTML table with tabulate
-        resources_table = tabulate.tabulate(
-            tabular_data=resources_data,
-            headers=['Resource', 'Version Change'],
-            tablefmt='html'
-        )
-
-        component_details.append(component_header + resources_table + '\n</details>')
-
-    return (
-        bom_diff_header
-        + summary_counts
-        + '\n'.join(summary_details)
-        + '\n## Component Details:\n'
-        + '\n'.join(component_details)
-    )
-
-
-def _enumerate_group_pairs(
-    left_elements: collections.abc.Sequence[ocm.Resource | ocm.Source | ocm.Label],
-    right_elements: collections.abc.Sequence[ocm.Resource | ocm.Source, ocm.Label],
-    unique_name: bool = False,
-) -> collections.abc.Generator[tuple[list, list], None, None] | \
-collections.abc.Generator[tuple, None, None]:
-    '''Groups elements of two sequences with the same name.
-
-    Can be used for Resources, Sources and Label
-    '''
-    # group the resources with the same name on both sides
-    for element in left_elements:
-        right_elements_group = [e for e in right_elements if e.name == element.name]
-        # get resources for one resource via name
-
-        # key is always in left group so we only have to check the length of the right group
-        if len(right_elements_group) == 0:
-            continue
-        else:
-            left_elements_group = [e for e in left_elements if e.name == element.name]
-
-            if unique_name:
-                if len(left_elements_group) == 1 and len(right_elements_group) == 1:
-                    yield (left_elements_group[0], right_elements_group[0])
-                else:
-                    raise RuntimeError(
-                        f'Element name "{element.name}"" is not unique at least one list. '
-                        f'{len(left_elements_group)=} {len(right_elements_group)=}')
-            else:
-                yield (left_elements_group, right_elements_group)
-
-
-@dataclasses.dataclass
-class ResourceDiff:
-    left_component: ocm.Component
-    right_component: ocm.Component
-    resource_refs_only_left: list[ocm.Resource] = dataclasses.field(default_factory=list)
-    resource_refs_only_right: list[ocm.Resource] = dataclasses.field(default_factory=list)
-    resourcepairs_version_changed: list[tuple[ocm.Resource, ocm.Resource]] = dataclasses.field(default_factory=list) # noqa:E501
-
-
-def _add_if_not_duplicate(list, res):
-    if (res.name, res.version) not in [(res.name, res.version) for res in list]:
-        list.append(res)
-
-
-def diff_resources(
-    left_component: ocm.Component,
-    right_component: ocm.Component,
-) -> ResourceDiff:
-    if type(left_component) is not ocm.Component:
-        raise NotImplementedError(
-            f'unsupported {type(left_component)=}',
-        )
-    if type(right_component) is not ocm.Component:
-        raise NotImplementedError(
-            f'unsupported {type(right_component)=}',
-        )
-
-    left_resource_identities_to_resource = {
-        r.identity(left_component.resources + right_component.resources): r
-        for r in left_component.resources
-    }
-    right_resource_identities_to_resource = {
-        r.identity(left_component.resources + right_component.resources): r
-        for r in right_component.resources
-    }
-
-    resource_diff = ResourceDiff(
-        left_component=left_component,
-        right_component=right_component,
-    )
-
-    if left_resource_identities_to_resource.keys() == right_resource_identities_to_resource.keys():
-        return resource_diff
-
-    left_names_to_resource = {r.name: r for r in left_component.resources}
-    right_names_to_resource = {r.name: r for r in right_component.resources}
-    # get left exclusive resources
-    for resource in left_resource_identities_to_resource.values():
-        if not resource.name in right_names_to_resource:
-            _add_if_not_duplicate(resource_diff.resource_refs_only_left, resource)
-
-    # get right exclusive resources
-    for resource in right_resource_identities_to_resource.values():
-        if not resource.name in left_names_to_resource:
-            _add_if_not_duplicate(resource_diff.resource_refs_only_right, resource)
-
-    # groups the resources by name. The version will be used at a later point
-    def enumerate_group_pairs(
-        left_resources: list[ocm.Resource],
-        right_resources: list[ocm.Resource]
-    ) -> collections.abc.Generator[tuple[list[ocm.Resource], list[ocm.Resource]], None, None]:
-        # group the resources with the same name on both sides
-        for name in left_names_to_resource.keys():
-            right_resource_group = [r for r in right_resources if r.name == name]
-
-            # key is always in left group so we only have to check the length of the right group
-            if len(right_resource_group) == 0:
-                continue
-            else:
-                left_resource_group = [r for r in left_resources if r.name == name]
-                yield (left_resource_group, right_resource_group)
-
-    for left_resource_group, right_resource_group in enumerate_group_pairs(
-        left_resources=left_component.resources,
-        right_resources=right_component.resources,
-    ):
-        if len(left_resource_group) == 1 and len(right_resource_group) == 1:
-            # if versions are equal resource will be ignored, resource is unchanged
-            if left_resource_group[0].version != right_resource_group[0].version:
-                resource_diff.resourcepairs_version_changed.append(
-                    (left_resource_group[0], right_resource_group[0]),
-                )
-            continue
-
-        left_identities = {
-            r.identity(left_component.resources + right_component.resources): r
-            for r in left_resource_group
-        }
-        right_identities = {
-            r.identity(left_component.resources + right_component.resources): r
-                            for r in right_resource_group
-        }
-
-        left_resource_ids = sorted(left_identities.keys())
-        right_resource_ids = sorted(right_identities.keys())
-
-        # sort resources. Important because down/upgrades depend on position in list
-        left_resources = [left_identities.get(id) for id in left_resource_ids]
-        right_resources = [right_identities.get(id) for id in right_resource_ids]
-
-        # remove all resources present in both
-        versions_in_both = {
-            r.version for r in left_resources
-        } & {
-            r.version for r in right_resources
-        }
-        left_resources = [
-            i for i in left_resources
-            if not i.version in versions_in_both
-        ]
-        right_resources = [
-            i for i in right_resources
-            if not i.version in versions_in_both
-        ]
-
-        # at this point we got left and right resources with the same name but different versions
-        i = 0
-        for i, left_resource in enumerate(left_resources):
-            if i >= len(right_resources):
-                _add_if_not_duplicate(resource_diff.resource_refs_only_left, left_resource)
-
-            else:
-                right_resource = right_resources[i]
-                resource_diff.resourcepairs_version_changed.append((left_resource, right_resource))
-
-        # returns an empyt dict if index out of bounds
-        left_resource = left_resources[i:]
-        right_resource = right_resources[i:]
-
-        for i in left_resource:
-            _add_if_not_duplicate(resource_diff.resource_refs_only_left, i)
-
-        for i in right_resource:
-            _add_if_not_duplicate(resource_diff.resource_refs_only_right, i)
-
-    return resource_diff
-
-
-def sanitise_version(version: str) -> str:
-    '''
-    Additional build metadata as defined in SemVer can be added via `+` to the version. However,
-    OCI registries don't support `+` as tag character, which is why it has to be sanitised, for
-    example using `META_SEPARATOR`.
-    '''
-    sanitised_version = version.replace('+', META_SEPARATOR)
-
-    return sanitised_version
-
-
-def desanitise_version(version: str) -> str:
-    '''
-    This function reverts the sanitisation of the `sanitise_version` function, which allows
-    processing the version the same way as prior to using `sanitise_version`.
-    '''
-    desanitised_version = version.replace(META_SEPARATOR, '+')
-
-    return desanitised_version
+import ocm.access
+import ocm.diff
+import ocm.util
+
+import version as _version
+
+# re-export classes and type aliases directly so isinstance checks and type annotations keep working
+ComponentId = ocm.ComponentId
+ComponentName = ocm.ComponentName
+
+ComponentResource = ocm.diff.ComponentResource
+LabelDiff = ocm.diff.LabelDiff
+ComponentDiff = ocm.diff.ComponentDiff
+ResourceDiff = ocm.diff.ResourceDiff
+
+META_SEPARATOR = _version.META_SEPARATOR
+
+_WARN = 'cnudie.util is deprecated - use ocm / ocm.access / ocm.diff / ocm.util / version instead'
+
+
+def to_component_id(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.to_component_id(*args, **kwargs)
+
+
+def to_component_name(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.to_component_name(*args, **kwargs)
+
+
+def to_component(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.to_component(*args, **kwargs)
+
+
+def iter_sorted(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    yield from ocm.iter_sorted(*args, **kwargs)
+
+
+def to_component_id_and_repository_url(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.access.to_component_id_and_repository_url(*args, **kwargs)
+
+
+def oci_ref(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.access.oci_ref(*args, **kwargs)
+
+
+def target_oci_ref(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.access.target_oci_ref(*args, **kwargs)
+
+
+def oci_artefact_reference(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.access.oci_artefact_reference(*args, **kwargs)
+
+
+def normalise_component_name(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.access.normalise_component_name(*args, **kwargs)
+
+
+def main_source(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.util.main_source(*args, **kwargs)
+
+
+def determine_main_source_for_component(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.util.main_source(*args, **kwargs)
+
+
+def diff_labels(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.diff.diff_labels(*args, **kwargs)
+
+
+def diff_components(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.diff.diff_components(*args, **kwargs)
+
+
+def diff_resources(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.diff.diff_resources(*args, **kwargs)
+
+
+def format_component_diff(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return ocm.diff.format_component_diff(*args, **kwargs)
+
+
+def sanitise_version(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return _version.sanitise_version(*args, **kwargs)
+
+
+def desanitise_version(*args, **kwargs):
+    warnings.warn(_WARN, DeprecationWarning, stacklevel=2)
+    return _version.desanitise_version(*args, **kwargs)

--- a/ctt/__main__.py
+++ b/ctt/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-import cnudie.retrieve
+import ocm.retrieve
 import ctt.process_dependencies
 import oci.auth
 import oci.client
@@ -111,8 +111,8 @@ def replicate(parsed):
         max_concurrency_per_host=parsed.max_concurrency_per_host,
     )
 
-    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(parsed.src_repo),
+    component_descriptor_lookup = ocm.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(parsed.src_repo),
         oci_client=oci_client,
     )
 

--- a/ctt/process_dependencies.py
+++ b/ctt/process_dependencies.py
@@ -23,7 +23,7 @@ import urllib.parse
 import dacite
 import yaml
 
-import cnudie.retrieve
+import ocm.retrieve
 import ctt.oci_util
 import ctt.replicate
 import sbom.cbom as sbom_cbom
@@ -94,9 +94,9 @@ class LocalBlobsMode(enum.StrEnum):
 def create_component_descriptor_lookup_for_ocm_repo(
     ocm_repo_url: str,
     oci_client: oci.client.Client | None=None,
-) -> cnudie.retrieve.ComponentDescriptorLookupById:
-    return cnudie.retrieve.create_default_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo_url),
+) -> ocm.retrieve.ComponentDescriptorLookupById:
+    return ocm.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(ocm_repo_url),
         oci_client=oci_client,
     )
 
@@ -351,8 +351,8 @@ def enum_processing_cfgs(
 def determine_changed_components(
     component_descriptor: ocm.ComponentDescriptor,
     tgt_ocm_repo_url: str,
-    component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
-    tgt_component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
+    tgt_component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
     component_filter: collections.abc.Callable[[ocm.Component], bool]=None,
     reftype_filter: collections.abc.Callable[[ocm.iter.NodeReferenceType], bool]=None,
     pruning_mode: PruningMode=PruningMode.PRUNE_SUBTREES,
@@ -615,8 +615,8 @@ def iter_replication_resource_elements(
 def create_replication_plan_step(
     processing_cfg: dict,
     root_component_descriptor: ocm.ComponentDescriptor,
-    src_component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
-    tgt_component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    src_component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
+    tgt_component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
     ocm_repository: str,
     tgt_oci_registries: collections.abc.Sequence[str],
     oci_client: oci.client.Client,
@@ -666,7 +666,7 @@ def create_replication_plan_step(
 def process_images(
     processing_cfg_path: str,
     root_component_descriptor: ocm.ComponentDescriptor,
-    component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
     oci_client: oci.client.Client,
     processing_mode: ProcessingMode=ProcessingMode.REGULAR,
     replication_mode: oci.ReplicationMode=oci.ReplicationMode.PREFER_MULTIARCH,
@@ -805,7 +805,7 @@ def process_replication_plan_step(
     replication_plan_step: ctt.model.ReplicationPlanStep,
     root_component_descriptor: ocm.ComponentDescriptor,
     oci_client: oci.client.Client,
-    tgt_component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    tgt_component_descriptor_lookup: ocm.retrieve.ComponentDescriptorLookupById,
     processing_mode: ProcessingMode=ProcessingMode.REGULAR,
     replication_mode: oci.ReplicationMode=oci.ReplicationMode.PREFER_MULTIARCH,
     inject_ocm_coordinates_into_oci_manifests: bool=False,

--- a/ctt/test/test_ctt_sbom_inject.py
+++ b/ctt/test/test_ctt_sbom_inject.py
@@ -34,7 +34,7 @@ import oci.model as om
 import ocm
 import ocm.oci
 import ocm.iter
-import cnudie.retrieve
+import ocm.retrieve
 import ctt.process_dependencies as pdeps
 
 logging.basicConfig(level=logging.INFO, stream=sys.stderr)
@@ -209,12 +209,12 @@ def run(run_id: str):
         src_refs.append(ref)
         logger.info(f'pushed src CD: {ref}')
 
-    src_lookup = cnudie.retrieve.oci_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(src_repo_url),
+    src_lookup = ocm.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(src_repo_url),
         oci_client=oci_client,
     )
-    dst_lookup = cnudie.retrieve.oci_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(dst_repo_url),
+    dst_lookup = ocm.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(dst_repo_url),
         oci_client=oci_client,
     )
 

--- a/ctt/test/test_sbom_inject_integration.py
+++ b/ctt/test/test_sbom_inject_integration.py
@@ -24,7 +24,7 @@ import tempfile
 
 import yaml
 
-import cnudie.retrieve
+import ocm.retrieve
 import ctt.process_dependencies as pdeps
 import oci.auth as oa
 import oci.client as oc
@@ -44,8 +44,8 @@ COMPONENT_VERSION = 'v1.55.3'
 
 def _oci_lookup(ocm_repo_url: str, oci_client: oc.Client):
     '''Build a lightweight OCI-only component descriptor lookup (no ctx/config system).'''
-    return cnudie.retrieve.oci_component_descriptor_lookup(
-        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo_url),
+    return ocm.retrieve.oci_component_descriptor_lookup(
+        ocm_repository_lookup=ocm.retrieve.ocm_repository_lookup(ocm_repo_url),
         oci_client=oci_client,
     )
 

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -8,7 +8,7 @@ import re
 import github3.pulls
 
 import ci.util
-import cnudie.retrieve
+import ocm.retrieve
 import cnudie.util
 import github.limits
 import gitutil
@@ -297,7 +297,7 @@ def bom_diff(
     else:
         delivery_dashboard_url_view_diff = None
 
-    bom_diff = cnudie.retrieve.component_diff(
+    bom_diff = ocm.retrieve.component_diff(
         left_component=from_component,
         right_component=to_component,
         component_descriptor_lookup=component_descriptor_lookup,

--- a/github/pullrequest.py
+++ b/github/pullrequest.py
@@ -8,8 +8,8 @@ import re
 import github3.pulls
 
 import ci.util
+import ocm.diff
 import ocm.retrieve
-import cnudie.util
 import github.limits
 import gitutil
 import ocm
@@ -303,7 +303,7 @@ def bom_diff(
         component_descriptor_lookup=component_descriptor_lookup,
     )
 
-    formatted_diff = cnudie.util.format_component_diff(
+    formatted_diff = ocm.diff.format_component_diff(
         component_diff=bom_diff,
         delivery_dashboard_url_view_diff=delivery_dashboard_url_view_diff,
         delivery_dashboard_url=delivery_dashboard_url

--- a/ocm/__init__.py
+++ b/ocm/__init__.py
@@ -3,6 +3,7 @@ import dataclasses
 import datetime
 import enum
 import functools
+import graphlib
 import io
 import json
 import logging
@@ -883,7 +884,15 @@ Iterable = collections.abc.Iterable
 
 
 # Type-Aliases (for interoperability w/ external implementations)
-ComponentName = str | tuple[str, str] | Component | ComponentIdentity
+ComponentName = (
+    Component
+    | ComponentDescriptor
+    | ComponentIdentity
+    | ComponentReference
+    | str
+    | tuple[str, str]
+)
+ComponentId = ComponentName  # alias; both coerce between name and identity
 OcmRepositoryLookup = Callable[
     [ComponentName],
     Iterable[OciOcmRepository],
@@ -896,3 +905,103 @@ VersionLookup = Callable[
     [ComponentName, OcmRepository],
     Iterable[str],
 ]
+
+
+def to_component_id(
+    component: ComponentId, /
+) -> ComponentIdentity:
+    if isinstance(component, ComponentIdentity):
+        return component
+
+    if isinstance(component, ComponentDescriptor) or hasattr(component, 'component'):
+        component = component.component
+        # fall through to next case
+    if isinstance(component, Component) or hasattr(component, 'name') \
+        and not hasattr(component, 'componentName'):
+        name = component.name
+        version = component.version
+    if isinstance(component, ComponentReference) or hasattr(component, 'componentName'):
+        name = component.componentName
+        version = component.version
+    if isinstance(component, str):
+        try:
+            name, version = component.split(':', 1)
+        except ValueError as ve:
+            ve.add_note(f'{component=}')
+            raise
+    if isinstance(component, tuple):
+        name, version = component
+
+    return ComponentIdentity(
+        name=name,
+        version=version,
+    )
+
+
+def to_component_name(
+    component: ComponentName, /
+) -> str:
+    if isinstance(component, ComponentDescriptor):
+        component = component.component
+    if isinstance(component, Component):
+        component = component.name
+    elif isinstance(component, ComponentIdentity):
+        component = component.name
+    elif isinstance(component, ComponentReference):
+        component = component.componentName
+    elif isinstance(component, tuple):
+        if not len(component) == 2:
+            raise ValueError('expected two-tuple with two elements')
+        component = component[0]
+    if not isinstance(component, str):
+        raise ValueError(component)
+
+    if ':' in component:
+        # assumption: has form <name>:<version>
+        # let exception raise in other cases
+        component, _ = component.split(':')
+
+    return component
+
+
+def to_component(
+    component: Component | ComponentDescriptor, /
+) -> Component:
+    if isinstance(component, Component):
+        return component
+    if isinstance(component, ComponentDescriptor):
+        return component.component
+    raise ValueError(component)
+
+
+def iter_sorted(
+    components: collections.abc.Iterable[Component | ComponentDescriptor], /
+) -> collections.abc.Generator[Component, None, None]:
+    '''
+    returns a generator yielding the given components, honouring their dependencies, starting
+    with "leaf" components (i.e. components w/o dependencies), also known as topologically sorted.
+    '''
+    components = (to_component(c) for c in components)
+    components_by_id = {c.identity(): c for c in components}
+
+    toposorter = graphlib.TopologicalSorter()
+
+    def ref_to_comp_id(component_ref: ComponentReference) -> ComponentIdentity:
+        return ComponentIdentity(
+            name=component_ref.componentName,
+            version=component_ref.version,
+        )
+
+    for component_id, component in components_by_id.items():
+        depended_on_comp_ids = (
+            ref_to_comp_id(cref)
+            for cref in component.componentReferences
+        )
+        toposorter.add(component_id, *depended_on_comp_ids)
+
+    for component_id in toposorter.static_order():
+        if component_id not in components_by_id:
+            # ignore component-references not contained in passed components for now
+            continue
+
+        yield components_by_id[component_id]

--- a/ocm/access.py
+++ b/ocm/access.py
@@ -148,3 +148,119 @@ def to_absolute_oci_access(
         raise ValueError(f'Unsupported access type: {access.type}')
 
     return access
+
+
+def normalise_component_name(component_name: str) -> str:
+    return component_name.lower()  # oci-spec demands lowercase
+
+
+def to_component_id_and_repository_url(
+    component: ocm.Component | ocm.ComponentDescriptor | ocm.ComponentIdentity | str,
+    repository: ocm.OciOcmRepository | str=None,
+) -> tuple[ocm.Component | ocm.ComponentIdentity, str]:
+    if isinstance(component, str):
+        name, version = component.rsplit(':', 1)
+        component = ocm.ComponentIdentity(
+            name=name,
+            version=version,
+        )
+
+    if isinstance(component, ocm.ComponentDescriptor):
+        component = component.component
+    elif isinstance(component, ocm.ComponentIdentity) and not repository:
+        raise ValueError('repository must be passed if calling w/ component-identity')
+
+    if not repository:  # component is sure to be of type ocm.Component by now (checked above)
+        repository = component.current_ocm_repo
+
+    if isinstance(repository, ocm.OciOcmRepository):
+        repo_base_url = repository.baseUrl
+    elif isinstance(repository, str):
+        repo_base_url = repository
+    else:
+        raise ValueError(f'only OciOcmRepository is supported - got: {repository=}')
+
+    return component, repo_base_url
+
+
+def oci_ref(
+    component: ocm.Component | ocm.ComponentDescriptor | ocm.ComponentIdentity | str,
+    repository: ocm.OciOcmRepository | str=None,
+) -> oci.model.OciImageReference:
+    component, repo_base_url = to_component_id_and_repository_url(
+        component=component,
+        repository=repository,
+    )
+
+    return oci.model.OciImageReference(
+        '/'.join((
+            repo_base_url.rstrip('/'),
+            'component-descriptors',
+            f'{component.name.lower()}:{component.version}',
+        )),
+    )
+
+
+def target_oci_ref(
+    component: ocm.Component,
+    component_ref: ocm.ComponentReference=None,
+    component_version: str=None,
+) -> str:
+    if not component_ref:
+        component_ref = component
+        component_name = component_ref.name
+    else:
+        component_name = component_ref.componentName
+
+    component_name = normalise_component_name(component_name)
+    component_version = component_ref.version
+
+    last_ocm_repo = component.current_ocm_repo
+
+    return last_ocm_repo.component_version_oci_ref(
+        name=component_name,
+        version=component_version,
+    )
+
+
+def oci_artefact_reference(
+    component: (
+        ocm.Component
+        | ocm.ComponentIdentity
+        | ocm.ComponentReference
+        | str  # 'name:version'
+        | tuple[str, str]  # (name, version)
+    ),
+    ocm_repository: str | ocm.OciOcmRepository=None,
+) -> str:
+    if isinstance(component, ocm.Component):
+        if not ocm_repository:
+            ocm_repository = component.current_ocm_repo
+        component_name = component.name
+        component_version = component.version
+    elif isinstance(component, ocm.ComponentIdentity):
+        component_name = component.name
+        component_version = component.version
+    elif isinstance(component, ocm.ComponentReference):
+        component_name = component.componentName
+        component_version = component.version
+    elif isinstance(component, str):
+        component_name, component_version = component.split(':')
+    elif isinstance(component, tuple):
+        if not len(component) == 2 or not all(isinstance(x, str) for x in component):
+            raise TypeError('if a tuple is given as component, it must contain two strings')
+        component_name, component_version = component
+    else:
+        raise ValueError(component)
+
+    if not ocm_repository:
+        raise ValueError('ocm_repository must be given unless a Component is passed.')
+    if isinstance(ocm_repository, str):
+        ocm_repository = ocm.OciOcmRepository(baseUrl=ocm_repository)
+    elif not isinstance(ocm_repository, ocm.OciOcmRepository):
+        raise TypeError(type(ocm_repository))
+
+    return ocm_repository.component_version_oci_ref(
+        name=component_name,
+        version=component_version,
+    )

--- a/ocm/retrieve.py
+++ b/ocm/retrieve.py
@@ -12,7 +12,7 @@ import dacite
 import requests
 import yaml
 
-import cnudie.util
+import ocm.diff
 import ocm
 import ocm.oci
 import ocm.iter as oi
@@ -200,7 +200,7 @@ def file_system_cache_component_descriptor_lookup(
     _writeback = WriteBack(writeback)
 
     def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         ocm_repository_lookup: OcmRepositoryLookup=ocm_repository_lookup,
     ):
         ocm_repos = iter_ocm_repositories(
@@ -221,7 +221,7 @@ def file_system_cache_component_descriptor_lookup(
             if not isinstance(ocm_repo, ocm.OciOcmRepository):
                 raise NotImplementedError(ocm_repo)
 
-            component_id = cnudie.util.to_component_id(component_id)
+            component_id = ocm.to_component_id(component_id)
 
             descriptor_path = os.path.join(
                 cache_dir,
@@ -259,7 +259,7 @@ def delivery_service_component_descriptor_lookup(
         absent_ok: bool=default_absent_ok,
         ignore_errors: tuple[Exception]=default_ignore_errors,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
         ocm_repos = iter_ocm_repositories(
             component_id,
             ocm_repository_lookup,
@@ -412,7 +412,7 @@ def oci_component_descriptor_lookup(
         if not ocm_repository_lookup:
             raise ValueError('ocm_repository_lookup must be passed')
 
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         if isinstance(oci_client, collections.abc.Callable):
             local_oci_client = oci_client()
@@ -484,7 +484,7 @@ def version_lookup(
         ocm_repository_lookup: OcmRepositoryLookup=ocm_repository_lookup,
         absent_ok: bool=default_absent_ok,
     ):
-        component_name = cnudie.util.to_component_name(component_id)
+        component_name = ocm.to_component_name(component_id)
         ocm_repos = iter_ocm_repositories(
             component_name,
             ocm_repository_lookup,
@@ -536,7 +536,7 @@ def composite_component_descriptor_lookup(
         ocm_repository_lookup=ocm_repository_lookup,
         absent_ok=default_absent_ok,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
         writebacks = []
         for lookup in lookups:
             res = None
@@ -637,9 +637,9 @@ def component_diff(
     ignore_component_names=(),
     component_descriptor_lookup: ComponentDescriptorLookupById=None,
     recursion_depth: int=-1,
-) -> cnudie.util.ComponentDiff:
-    left_component = cnudie.util.to_component(left_component)
-    right_component = cnudie.util.to_component(right_component)
+) -> ocm.diff.ComponentDiff:
+    left_component = ocm.to_component(left_component)
+    right_component = ocm.to_component(right_component)
 
     if not component_descriptor_lookup:
         component_descriptor_lookup = create_default_component_descriptor_lookup()
@@ -661,7 +661,7 @@ def component_diff(
         ) if component_node.component.name not in ignore_component_names
     )
 
-    return cnudie.util.diff_components(
+    return ocm.diff.diff_components(
         left_components=left_components,
         right_components=right_components,
         ignore_component_names=ignore_component_names,

--- a/ocm/retrieve_async.py
+++ b/ocm/retrieve_async.py
@@ -12,7 +12,7 @@ import dacite
 import requests
 import yaml
 
-import cnudie.util
+import ocm.diff
 import ocm
 import ocm.iter as oi
 import ocm.oci
@@ -25,12 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 ComponentDescriptorLookupById = collections.abc.Callable[
-    [cnudie.util.ComponentId, ocm.retrieve.OcmRepositoryLookup],
+    [ocm.ComponentId, ocm.retrieve.OcmRepositoryLookup],
     collections.abc.Awaitable[ocm.ComponentDescriptor],
 ]
 
 VersionLookupByComponent = collections.abc.Callable[
-    [cnudie.util.ComponentName, ocm.OcmRepository],
+    [ocm.ComponentName, ocm.OcmRepository],
     collections.abc.Awaitable[collections.abc.Sequence[str]],
 ]
 
@@ -74,10 +74,10 @@ def in_memory_cache_component_descriptor_lookup(
     _writeback = WriteBack(writeback)
 
     async def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         ocm_repository_lookup=ocm_repository_lookup,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         ocm_repos = ocm.retrieve.iter_ocm_repositories(
             component_id,
@@ -143,10 +143,10 @@ def file_system_cache_component_descriptor_lookup(
     _writeback = WriteBack(writeback)
 
     async def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         ocm_repository_lookup: ocm.retrieve.OcmRepositoryLookup=ocm_repository_lookup,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         ocm_repos = ocm.retrieve.iter_ocm_repositories(
             component_id,
@@ -197,12 +197,12 @@ def delivery_service_component_descriptor_lookup(
         raise ValueError(delivery_client)
 
     async def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         ocm_repository_lookup: ocm.retrieve.OcmRepositoryLookup=ocm_repository_lookup,
         absent_ok: bool=default_absent_ok,
         ignore_errors: tuple[Exception]=default_ignore_errors,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         ocm_repos = ocm.retrieve.iter_ocm_repositories(
             component_id,
@@ -350,11 +350,11 @@ def oci_component_descriptor_lookup(
         raise ValueError(oci_client)
 
     async def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         ocm_repository_lookup: ocm.retrieve.OcmRepositoryLookup=ocm_repository_lookup,
         absent_ok=default_absent_ok,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         if isinstance(oci_client, collections.abc.Callable):
             local_oci_client = oci_client()
@@ -404,11 +404,11 @@ def version_lookup(
     default_absent_ok: bool=True,
 ) -> VersionLookupByComponent:
     async def lookup(
-        component_id: cnudie.util.ComponentName,
+        component_id: ocm.ComponentName,
         ocm_repository_lookup: ocm.retrieve.OcmRepositoryLookup=ocm_repository_lookup,
         absent_ok: bool=default_absent_ok,
     ):
-        component_name = cnudie.util.to_component_name(component_id)
+        component_name = ocm.to_component_name(component_id)
 
         ocm_repos = ocm.retrieve.iter_ocm_repositories(
             component_name,
@@ -458,12 +458,12 @@ def composite_component_descriptor_lookup(
     default_absent_ok=True,
 ) -> ComponentDescriptorLookupById:
     async def lookup(
-        component_id: cnudie.util.ComponentId,
+        component_id: ocm.ComponentId,
         /,
         ocm_repository_lookup=ocm_repository_lookup,
         absent_ok=default_absent_ok,
     ):
-        component_id = cnudie.util.to_component_id(component_id)
+        component_id = ocm.to_component_id(component_id)
 
         writebacks = []
         for lookup in lookups:
@@ -565,11 +565,11 @@ async def component_diff(
     right_component: ocm.Component | ocm.ComponentDescriptor,
     component_descriptor_lookup: ComponentDescriptorLookupById,
     ignore_component_names=(),
-) -> cnudie.util.ComponentDiff:
+) -> ocm.diff.ComponentDiff:
     import ocm.iter_async as oia # late import to avoid cyclic dependencies
 
-    left_component = cnudie.util.to_component(left_component)
-    right_component = cnudie.util.to_component(right_component)
+    left_component = ocm.to_component(left_component)
+    right_component = ocm.to_component(right_component)
 
     left_components = [
         component_node.component async for component_node in oia.iter(
@@ -587,7 +587,7 @@ async def component_diff(
         ) if component_node.component.name not in ignore_component_names
     ]
 
-    return cnudie.util.diff_components(
+    return ocm.diff.diff_components(
         left_components=left_components,
         right_components=right_components,
         ignore_component_names=ignore_component_names,

--- a/ocm/util.py
+++ b/ocm/util.py
@@ -23,30 +23,35 @@ def main_source(
     ambiguous_ok: bool=True,
 ) -> ocm.Source | None:
     '''
-    returns the "main source" of the given OCM Component. Typically, components will have exactly
-    one source, in which the applied logic is to return the sole source-artefact.
+    returns the "main source" of the given OCM Component. Sources labelled with
+    `cloud.gardener/cicd/source` and `repository-classification: main` take precedence.
+    Otherwise, a component with exactly one source is unambiguous.
 
     For other cases, behaviour can be controlled via kw-(only-)params:
 
     no_source_ok: if component has _no_ sources, return None
-    ambiguous_ok: if component has more than one source, return first
+    ambiguous_ok: if no main-source can be determined, return first source
 
     In cases where no main-source can be determined, raises ValueError.
     '''
     component = as_component(component)
 
+    for source in component.sources:
+        label = source.find_label('cloud.gardener/cicd/source')
+        if label and label.value.get('repository-classification') == 'main':
+            return source
+
     if len(component.sources) == 1:
         return component.sources[0]
-    elif not component.sources:
+    if not component.sources:
         if no_source_ok:
             return None
-        else:
-            raise ValueError('no sources', component)
+        raise ValueError('no sources', component)
 
     if ambiguous_ok:
         return component.sources[0]
 
-    raise ValueError('could not umambiguously determine main-source', component)
+    raise ValueError('could not unambiguously determine main-source', component)
 
 
 def artifact_url(

--- a/release_notes/fetch.py
+++ b/release_notes/fetch.py
@@ -6,7 +6,7 @@ import os
 import git
 import github3.repos
 
-import cnudie.retrieve
+import ocm.retrieve
 import gitutil
 import ocm
 import ocm.util
@@ -261,7 +261,7 @@ def _determine_blocks_to_include(
 
 def fetch_release_notes(
     component: ocm.Component,
-    version_lookup: cnudie.retrieve.VersionLookupByComponent,
+    version_lookup: ocm.retrieve.VersionLookupByComponent,
     git_helper: gitutil.GitHelper,
     github_api_lookup: rnu.GithubApiLookup,
     version_whither: str | None=None,

--- a/release_notes/ocm.py
+++ b/release_notes/ocm.py
@@ -13,7 +13,7 @@ import zlib
 import dacite
 import yaml
 
-import cnudie.retrieve
+import ocm.retrieve
 import oci.client
 import ocm
 import ocm.gardener
@@ -206,7 +206,7 @@ def release_notes_for_subcomponents(
     version_filter: collections.abc.Callable[[str], bool]=lambda _: True,
     seen_component_ids: set[ocm.ComponentIdentity] | None=None,
 ) -> collections.abc.Iterable[rnm.ReleaseNotesDoc]:
-    component_diff = cnudie.retrieve.component_diff(
+    component_diff = ocm.retrieve.component_diff(
         left_component=whence_component,
         right_component=whither_component,
         component_descriptor_lookup=component_descriptor_lookup,

--- a/sbom/__main__.py
+++ b/sbom/__main__.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 
-import cnudie.retrieve
+import ocm.retrieve
 import oci.auth
 import oci.client
 import ocm
@@ -98,13 +98,13 @@ def _fetch_sboms(parsed):
 
     format_prefixes: list[str] = parsed.sbom_formats
 
-    ocm_repo_lookup = cnudie.retrieve.ocm_repository_lookup(*parsed.ocm_repositories)
-    lookup = cnudie.retrieve.composite_component_descriptor_lookup(
+    ocm_repo_lookup = ocm.retrieve.ocm_repository_lookup(*parsed.ocm_repositories)
+    lookup = ocm.retrieve.composite_component_descriptor_lookup(
         lookups=(
-            cnudie.retrieve.in_memory_cache_component_descriptor_lookup(
+            ocm.retrieve.in_memory_cache_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
             ),
-            cnudie.retrieve.oci_component_descriptor_lookup(
+            ocm.retrieve.oci_component_descriptor_lookup(
                 ocm_repository_lookup=ocm_repo_lookup,
                 oci_client=oci_client,
             ),

--- a/test/ocm/ocm_util_test.py
+++ b/test/ocm/ocm_util_test.py
@@ -2,15 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 import pytest
 
-import cnudie.util
 import ocm
-
-# functions under test
-diff_components = cnudie.util.diff_components
-diff_resources = cnudie.util.diff_resources
+import ocm.diff
+import ocm.util
 
 
 @pytest.fixture
@@ -65,17 +61,17 @@ def iref():
 
 
 def test_componentdiff_to_str(cid):
-    diff = cnudie.util.ComponentDiff(
+    diff = ocm.diff.ComponentDiff(
         cidentities_only_left=(cid(name='a', version='1.0.0'), cid(name='b', version='2.0.0')),
         cidentities_only_right=(cid(name='c', version='3.0.0'),),  # added
         cpairs_version_changed=[
-            (comp('d', '1.0.0'), comp('d', '2.0.0'))  # changed
+            (comp('d', '1.0.0'), comp('d', '2.0.0')),  # changed
         ],
         names_only_left={'a', 'b'},
         names_only_right={'c'},
         names_version_changed={'d'},
     )
-    formatted_diff = cnudie.util.format_component_diff(
+    formatted_diff = ocm.diff.format_component_diff(
         component_diff=diff,
         delivery_dashboard_url_view_diff=None,
         delivery_dashboard_url=None,
@@ -111,7 +107,7 @@ def test_iter_sorted():
     comp_b = comp(name='b', version=1, componentReferences=[cref(comp_a)])
     comp_c = comp(name='c', version=1, componentReferences=[cref(comp_a), cref(comp_b)])
 
-    sorted_comps = tuple(cnudie.util.iter_sorted((comp_c, comp_b, comp_a)))
+    sorted_comps = tuple(ocm.iter_sorted((comp_c, comp_b, comp_a)))
 
     assert sorted_comps == (comp_a, comp_b, comp_c)
 
@@ -123,12 +119,15 @@ def test_remove_component(cid):
     ]
 
     right_components = [
-        comp('c1', '1.2.3'), # version changed
-        # comp('c2', '1.2.3'), # removed
+        comp('c1', '1.2.3'),  # version changed
+        # comp('c2', '1.2.3'),  # removed
     ]
 
-    result = diff_components(left_components=left_components, right_components=right_components)
-    assert result.cidentities_only_left ==  {cid('c2', 'v2.0.0')}
+    result = ocm.diff.diff_components(
+        left_components=left_components,
+        right_components=right_components,
+    )
+    assert result.cidentities_only_left == {cid('c2', 'v2.0.0')}
     assert result.cidentities_only_right == set()
     assert result.cpairs_version_changed == []
     assert result.names_only_left == {'c2'}
@@ -139,8 +138,11 @@ def test_remove_component(cid):
     left_components.append(comp('c2', 'v1.4.0'))
     left_components.append(comp('c2', 'v1.5.0'))
 
-    result = diff_components(left_components=left_components, right_components=right_components)
-    assert result.cidentities_only_left ==  {
+    result = ocm.diff.diff_components(
+        left_components=left_components,
+        right_components=right_components,
+    )
+    assert result.cidentities_only_left == {
         cid('c2', 'v1.4.0'),
         cid('c2', 'v1.5.0'),
     }
@@ -156,19 +158,19 @@ def test_diff_components(cid):
         comp('c1', '1.2.3'),
         comp('c2', '1.2.3'),
         comp('c3', '1.2.3'),
-        # comp('c4', '1.2.3'), # missing on left
-        comp('c5', '1.2.3'), # version changed
+        # comp('c4', '1.2.3'),  # missing on left
+        comp('c5', '1.2.3'),  # version changed
     )
 
     right_components = (
-        comp('c1', '2.2.3'), # version changed
-        comp('c2', '1.2.3'), # no change
-        #cid('c3', '1.2.3'), # missing on right
-        comp('c4', '1.2.3'), # added on right
-        comp('c5', '2.3.4'), # version changed
+        comp('c1', '2.2.3'),  # version changed
+        comp('c2', '1.2.3'),  # no change
+        # cid('c3', '1.2.3'),  # missing on right
+        comp('c4', '1.2.3'),  # added on right
+        comp('c5', '2.3.4'),  # version changed
     )
 
-    result = diff_components(left_components, right_components)
+    result = ocm.diff.diff_components(left_components, right_components)
 
     assert result.cidentities_only_left == {
         cid('c1', '1.2.3'), cid('c3', '1.2.3'), cid('c5', '1.2.3'),
@@ -182,10 +184,10 @@ def test_diff_components(cid):
     ]
     assert result.names_only_left == {'c3'}
     assert result.names_only_right == {'c4'}
-    assert result.names_version_changed == {'c1','c5'}
+    assert result.names_version_changed == {'c1', 'c5'}
 
 
-#TODO add other resources than OCI images
+# TODO add other resources than OCI images
 def test_diff_resources(iref):
     left_comp = comp('x.o/a/b', '1.2.3')
     right_comp = comp('x.o/a/b', '2.3.4')
@@ -195,9 +197,9 @@ def test_diff_resources(iref):
     left_comp.resources.append(img1)
     right_comp.resources.append(img1)
 
-    img_diff = diff_resources(left_component=left_comp, right_component=right_comp)
+    img_diff = ocm.diff.diff_resources(left_component=left_comp, right_component=right_comp)
 
-    # same image added declared by left and right - expect empty diff
+    # same image declared by left and right - expect empty diff
     assert img_diff.left_component == left_comp
     assert img_diff.right_component == right_comp
     assert len(img_diff.resource_refs_only_right) == 0
@@ -209,17 +211,17 @@ def test_diff_resources(iref):
     right_comp.resources.append(img3)
 
     # img2 only left, img3 only right
-    resource_diff = diff_resources(left_component=left_comp, right_component=right_comp)
+    resource_diff = ocm.diff.diff_resources(left_component=left_comp, right_component=right_comp)
     assert len(resource_diff.resource_refs_only_left) == 1
     assert len(resource_diff.resource_refs_only_right) == 1
     assert list(resource_diff.resource_refs_only_left)[0] == img2
     assert list(resource_diff.resource_refs_only_right)[0] == img3
 
     img4_0 = iref('i4', '1.2.3')
-    img4_1 = iref('i4', '2.0.0') # changed version
+    img4_1 = iref('i4', '2.0.0')  # changed version
     left_comp.resources.append(img4_0)
     right_comp.resources.append(img4_1)
-    resource_diff = diff_resources(left_component=left_comp, right_component=right_comp)
+    resource_diff = ocm.diff.diff_resources(left_component=left_comp, right_component=right_comp)
     assert len(resource_diff.resource_refs_only_left) == 1
     assert len(resource_diff.resource_refs_only_right) == 1
     assert len(resource_diff.resourcepairs_version_changed) == 1
@@ -235,18 +237,18 @@ def test_diff_resources(iref):
     left_comp.resources.append(img5_0)
     left_comp.resources.append(img5_1)
     left_comp.resources.append(img5_2)
-    resource_diff = diff_resources(left_component=left_comp, right_component=right_comp)
+    resource_diff = ocm.diff.diff_resources(left_component=left_comp, right_component=right_comp)
     assert len(resource_diff.resource_refs_only_left) == 4
     assert len(resource_diff.resource_refs_only_right) == 1
     assert list(resource_diff.resource_refs_only_left)[1] == img5_0
     assert list(resource_diff.resource_refs_only_left)[2] == img5_1
     assert list(resource_diff.resource_refs_only_left)[3] == img5_2
 
-    # test if grouping semantic does work
+    # test if grouping semantics work
     right_comp.resources.append(img5_0)
     img5_3 = iref('res5', '1.2.6')
     right_comp.resources.append(img5_3)
-    resource_diff = diff_resources(left_component=left_comp, right_component=right_comp)
+    resource_diff = ocm.diff.diff_resources(left_component=left_comp, right_component=right_comp)
 
     assert len(resource_diff.resource_refs_only_left) == 2
     assert len(resource_diff.resource_refs_only_right) == 1
@@ -262,7 +264,7 @@ def test_label_usage():
             access=ocm.GithubAccess(
                 type=ocm.AccessType.GITHUB,
                 ref='refs/heads/master',
-                repoUrl='github.com/otherOrg/otherRepo'
+                repoUrl='github.com/otherOrg/otherRepo',
             ),
             labels=[
                 ocm.Label(
@@ -276,7 +278,7 @@ def test_label_usage():
             access=ocm.GithubAccess(
                 type=ocm.AccessType.GITHUB,
                 ref='refs/heads/master',
-                repoUrl='github.com/org/repo'
+                repoUrl='github.com/org/repo',
             ),
             labels=[
                 ocm.Label(
@@ -302,7 +304,7 @@ def test_label_usage():
         provider=[],
     )
 
-    main_source = cnudie.util.determine_main_source_for_component(component_with_source_label,)
+    main_source = ocm.util.main_source(component_with_source_label)
     assert main_source.labels[0].value == {'repository-classification': 'main'}
     assert main_source.name == 'repo_main_source'
 
@@ -315,7 +317,7 @@ def test_label_usage():
                 access=ocm.GithubAccess(
                     type=ocm.AccessType.GITHUB,
                     ref='refs/heads/master',
-                    repoUrl='github.com/org/repo'
+                    repoUrl='github.com/org/repo',
                 ),
             ),
             ocm.Source(
@@ -323,7 +325,7 @@ def test_label_usage():
                 access=ocm.GithubAccess(
                     type=ocm.AccessType.GITHUB,
                     ref='refs/heads/master',
-                    repoUrl='github.com/otherOrg/otherRepo'
+                    repoUrl='github.com/otherOrg/otherRepo',
                 ),
             ),
         ],
@@ -339,7 +341,7 @@ def test_label_usage():
         provider=[],
     )
 
-    main_source = cnudie.util.determine_main_source_for_component(component_without_source_label)
+    main_source = ocm.util.main_source(component_without_source_label)
 
     assert main_source.name == 'repo_main_source'
 
@@ -347,66 +349,62 @@ def test_label_usage():
 def test_diff_label():
     label_foo = ocm.Label(name='foo', value='bar v1')
 
-    left_labels = [
-        label_foo
-    ]
-    right_labels = [
-        label_foo
-    ]
+    left_labels = [label_foo]
+    right_labels = [label_foo]
 
-    # check identical label in both lists
-    label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    # identical labels in both lists
+    label_diff = ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
     assert len(label_diff.label_pairs_changed) == 0
     assert len(label_diff.labels_only_left) == 0
     assert len(label_diff.labels_only_right) == 0
 
-    # check left exclusive label
+    # left-exclusive label
     label_only_left = ocm.Label(name='left', value='only')
     left_labels.append(label_only_left)
-    label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    label_diff = ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
     assert len(label_diff.label_pairs_changed) == 0
     assert len(label_diff.labels_only_left) == 1
     assert label_diff.labels_only_left[0] == label_only_left
     assert len(label_diff.labels_only_right) == 0
 
-    # check right exclusive label
+    # right-exclusive label
     label_only_right = ocm.Label(name='right', value='only')
     right_labels.append(label_only_right)
-    label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    label_diff = ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
     assert len(label_diff.label_pairs_changed) == 0
     assert len(label_diff.labels_only_left) == 1
     assert len(label_diff.labels_only_right) == 1
     assert label_diff.labels_only_right[0] == label_only_right
 
-    # check removal of one label
+    # removal of one label
     right_labels.remove(label_foo)
-    label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    label_diff = ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
     assert len(label_diff.label_pairs_changed) == 0
     assert len(label_diff.labels_only_left) == 2
     assert label_diff.labels_only_left[0] == label_foo
     assert len(label_diff.labels_only_right) == 1
 
-    # check different label value with the same name
+    # same name, different value
     label_foo_updated = ocm.Label(name='foo', value='bar v2')
     right_labels.append(label_foo_updated)
-    label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    label_diff = ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
     assert len(label_diff.label_pairs_changed) == 1
     assert label_diff.label_pairs_changed[0] == (label_foo, label_foo_updated)
     assert len(label_diff.labels_only_left) == 1
     assert len(label_diff.labels_only_right) == 1
 
-    # check that duplicate label name in one list cause exception
+    # duplicate label names in one list must raise
     right_labels.append(label_foo_updated)
     with pytest.raises(RuntimeError) as re:
-        label_diff = cnudie.util.diff_labels(left_labels=left_labels, right_labels=right_labels)
-    assert re != None
+        ocm.diff.diff_labels(left_labels=left_labels, right_labels=right_labels)
+    assert re is not None
 
 
 def test_to_component_id():
     base_identity = ocm.ComponentIdentity(name='Foo', version='1.2.3')
 
     test_identity = ocm.ComponentIdentity(name='Foo', version='1.2.3')
-    assert cnudie.util.to_component_id(test_identity) == base_identity
+    assert ocm.to_component_id(test_identity) == base_identity
 
     test_component = ocm.Component(
         name='Foo',
@@ -417,36 +415,36 @@ def test_to_component_id():
         componentReferences=[],
         resources=[],
     )
-    assert cnudie.util.to_component_id(test_component) == base_identity
+    assert ocm.to_component_id(test_component) == base_identity
 
     test_component_descriptor = ocm.ComponentDescriptor(
         meta=ocm.Metadata(),
         component=test_component,
         signatures=[],
     )
-    assert cnudie.util.to_component_id(test_component_descriptor) == base_identity
+    assert ocm.to_component_id(test_component_descriptor) == base_identity
 
     test_component_reference = ocm.ComponentReference(
         componentName='Foo', name='Bar', version='1.2.3',
     )
-    assert cnudie.util.to_component_id(test_component_reference) == base_identity
+    assert ocm.to_component_id(test_component_reference) == base_identity
 
     test_str = 'Foo:1.2.3'
-    assert cnudie.util.to_component_id(test_str) == base_identity
+    assert ocm.to_component_id(test_str) == base_identity
 
     test_str = 'Foo'
     with pytest.raises(ValueError):
-        cnudie.util.to_component_id(test_str)
+        ocm.to_component_id(test_str)
 
     test_tuple = 'Foo', '1.2.3'
-    assert cnudie.util.to_component_id(test_tuple) == base_identity
+    assert ocm.to_component_id(test_tuple) == base_identity
 
 
 def test_to_component_name():
     base_name = 'Foo'
 
     test_identity = ocm.ComponentIdentity(name='Foo', version='1.2.3')
-    assert cnudie.util.to_component_name(test_identity) == base_name
+    assert ocm.to_component_name(test_identity) == base_name
 
     test_component = ocm.Component(
         name='Foo',
@@ -457,26 +455,26 @@ def test_to_component_name():
         componentReferences=[],
         resources=[],
     )
-    assert cnudie.util.to_component_name(test_component) == base_name
+    assert ocm.to_component_name(test_component) == base_name
 
     test_component_descriptor = ocm.ComponentDescriptor(
         meta=ocm.Metadata(),
         component=test_component,
         signatures=[],
     )
-    assert cnudie.util.to_component_name(test_component_descriptor) == base_name
+    assert ocm.to_component_name(test_component_descriptor) == base_name
 
     test_component_reference = ocm.ComponentReference(
         componentName='Foo', name='Bar', version='1.2.3',
     )
-    assert cnudie.util.to_component_name(test_component_reference) == base_name
+    assert ocm.to_component_name(test_component_reference) == base_name
 
     test_str = 'Foo:1.2.3'
-    assert cnudie.util.to_component_name(test_str) == base_name
+    assert ocm.to_component_name(test_str) == base_name
 
     test_str = 'Foo:Bar:Baz'
     with pytest.raises(ValueError):
-        cnudie.util.to_component_name(test_str)
+        ocm.to_component_name(test_str)
 
     test_tuple = 'Foo', '1.2.3'
-    assert cnudie.util.to_component_name(test_tuple) == base_name
+    assert ocm.to_component_name(test_tuple) == base_name

--- a/test/sbom/scan_test.py
+++ b/test/sbom/scan_test.py
@@ -34,7 +34,7 @@ def _load_scan():
 
     spec = importlib.util.spec_from_file_location('scan', _scan_py)
     mod = importlib.util.module_from_spec(spec)
-    for name in ('cnudie', 'cnudie.retrieve', 'oci.auth', 'ocm.iter'):
+    for name in ('oci.auth', 'ocm.iter', 'ocm.retrieve'):
         if name not in sys.modules:
             sys.modules[name] = types.ModuleType(name)
     spec.loader.exec_module(mod)

--- a/version.py
+++ b/version.py
@@ -709,3 +709,22 @@ def find_predecessor(
                 return candidate_orig
 
     return candidate_orig
+
+
+META_SEPARATOR = '.build-'
+
+
+def sanitise_version(version: str) -> str:
+    '''
+    Additional build-metadata as defined in SemVer can be added via `+` to the version. However,
+    OCI registries don't support `+` as a tag character, so this function converts a semver into
+    an OCI-tag-safe form by replacing `+` with `META_SEPARATOR`.
+    '''
+    return version.replace('+', META_SEPARATOR)
+
+
+def desanitise_version(version: str) -> str:
+    '''
+    Reverts `sanitise_version`, restoring the original semver representation.
+    '''
+    return version.replace(META_SEPARATOR, '+')


### PR DESCRIPTION
`cnudie.util` was the last part of the deprecated `cnudie` package that still contained
implementations. This PR moves them to their new canonical homes and reduces `cnudie.util`
to a pure re-export shim, mirroring how `cnudie.retrieve` was handled in #1704.

**New homes**
- `ocm/__init__.py`: `ComponentId` / `ComponentName` aliases (widened), `to_component_id`,
  `to_component_name`, `to_component`, `iter_sorted`
- `ocm/diff.py` (new): `ComponentDiff`, `LabelDiff`, `ResourceDiff`, `ComponentResource`,
  `diff_components`, `diff_labels`, `diff_resources`, `format_component_diff`
- `ocm/access.py`: `oci_ref`, `target_oci_ref`, `oci_artefact_reference`,
  `normalise_component_name`, `to_component_id_and_repository_url`
- `ocm/util.py`: `main_source` gained the label-aware heuristic already known to
  `cnudie.util` (`cloud.gardener/cicd/source` + `repository-classification=main`)
- `version.py`: `META_SEPARATOR`, `sanitise_version`, `desanitise_version`

**Dropped**
- `determine_component_name` (no callers)

**Consumers re-pointed**
- `ocm/retrieve{,_async}.py` now bootstrap off `ocm` itself, no longer off `cnudie.util`
- `github/pullrequest.py` uses `ocm.diff.format_component_diff`
- `test/cnudie/cnudie_util_test.py` → `test/ocm/ocm_util_test.py`, targeting new locations

Also on this branch: a preceding commit migrates remaining `cnudie.retrieve` callers
to `ocm.retrieve` (which had already been a pure re-export shim).

The `cnudie` package itself remains shipped for backwards compatibility.

**Release note**:
```other operator
Deprecated `cnudie.util`; helpers moved to `ocm` (`ocm.diff`, `ocm.access`, `ocm.util`,
top-level `ocm`) and `version`. `cnudie.util` continues to work, emitting
`DeprecationWarning`.
```