### PR TITLE
retry transient network failures in install-actions

### DIFF
--- a/.github/actions/install-cbomkit-theia/action.yaml
+++ b/.github/actions/install-cbomkit-theia/action.yaml
@@ -25,7 +25,24 @@ runs:
         image="ghcr.io/cbomkit/cbomkit-theia:${{ inputs.version }}"
         install_dir="${HOME}/.local/bin"
         mkdir -p "${install_dir}"
-        cid="$(docker create --platform "${platform}" "${image}")"
+
+        # retry pull/create: we observed rare TLS-handshake-timeouts to ghcr.io
+        # (e.g. on solinas runners) which are transient; a fresh connection fixes it
+        attempts=3
+        for attempt in $(seq 1 ${attempts}); do
+          if cid="$(docker create --platform "${platform}" "${image}" 2>/tmp/cbomkit-create.err)"; then
+            break
+          fi
+          rc=$?
+          echo "::warning::cbomkit-theia: docker create failed (attempt ${attempt}/${attempts}): $(cat /tmp/cbomkit-create.err)"
+          if [ ${attempt} -lt ${attempts} ]; then
+            sleep $((attempt * 5))
+          else
+            echo "::error::cbomkit-theia: docker create failed after ${attempts} attempts"
+            exit ${rc}
+          fi
+        done
+
         docker cp "${cid}:/app/cbomkit-theia" "${install_dir}/cbomkit-theia"
         docker rm "${cid}"
         echo "${install_dir}" >> "${GITHUB_PATH}"

--- a/.github/actions/install-gardener-gha-libs/action.yaml
+++ b/.github/actions/install-gardener-gha-libs/action.yaml
@@ -72,7 +72,23 @@ runs:
       run: |
         set -euo pipefail
         # fallback if running on GHE
-        git clone https://github.com/gardener/cc-utils
+        # retry clone: we observed rare transient TLS/HTTP flakes from solinas
+        # runners to github.com; a fresh connection fixes it
+        attempts=3
+        for attempt in $(seq 1 ${attempts}); do
+          if git clone https://github.com/gardener/cc-utils; then
+            break
+          fi
+          rc=$?
+          echo "::warning::install-gardener-gha-libs: git clone failed (attempt ${attempt}/${attempts})"
+          if [ ${attempt} -lt ${attempts} ]; then
+            rm -rf cc-utils  # possibly-partial clone from previous attempt
+            sleep $((attempt * 5))
+          else
+            echo "::error::install-gardener-gha-libs: git clone failed after ${attempts} attempts"
+            exit ${rc}
+          fi
+        done
     # removed on pinned branches
     - name: install-gardener-gha-libs
       if: ${{ ! steps.check.outputs.already-installed && steps.bundle.outputs.no-bundle == 'true' }}

--- a/.github/actions/install-syft/action.yaml
+++ b/.github/actions/install-syft/action.yaml
@@ -99,11 +99,21 @@ runs:
       run: |
         set -eu
         install_ok=false
-        if curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-          | sh -s -- -b '${{ steps.version.outputs.install-dir }}' \
-               'v${{ steps.version.outputs.target }}'; then
-          install_ok=true
-        fi
+        attempts=3
+        # retry the download: we observed rare transient network/TLS flakes on
+        # solinas runners; fresh connection usually fixes it
+        for attempt in $(seq 1 ${attempts}); do
+          if curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b '${{ steps.version.outputs.install-dir }}' \
+                 'v${{ steps.version.outputs.target }}'; then
+            install_ok=true
+            break
+          fi
+          echo "::warning::syft: download failed (attempt ${attempt}/${attempts})"
+          if [ ${attempt} -lt ${attempts} ]; then
+            sleep $((attempt * 5))
+          fi
+        done
         echo "success=${install_ok}" >> "${GITHUB_OUTPUT}"
 
     - name: add-to-path

--- a/.github/actions/merge-ocm-fragments/action.yaml
+++ b/.github/actions/merge-ocm-fragments/action.yaml
@@ -333,13 +333,7 @@ runs:
 
     - name: install-syft
       if: ${{ inputs.oci-registry != '' }}
-      shell: bash
-      run: |
-        install_dir="${HOME}/.local/bin"
-        mkdir -p "${install_dir}"
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-          | sh -s -- -b "${install_dir}"
-        echo "${install_dir}" >> "${GITHUB_PATH}"
+      uses: gardener/cc-utils/.github/actions/install-syft@master
 
     - name: install-cbomkit-theia
       if: ${{ inputs.oci-registry != '' }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -380,13 +380,9 @@ jobs:
           remove-trusted-label: false
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: install-syft
-        shell: bash
-        run: |
-          install_dir="${HOME}/.local/bin"
-          mkdir -p "${install_dir}"
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-            | sh -s -- -b "${install_dir}"
-          echo "${install_dir}" >> "${GITHUB_PATH}"
+        # use the shared action (retries transient curl flakes; keeps pinned-version
+        # fallback in sync)
+        uses: ./.github/actions/install-syft
       - name: install-cbomkit-theia
         uses: ./.github/actions/install-cbomkit-theia
       - uses: gardener/cc-utils/.github/actions/oci-auth@master
@@ -417,13 +413,9 @@ jobs:
           remove-trusted-label: false
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
       - name: install-syft
-        shell: bash
-        run: |
-          install_dir="${HOME}/.local/bin"
-          mkdir -p "${install_dir}"
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-            | sh -s -- -b "${install_dir}"
-          echo "${install_dir}" >> "${GITHUB_PATH}"
+        # use the shared action (retries transient curl flakes; keeps pinned-version
+        # fallback in sync)
+        uses: ./.github/actions/install-syft
       - name: install-cbomkit-theia
         uses: ./.github/actions/install-cbomkit-theia
       - uses: gardener/cc-utils/.github/actions/oci-auth@master


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

We observed transient network failures on solinas GitHub-Actions runners:

- `install-cbomkit-theia`: `docker create` on `ghcr.io/cbomkit/cbomkit-theia` failed once with
  `TLS handshake timeout` fetching the anonymous token (kubernetes-private/cc-pipelines run
  9297605, runner group sugar-runners-50135). Subsequent runs on same pool passed.
- `install-gardener-gha-libs`: checkout-fallback `git clone https://github.com/gardener/cc-utils`
  flaked with `could not read Username for 'https://github.com'` (run 9301455, same runner pool).

Both are textbook transient single-connection failures. This change adds small bounded retry-loops
so a singleton flake does not fail an entire release pipeline:

- `install-syft`: retry download 3 times
- `install-cbomkit-theia`: retry `docker create` 3 times
- `install-gardener-gha-libs`: retry checkout-fallback clone 3 times
- `merge-ocm-fragments` + `build-and-test.yaml`: replace duplicated inline curl-install of syft
  with the shared `install-syft` action, so all consumers get the retry and the version-pin
  fallback in one place

**Release note**:
```other operator
install-actions now retry transient network failures (syft download, cbomkit-theia docker-create, fallback git-clone on GHE)
```
