### PR TITLE
oci: cleanup and fixes

### DIFF
--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -61,6 +61,142 @@ class ReplicationMode(enum.Enum):
             raise NotImplementedError(self)
 
 
+def _apply_annotations(
+    manifest: om.OciImageManifest | om.OciImageManifestList,
+    annotations: dict[str, str],
+) -> bool:
+    '''Patches annotations into manifest in-place. Returns True if any value changed.'''
+    dirty = False
+    for k, v in annotations.items():
+        if manifest.annotations.get(k) != v:
+            manifest.annotations[k] = v
+            dirty = True
+    return dirty
+
+
+def _replicate_manifest_list(
+    raw_manifest: str,
+    manifest: om.OciImageManifestList,
+    src_image_reference: om.OciImageReference,
+    tgt_image_reference: om.OciImageReference,
+    client: oc.Client,
+    mode: ReplicationMode,
+    platform_filter: collections.abc.Callable[[om.OciPlatform], bool] | None,
+    annotations: dict[str, str] | None,
+) -> tuple[requests.Response, om.OciImageReference, bytes]:
+    src_name = src_image_reference.ref_without_tag
+    tgt_name = tgt_image_reference.ref_without_tag
+    manifest_dirty = False
+
+    for idx, sub_manifest in enumerate(tuple(manifest.manifests)):
+        src_reference = f'{src_name}@{sub_manifest.digest}'
+        tgt_reference = f'{tgt_name}'
+
+        if platform_filter:
+            platform = op.from_single_image(
+                image_reference=src_reference,
+                oci_client=client,
+                base_platform=sub_manifest.platform,
+            )
+            if not platform_filter(platform):
+                logger.info(f'skipping {platform=} for {src_image_reference=}')
+                manifest_dirty = True
+                manifest.manifests.remove(sub_manifest)
+                continue
+
+        logger.info(f'replicating to {tgt_reference=}')
+
+        # only propagate PREFER_MULTIARCH (preserves nested indices); never pass
+        # NORMALISE_TO_MULTIARCH as it would wrap sub-manifests in spurious index layers
+        recursive_mode = ReplicationMode.REGISTRY_DEFAULTS
+        if mode is ReplicationMode.PREFER_MULTIARCH:
+            recursive_mode = ReplicationMode.PREFER_MULTIARCH
+
+        res, ref, submanifest_bytes = replicate_artifact(
+            src_image_reference=src_reference,
+            tgt_image_reference=tgt_reference,
+            oci_client=client,
+            mode=recursive_mode,
+            annotations=annotations,
+        )
+
+        submanifest_digest = f'sha256:{hashlib.sha256(submanifest_bytes).hexdigest()}'
+        if submanifest_digest != sub_manifest.digest:
+            patched = dataclasses.replace(
+                sub_manifest,
+                digest=submanifest_digest,
+                size=len(submanifest_bytes),
+            )
+            manifest.manifests.remove(sub_manifest)
+            manifest.manifests.insert(idx, patched)
+            manifest_dirty = True
+
+    if annotations:
+        manifest_dirty |= _apply_annotations(manifest, annotations)
+
+    if manifest_dirty:
+        raw_manifest = json.dumps(manifest.as_dict())
+
+    manifest_digest = hashlib.sha256(raw_manifest.encode('utf-8')).hexdigest()
+    tgt_image_reference = tgt_image_reference.with_new_digest(digest=manifest_digest)
+
+    res = client.put_manifest(
+        image_reference=tgt_image_reference,
+        manifest=raw_manifest,
+    )
+
+    return res, tgt_image_reference, raw_manifest.encode('utf-8')
+
+
+def _wrap_single_as_manifest_list(
+    src_image_reference: om.OciImageReference,
+    tgt_image_reference: om.OciImageReference,
+    client: oc.Client,
+    media_type: str,
+    annotations: dict[str, str] | None,
+) -> tuple[requests.Response, om.OciImageReference, bytes]:
+    if not src_image_reference.has_digest_tag:
+        src_image_reference = om.OciImageReference.to_image_ref(
+            client.to_digest_hash(image_reference=src_image_reference)
+        )
+
+    platform = op.from_single_image(
+        image_reference=src_image_reference,
+        oci_client=client,
+    )
+    # force digest-tag so the sub-manifest entry is addressable
+    tgt_image_ref = f'{tgt_image_reference.ref_without_tag}@{src_image_reference.tag}'
+
+    res, ref, manifest_bytes = replicate_artifact(
+        src_image_reference=src_image_reference,
+        tgt_image_reference=tgt_image_ref,
+        oci_client=client,
+        annotations=annotations,
+    )
+
+    manifest_list = om.OciImageManifestList(
+        manifests=[
+            om.OciImageManifestListEntry(
+                digest=f'sha256:{hashlib.sha256(manifest_bytes).hexdigest()}',
+                mediaType=media_type,
+                size=len(manifest_bytes),
+                platform=platform,
+            ),
+        ],
+        mediaType=om.DOCKER_MANIFEST_LIST_MIME,
+    )
+    manifest_list_bytes = json.dumps(manifest_list.as_dict()).encode('utf-8')
+    manifest_digest = hashlib.sha256(manifest_list_bytes).hexdigest()
+    tgt_image_reference = tgt_image_reference.with_new_digest(digest=manifest_digest)
+
+    res = client.put_manifest(
+        image_reference=tgt_image_reference,
+        manifest=manifest_list_bytes,
+    )
+
+    return res, tgt_image_reference, manifest_list_bytes
+
+
 def replicate_artifact(
     src_image_reference: str | om.OciImageReference,
     tgt_image_reference: str | om.OciImageReference,
@@ -119,7 +255,7 @@ def replicate_artifact(
 
     accept = mode.accept_header()
 
-    # we need the unaltered - manifest for verbatim replication
+    # we need the unaltered manifest for verbatim replication
     resp = client.manifest_raw(
         image_reference=src_image_reference,
         accept=accept,
@@ -161,158 +297,44 @@ def replicate_artifact(
     elif schema_version == 2:
         media_type = manifest.get('mediaType', om.DOCKER_MANIFEST_SCHEMA_V2_MIME)
 
-        if media_type in (
-            om.DOCKER_MANIFEST_LIST_MIME,
-            om.OCI_IMAGE_INDEX_MIME,
-        ):
-            # multi-arch
-            manifest = dacite.from_dict(
-                data_class=om.OciImageManifestList,
-                data=manifest,
-            )
-            manifest: om.OciImageManifestList
-
-            src_ref = om.OciImageReference(image_reference=src_image_reference)
-            src_name = src_ref.ref_without_tag
-            tgt_ref = om.OciImageReference(image_reference=tgt_image_reference)
-            tgt_name = tgt_ref.ref_without_tag
-
-            # try to avoid modifications (from x-serialisation) - unless we have to
-            manifest_dirty = False
-
-            # cp manifests to tuple, because we _might_ modify if there is a platform_filter
-            for idx, sub_manifest in enumerate(tuple(manifest.manifests)):
-                src_reference = f'{src_name}@{sub_manifest.digest}'
-                tgt_reference = f'{tgt_name}'
-
-                if platform_filter:
-                    platform = op.from_single_image(
-                        image_reference=src_reference,
-                        oci_client=oci_client,
-                        base_platform=sub_manifest.platform,
-                    )
-                    if not platform_filter(platform):
-                        logger.info(f'skipping {platform=} for {src_image_reference=}')
-                        manifest_dirty = True
-                        manifest.manifests.remove(sub_manifest)
-                        continue
-
-                logger.info(f'replicating to {tgt_reference=}')
-
-                # only propagate PREFER_MULTIARCH (preserves nested indices); never pass
-                # NORMALISE_TO_MULTIARCH as it would wrap sub-manifests in spurious index layers
-                recursive_mode = ReplicationMode.REGISTRY_DEFAULTS
-                if mode is ReplicationMode.PREFER_MULTIARCH:
-                    recursive_mode = ReplicationMode.PREFER_MULTIARCH
-
-                res, ref, submanifest_bytes = replicate_artifact(
-                    src_image_reference=src_reference,
-                    tgt_image_reference=tgt_reference,
-                    oci_client=client,
-                    mode=recursive_mode,
-                    annotations=annotations,
-                )
-
-                submanifest_digest = f'sha256:{hashlib.sha256(submanifest_bytes).hexdigest()}'
-                if submanifest_digest != sub_manifest.digest:
-                    patched_sub_manifest = dataclasses.replace(
-                        sub_manifest,
-                        digest=submanifest_digest,
-                        size=len(submanifest_bytes),
-                    )
-                    manifest.manifests.remove(sub_manifest)
-                    manifest.manifests.insert(idx, patched_sub_manifest)
-                    manifest_dirty = True
-
-            if annotations:
-                # try to avoid unnecessary changes by x-serialisation - only add values if
-                # they are either new or different
-                for k, v in annotations.items():
-                    if manifest.annotations.get(k) == v:
-                        continue
-                    else:
-                        manifest.annotations[k] = v
-                        manifest_dirty = True
-
-            if manifest_dirty:
-                raw_manifest = json.dumps(manifest.as_dict())
-
-            manifest_digest = hashlib.sha256(raw_manifest.encode('utf-8')).hexdigest()
-            tgt_image_reference = tgt_image_reference.with_new_digest(digest=manifest_digest)
-
-            res = client.put_manifest(
-                image_reference=tgt_image_reference,
-                manifest=raw_manifest,
+        if media_type in (om.DOCKER_MANIFEST_LIST_MIME, om.OCI_IMAGE_INDEX_MIME):
+            return _replicate_manifest_list(
+                raw_manifest=raw_manifest,
+                manifest=dacite.from_dict(
+                    data_class=om.OciImageManifestList,
+                    data=manifest,
+                ),
+                src_image_reference=src_image_reference,
+                tgt_image_reference=tgt_image_reference,
+                client=client,
+                mode=mode,
+                platform_filter=platform_filter,
+                annotations=annotations,
             )
 
-            return res, tgt_image_reference, raw_manifest.encode('utf-8')
-
-        elif media_type in (
-            om.OCI_MANIFEST_SCHEMA_V2_MIME,
-            om.DOCKER_MANIFEST_SCHEMA_V2_MIME,
-        ):
+        elif media_type in (om.OCI_MANIFEST_SCHEMA_V2_MIME, om.DOCKER_MANIFEST_SCHEMA_V2_MIME):
             if mode is ReplicationMode.NORMALISE_TO_MULTIARCH:
-                if not src_image_reference.has_digest_tag:
-                    src_image_reference = om.OciImageReference.to_image_ref(
-                        oci_client.to_digest_hash(
-                            image_reference=src_image_reference,
-                        )
-                    )
-                platform = op.from_single_image(
-                    image_reference=src_image_reference,
-                    oci_client=oci_client,
-                )
-                # force usage of digest-tag (symbolic tag required for manifest-list
-                tgt_image_ref = \
-                    f'{tgt_image_reference.ref_without_tag}@{src_image_reference.tag}'
-
-                res, ref, manifest_bytes = replicate_artifact(
+                return _wrap_single_as_manifest_list(
                     src_image_reference=src_image_reference,
-                    tgt_image_reference=tgt_image_ref,
-                    oci_client=oci_client,
+                    tgt_image_reference=tgt_image_reference,
+                    client=client,
+                    media_type=media_type,
                     annotations=annotations,
                 )
-
-                manifest_list = om.OciImageManifestList(
-                    manifests=[
-                        om.OciImageManifestListEntry(
-                            digest=f'sha256:{hashlib.sha256(manifest_bytes).hexdigest()}',
-                            mediaType=media_type,
-                            size=len(manifest_bytes),
-                            platform=platform,
-                        ),
-                    ],
-                    mediaType=om.DOCKER_MANIFEST_LIST_MIME,
-                )
-
-                manifest_list_bytes = json.dumps(
-                    manifest_list.as_dict(),
-                ).encode('utf-8')
-
-                manifest_digest = hashlib.sha256(manifest_list_bytes).hexdigest()
-                tgt_image_reference = tgt_image_reference.with_new_digest(digest=manifest_digest)
-
-                res = oci_client.put_manifest(
-                    image_reference=tgt_image_reference,
-                    manifest=manifest_list_bytes,
-                )
-
-                return res, tgt_image_reference, manifest_list_bytes
 
             manifest = dacite.from_dict(
                 data_class=om.OciImageManifest,
-                data=json.loads(raw_manifest)
+                data=json.loads(raw_manifest),
             )
             need_uncompressed_layer_digests = False
             uncompressed_layer_digests = None
         else:
             raise NotImplementedError(f'{media_type=}')
     else:
-      raise NotImplementedError(schema_version)
+        raise NotImplementedError(schema_version)
 
     for idx, layer in enumerate(manifest.blobs()):
         # need to specially handle cfg-blob (may be absent for v2 / legacy images)
-
         is_cfg_blob = idx == 0
         if is_cfg_blob and need_to_synthesise_cfg_blob:
             # if we need(ed) to synthesise cfg-blob (because source-image contained a v1-manifest)
@@ -374,39 +396,32 @@ def replicate_artifact(
 
     if need_to_synthesise_cfg_blob:
         fake_cfg_dict = json.loads(json.loads(raw_manifest)['history'][0]['v1Compatibility'])
-
-        # patch-in uncompressed layer-digests
         fake_cfg_dict['rootfs'] = {
             'diff_ids': uncompressed_layer_digests,
             'type': 'layers',
         }
-
         fake_cfg_raw = json.dumps(fake_cfg_dict).encode('utf-8')
+        cfg_digest = f'sha256:{hashlib.sha256(fake_cfg_raw).hexdigest()}'
 
         client.put_blob(
             image_reference=tgt_image_reference,
-            digest=(cfg_digest := f'sha256:{hashlib.sha256(fake_cfg_raw).hexdigest()}'),
+            digest=cfg_digest,
             octets_count=len(fake_cfg_raw),
             data=fake_cfg_raw,
         )
 
-        manifest_dict = manifest.as_dict()
-        # patch-on altered cfg-digest
-        manifest_dict['config']['digest'] = cfg_digest
-        manifest_dict['config']['size'] = len(fake_cfg_raw)
-        raw_manifest = json.dumps(manifest_dict)
+        manifest = dataclasses.replace(
+            manifest,
+            config=dataclasses.replace(
+                manifest.config,
+                digest=cfg_digest,
+                size=len(fake_cfg_raw),
+            ),
+        )
+        raw_manifest = json.dumps(manifest.as_dict())
 
     if annotations:
-        manifest_dirty = False
-
-        for k, v in annotations.items():
-            if manifest.annotations.get(k) == v:
-                continue
-            else:
-                manifest.annotations[k] = v
-                manifest_dirty = True
-
-        if manifest_dirty:
+        if _apply_annotations(manifest, annotations):
             raw_manifest = json.dumps(manifest.as_dict())
 
     manifest_digest = hashlib.sha256(raw_manifest.encode('utf-8')).hexdigest()

--- a/oci/__init__.py
+++ b/oci/__init__.py
@@ -88,7 +88,9 @@ def _replicate_manifest_list(
     tgt_name = tgt_image_reference.ref_without_tag
     manifest_dirty = False
 
-    for idx, sub_manifest in enumerate(tuple(manifest.manifests)):
+    replicated_manifests = []
+
+    for sub_manifest in manifest.manifests:
         src_reference = f'{src_name}@{sub_manifest.digest}'
         tgt_reference = f'{tgt_name}'
 
@@ -101,7 +103,6 @@ def _replicate_manifest_list(
             if not platform_filter(platform):
                 logger.info(f'skipping {platform=} for {src_image_reference=}')
                 manifest_dirty = True
-                manifest.manifests.remove(sub_manifest)
                 continue
 
         logger.info(f'replicating to {tgt_reference=}')
@@ -122,14 +123,16 @@ def _replicate_manifest_list(
 
         submanifest_digest = f'sha256:{hashlib.sha256(submanifest_bytes).hexdigest()}'
         if submanifest_digest != sub_manifest.digest:
-            patched = dataclasses.replace(
+            sub_manifest = dataclasses.replace(
                 sub_manifest,
                 digest=submanifest_digest,
                 size=len(submanifest_bytes),
             )
-            manifest.manifests.remove(sub_manifest)
-            manifest.manifests.insert(idx, patched)
             manifest_dirty = True
+
+        replicated_manifests.append(sub_manifest)
+
+    manifest.manifests = replicated_manifests
 
     if annotations:
         manifest_dirty |= _apply_annotations(manifest, annotations)

--- a/oci/auth.py
+++ b/oci/auth.py
@@ -279,14 +279,24 @@ def docker_credentials_lookup(
 
         return find_nothing_lookup
 
+    _cfg_cache: dict = {}  # keys: 'auth', 'mtime'
+
     def docker_auth_lookup(
         image_reference: str,
         privileges: Privileges=Privileges.READONLY,
         absent_ok: bool=False,
     ):
-        # re-read docker-cfg to reflect fs-updates
-        with open(docker_cfg) as f:
-            docker_auth = json.load(f)
+        try:
+            mtime = os.stat(docker_cfg).st_mtime
+        except OSError:
+            mtime = None
+
+        if 'auth' not in _cfg_cache or _cfg_cache.get('mtime') != mtime:
+            with open(docker_cfg) as f:
+                _cfg_cache['auth'] = json.load(f)
+            _cfg_cache['mtime'] = mtime
+
+        docker_auth = _cfg_cache['auth']
 
         if image_reference.startswith('/'):
             # relative reference - no means to find appropriate cfg

--- a/oci/client.py
+++ b/oci/client.py
@@ -1610,125 +1610,29 @@ class Client:
                 data=data,
                 mimetype=mimetype,
             )
-        elif octets_count >= max_chunk and (data_is_generator or data_is_requests_resp):
-            # workaround: write into temporary file, as at least GCR does not implement
-            # chunked-upload, and requests will not properly work w/ all generators
-            # (in particular, it will not work w/ our "fake" on)
-            with tempfile.TemporaryFile() as tf:
-                if data_is_generator:
-                    for chunk in data:
-                        tf.write(chunk)
-                elif data_is_requests_resp:
-                    while (chunk := data.raw.read(8192)):
-                        tf.write(chunk)
-                else:
-                    # must only enter this codepath, if either generator or requests-response
-                    raise RuntimeError('this line must not be reached')
-                tf.seek(0)
 
-                return self._put_blob_single_post(
-                    image_reference=image_reference,
-                    digest=digest,
-                    octets_count=octets_count,
-                    data=tf,
-                    mimetype=mimetype,
-                )
-        else:
-            if data_is_requests_resp:
-                with data:
-                  return self._put_blob_chunked(
-                      image_reference=image_reference,
-                      octets_count=octets_count,
-                      data_iterator=data.iter_content(chunk_size=max_chunk),
-                      chunk_size=max_chunk,
-                      mimetype=mimetype,
-                  )
+        if not (data_is_generator or data_is_requests_resp):
+            raise NotImplementedError(type(data))
+
+        # workaround: write into temporary file, as at least GCR does not implement
+        # chunked-upload, and requests will not properly work w/ all generators
+        # (in particular, it will not work w/ our "fake" on)
+        with tempfile.TemporaryFile() as tf:
+            if data_is_generator:
+                for chunk in data:
+                    tf.write(chunk)
             else:
-              raise NotImplementedError
+                while (chunk := data.raw.read(8192)):
+                    tf.write(chunk)
+            tf.seek(0)
 
-    @initialise_repository_if_required
-    def _put_blob_chunked(
-        self,
-        image_reference: str | om.OciImageReference,
-        octets_count: int,
-        data_iterator: collections.abc.Iterator[bytes],
-        chunk_size: int=1024 * 1024 * 16, # 16 MiB
-        mimetype='application/octect-stream',
-    ):
-        image_reference = om.OciImageReference(image_reference)
-        scope = _scope(image_reference=image_reference, action='push,pull')
-        logger.debug(f'chunked-put {chunk_size=}')
-
-        # start uploading session
-        res = self._request(
-            url=self.routes.uploads_url(image_reference=image_reference),
-            image_reference=image_reference,
-            scope=scope,
-            method='POST',
-            headers={
-                'content-length': '0',
-            }
-        )
-        res.raise_for_status()
-
-        upload_url = res.headers['location']
-
-        octets_left = octets_count
-        octets_sent = 0
-        offset = 0
-        sha256 = hashlib.sha256()
-
-        while octets_left > 0:
-            octets_to_send = min(octets_left, chunk_size)
-            octets_left -= octets_to_send
-
-            data = next(data_iterator)
-            sha256.update(data)
-
-            if not len(data) == octets_to_send:
-                # sanity check to detect programming errors
-                raise ValueError(f'{len(data)=} vs {octets_to_send=}')
-
-            logger.debug(f'{octets_to_send=} {octets_left=} {len(data)=}')
-            logger.debug(f'{octets_sent + offset}-{octets_sent + octets_to_send + offset}')
-
-            crange_from = octets_sent
-            crange_to = crange_from + len(data) - 1
-
-            res = self._request(
-                url=upload_url,
+            return self._put_blob_single_post(
                 image_reference=image_reference,
-                scope=scope,
-                method='PATCH',
-                data=data,
-                headers={
-                 'Content-Length': str(octets_to_send),
-                 'Content-Type': mimetype,
-                 'Content-Range': f'{crange_from}-{crange_to}',
-                 'Range': f'{crange_from}-{crange_to}',
-                }
+                digest=digest,
+                octets_count=octets_count,
+                data=tf,
+                mimetype=mimetype,
             )
-            res.raise_for_status()
-
-            upload_url = res.headers['location']
-
-            octets_sent += len(data)
-
-        sha256_digest = f'sha256:{sha256.hexdigest()}'
-
-        # close uploading session
-        query = urllib.parse.urlencode({'digest': sha256_digest})
-        upload_url = res.headers['location'] + '?' + query
-        res = self._request(
-            url=upload_url,
-            image_reference=image_reference,
-            scope=scope,
-            method='PUT',
-            headers={
-                 'Content-Length': '0',
-            },
-        )
-        return res
 
     @initialise_repository_if_required
     def _put_blob_single_post(

--- a/oci/model.py
+++ b/oci/model.py
@@ -20,7 +20,7 @@ DOCKER_MANIFEST_SCHEMA_V2_MIME = 'application/vnd.docker.distribution.manifest.v
 empty_dict = dataclasses.field(default_factory=dict) # noqa:E3701
 
 
-class MimeTypes:
+class MimeTypes(enum.StrEnum):
     '''
     predefined, well-known mimetypes, handy to be used in oci.client.Client.manifest as `accept` arg
 
@@ -30,9 +30,12 @@ class MimeTypes:
 
     note: not all registries honour `access` header
     '''
-    single_image = ', '.join((OCI_MANIFEST_SCHEMA_V2_MIME, DOCKER_MANIFEST_SCHEMA_V2_MIME))
-    multiarch = ', '.join((OCI_IMAGE_INDEX_MIME, DOCKER_MANIFEST_LIST_MIME))
-    prefer_multiarch = ', '.join((multiarch, single_image))
+    single_image = f'{OCI_MANIFEST_SCHEMA_V2_MIME}, {DOCKER_MANIFEST_SCHEMA_V2_MIME}'
+    multiarch = f'{OCI_IMAGE_INDEX_MIME}, {DOCKER_MANIFEST_LIST_MIME}'
+    prefer_multiarch = (
+        f'{OCI_IMAGE_INDEX_MIME}, {DOCKER_MANIFEST_LIST_MIME}'
+        f', {OCI_MANIFEST_SCHEMA_V2_MIME}, {DOCKER_MANIFEST_SCHEMA_V2_MIME}'
+    )
 
 
 class OciTagType(enum.Enum):
@@ -296,7 +299,7 @@ class OciImageReference:
                oci.util.normalise_image_reference(other._orig_image_reference)
 
     def __hash__(self):
-        return hash((self._orig_image_reference,))
+        return hash(oci.util.normalise_image_reference(self._orig_image_reference))
 
 
 class OciManifestSchemaVersion(enum.Enum):

--- a/oci/workarounds.py
+++ b/oci/workarounds.py
@@ -24,7 +24,7 @@ def is_cfg_blob_sane(
     manifest: om.OciImageManifest,
     cfg_blob: bytes | dict,
 ) -> bool:
-    if isinstance(cfg_blob, bytes) or isinstance(cfg_blob, str):
+    if isinstance(cfg_blob, (bytes, str)):
         cfg_blob = json.loads(cfg_blob)
     if not isinstance(cfg_blob, dict):
         raise ValueError(cfg_blob)
@@ -50,7 +50,7 @@ def sanitise_cfg_blob(
     if is_cfg_blob_sane(manifest=manifest, cfg_blob=cfg_blob):
         return cfg_blob
 
-    if isinstance(cfg_blob, bytes) or isinstance(cfg_blob, str):
+    if isinstance(cfg_blob, (bytes, str)):
         cfg_blob = json.loads(cfg_blob)
 
     cfg_blob_nonempty_layers = _cfg_blob_non_empty_history_layers(cfg_blob=cfg_blob)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Three commits cleaning up the `oci` package after a code-review pass.

**Commit 1 — refactor + bug fix (`oci/__init__.py`)**

Extracted three helpers from the ~360-line `replicate_artifact` monolith:
`_apply_annotations`, `_replicate_manifest_list`, `_wrap_single_as_manifest_list`.

Bug fixed: the `NORMALISE_TO_MULTIARCH` branch called `oci_client.*` (the
function parameter, which is `None` when only `credentials_lookup` is provided)
instead of the resolved local `client` — causing `AttributeError` at runtime
for any caller that passes `credentials_lookup` and uses that mode.

Secondary fix: v1 cfg-blob synthesis now updates the manifest dataclass via
`dataclasses.replace` so a subsequent annotation patch re-serialises the
correct config digest rather than the stale pre-synthesis one.

**Commit 2 — `OciImageReference` hash/eq + `MimeTypes` (`oci/model.py`)**

`__hash__` previously hashed the original (un-normalised) string while `__eq__`
can match on normalised forms, violating the hash contract and breaking sets and
dicts. Fixed to use `oci.util.normalise_image_reference` directly (calling the
`@functools.cache`-decorated property from `__hash__` causes infinite recursion
because `functools.cache` hashes `self` as its own key).

`MimeTypes` promoted to `enum.StrEnum`. Values are `str` subclasses and
compare/interpolate identically — API-compatible.

**Commit 3 — miscellaneous cleanups (`oci/auth.py`, `oci/client.py`, `oci/workarounds.py`)**

- `docker_credentials_lookup`: stat-based mtime check before re-reading docker
  config on each auth lookup; re-reads only when the file changes.
- `client`: remove dead `_put_blob_chunked` (unreachable since the single-POST
  tempfile path was added); simplify `put_blob` branching accordingly.
- `workarounds`: `isinstance(x, bytes) or isinstance(x, str)` →
  `isinstance(x, (bytes, str))`.

**Release note**:
```bugfix developer
oci: fix replicate_artifact NORMALISE_TO_MULTIARCH crash when called with credentials_lookup; fix OciImageReference hash/eq contract
```