### PR TITLE
Add SAST linting to OCM image build workflow

### DIFF
--- a/.github/workflows/build-ocm.yaml
+++ b/.github/workflows/build-ocm.yaml
@@ -21,6 +21,54 @@ jobs:
       version-prerelease: ${{ (inputs.mode == 'snapshot' || inputs.mode == '') && 'dev0' || '' }}
       base-component-file: .ocm/ocm-component.yaml
 
+  lint-pybandit:
+    runs-on: ${{ vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+      - name: install-linters
+        shell: bash
+        run: |
+          pip3 install --break-system-packages bandit
+      - name: lint-python
+        shell: bash
+        run: |
+          set -euo pipefail
+          blobs_dir=/tmp/blobs.d
+          mkdir -p "${blobs_dir}"
+
+          bandit_logfile=bandit.log
+          bandit_evidence="${blobs_dir}/bandit.tar.gz"
+
+          bandit \
+            --configfile pyproject.toml \
+            --recursive \
+            -f txt -o "${bandit_logfile}" \
+            ocm/
+
+          tar czf "${bandit_evidence}" "${bandit_logfile}" pyproject.toml
+      - name: add-banditlog-to-component-descriptor
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        with:
+          blobs-directory: /tmp/blobs.d
+          ocm-resources: |
+            name: sast-linting-evidence
+            relation: local
+            access:
+              type: localBlob
+              localReference: bandit.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - lint
+                  - sast
+                  - pybandit
+              - name: gardener.cloud/comment
+                value: |
+                  we use bandit (linter) for SAST-Scans.
+                  See: https://bandit.readthedocs.io/en/latest/
+
   build-ocm-oci-image:
     name: Build OCM-OCI-Image
     needs:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Adds a lint-pybandit job to the `build-ocm.yaml`workflow to connect the existing bandit SAST scan with the ODG delivery service.

The job runs `.ci/lint` (which already executes pylint, flake8, and bandit) and exports the output as an OCM resource fragment with sast/pybandit purposes, so the delivery service recognises the scan and resolves the no-linter finding for the github.com/gardener/cc-utils/ocm component.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add SAST linting job to OCM image build workflow
```
