### PR TITLE
ocm-image: switch base image from alpine to wolfi-base

### DIFF
--- a/Dockerfile.ocm
+++ b/Dockerfile.ocm
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM cgr.dev/chainguard/wolfi-base
 
 RUN --mount=type=bind,source=.,target=/src,rw \
     apk add --no-cache \
@@ -6,6 +6,7 @@ RUN --mount=type=bind,source=.,target=/src,rw \
         python3 \
         py3-pip \
         py3-setuptools \
+        py3-wheel \
 &&  cd /src  \
 && sed -i 's/-//g' /src/oci/VERSION \
 && export version_file=/src/ocm/image-version \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Switches the base image of the `ocm-image` to Chainguard's [wolfi-base](https://github.com/wolfi-dev/wolfi-base). Also adds `py3-wheel`, which on wolfi (Python 3.13) is needed for `setup.py bdist_wheel`.

Build and smoketest validated locally:
- image builds cleanly for linux/amd64
- CLI (`create`, `normalise`, `download component-descriptor`) round-trips against a public OCM repository

**Release note**:
```other operator
switch ocm-image base from alpine to wolfi-base
```